### PR TITLE
Various fixes

### DIFF
--- a/src/base64_decode.cpp
+++ b/src/base64_decode.cpp
@@ -147,7 +147,7 @@ namespace fastgltf::base64 {
     auto* out = ret.data();
 
     for (size_t pos = 0; pos < alignedSize; pos += dataSetSize) {
-        auto in = _mm_load_si128(reinterpret_cast<const __m128i*>(&encoded[pos]));
+        auto in = _mm_loadu_si128(reinterpret_cast<const __m128i*>(&encoded[pos]));
         auto values = sse4_lookup_pshufb_bitmask(in);
         const auto merged = sse4_pack_ints(values);
 

--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -733,31 +733,28 @@ fg::Error fg::glTF::parseMaterials() {
         {
             TextureInfo normalTexture = {};
             auto error = parseTextureObject(&materialObject, "normalTexture", &normalTexture);
-            if (error != Error::None && error != Error::MissingField) {
-                return returnError(error);
-            }
             if (error == Error::None) {
                 material.normalTexture = normalTexture;
+            } else if (error != Error::MissingField) {
+                return returnError(error);
             }
         }
         {
             TextureInfo occlusionTexture = {};
             auto error = parseTextureObject(&materialObject, "occlusionTexture", &occlusionTexture);
-            if (error != Error::None && error != Error::MissingField) {
-                return returnError(error);
-            }
             if (error == Error::None) {
                 material.occlusionTexture = occlusionTexture;
+            } else if (error != Error::MissingField) {
+                return returnError(error);
             }
         }
         {
             TextureInfo emissiveTexture = {};
             auto error = parseTextureObject(&materialObject, "emissiveTexture", &emissiveTexture);
-            if (error != Error::None && error != Error::MissingField) {
-                return returnError(error);
-            }
             if (error == Error::None) {
                 material.emissiveTexture = emissiveTexture;
+            } else if (error != Error::MissingField) {
+                return returnError(error);
             }
         }
 
@@ -793,21 +790,19 @@ fg::Error fg::glTF::parseMaterials() {
             {
                 TextureInfo baseColorTexture = {};
                 auto error = parseTextureObject(&pbrMetallicRoughness, "baseColorTexture", &baseColorTexture);
-                if (error != Error::None && error != Error::MissingField) {
-                    return returnError(error);
-                }
                 if (error == Error::None) {
-                    pbr.baseColorTexture = baseColorTexture;
+                   pbr.baseColorTexture = baseColorTexture;
+                } else if (error != Error::MissingField) {
+                    return returnError(error);
                 }
             }
             {
                 TextureInfo metallicRoughnessTexture = {};
                 auto error = parseTextureObject(&pbrMetallicRoughness, "metallicRoughnessTexture", &metallicRoughnessTexture);
-                if (error != Error::None && error != Error::MissingField) {
-                    return returnError(error);
-                }
                 if (error == Error::None) {
-                    pbr.metallicRoughnessTexture = metallicRoughnessTexture;
+                   pbr.metallicRoughnessTexture = metallicRoughnessTexture;
+                } else if (error != Error::MissingField) {
+                    return returnError(error);
                 }
             }
 

--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -285,6 +285,7 @@ fg::Asset* fg::glTF::getParsedAssetPointer() {
 
 fg::Error fg::glTF::parseAll() {
     parseAccessors();
+    parseAnimations();
     parseBuffers();
     parseBufferViews();
     parseImages();

--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -1198,8 +1198,11 @@ fg::Error fg::glTF::parseTextureObject(void* object, std::string_view key, Textu
     auto& obj = *static_cast<dom::object*>(object);
 
     dom::object child;
-    if (obj[key].get_object().get(child) != SUCCESS) {
+    const auto childErr = obj[key].get_object().get(child);
+    if (childErr == NO_SUCH_FIELD) {
         return Error::MissingField;
+    } else if (childErr != SUCCESS) {
+        return Error::InvalidGltf;
     }
 
     uint64_t index;

--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -468,16 +468,16 @@ fg::Error fg::glTF::parseAnimations() {
             std::string_view interpolation;
             if (samplerObject["interpolation"].get_string().get(interpolation) != SUCCESS) {
                 sampler.interpolation = AnimationInterpolation::Linear;
-            }
-
-            if (interpolation == "LINEAR") {
-                sampler.interpolation = AnimationInterpolation::Linear;
-            } else if (interpolation == "STEP") {
-                sampler.interpolation = AnimationInterpolation::Step;
-            } else if (interpolation == "CUBICSPLINE") {
-                sampler.interpolation = AnimationInterpolation::CubicSpline;
             } else {
-                return returnError(Error::InvalidGltf);
+                if (interpolation == "LINEAR") {
+                    sampler.interpolation = AnimationInterpolation::Linear;
+                } else if (interpolation == "STEP") {
+                    sampler.interpolation = AnimationInterpolation::Step;
+                } else if (interpolation == "CUBICSPLINE") {
+                    sampler.interpolation = AnimationInterpolation::CubicSpline;
+                } else {
+                    return returnError(Error::InvalidGltf);
+                }
             }
 
             animation.samplers.emplace_back(sampler);

--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -483,6 +483,14 @@ fg::Error fg::glTF::parseAnimations() {
             animation.samplers.emplace_back(sampler);
         }
 
+        // name is optional.
+        {
+            std::string_view name;
+            if (animationObject["name"].get_string().get(name) == SUCCESS) {
+                animation.name = std::string { name };
+            }
+        }
+
         parsedAsset->animations.emplace_back(std::move(animation));
     }
 

--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -733,26 +733,32 @@ fg::Error fg::glTF::parseMaterials() {
         {
             TextureInfo normalTexture = {};
             auto error = parseTextureObject(&materialObject, "normalTexture", &normalTexture);
-            if (error != Error::None) {
+            if (error != Error::None && error != Error::MissingField) {
                 return returnError(error);
             }
-            material.normalTexture = normalTexture;
+            if (error == Error::None) {
+                material.normalTexture = normalTexture;
+            }
         }
         {
             TextureInfo occlusionTexture = {};
             auto error = parseTextureObject(&materialObject, "occlusionTexture", &occlusionTexture);
-            if (error != Error::None) {
+            if (error != Error::None && error != Error::MissingField) {
                 return returnError(error);
             }
-            material.occlusionTexture = occlusionTexture;
+            if (error == Error::None) {
+                material.occlusionTexture = occlusionTexture;
+            }
         }
         {
             TextureInfo emissiveTexture = {};
             auto error = parseTextureObject(&materialObject, "emissiveTexture", &emissiveTexture);
-            if (error != Error::None) {
+            if (error != Error::None && error != Error::MissingField) {
                 return returnError(error);
             }
-            material.emissiveTexture = emissiveTexture;
+            if (error == Error::None) {
+                material.emissiveTexture = emissiveTexture;
+            }
         }
 
         dom::object pbrMetallicRoughness;
@@ -787,18 +793,22 @@ fg::Error fg::glTF::parseMaterials() {
             {
                 TextureInfo baseColorTexture = {};
                 auto error = parseTextureObject(&pbrMetallicRoughness, "baseColorTexture", &baseColorTexture);
-                if (error != Error::None) {
+                if (error != Error::None && error != Error::MissingField) {
                     return returnError(error);
                 }
-                pbr.baseColorTexture = baseColorTexture;
+                if (error == Error::None) {
+                    pbr.baseColorTexture = baseColorTexture;
+                }
             }
             {
                 TextureInfo metallicRoughnessTexture = {};
                 auto error = parseTextureObject(&pbrMetallicRoughness, "metallicRoughnessTexture", &metallicRoughnessTexture);
-                if (error != Error::None) {
+                if (error != Error::None && error != Error::MissingField) {
                     return returnError(error);
                 }
-                pbr.metallicRoughnessTexture = metallicRoughnessTexture;
+                if (error == Error::None) {
+                    pbr.metallicRoughnessTexture = metallicRoughnessTexture;
+                }
             }
 
             material.pbrData = pbr;
@@ -1189,7 +1199,7 @@ fg::Error fg::glTF::parseTextureObject(void* object, std::string_view key, Textu
 
     dom::object child;
     if (obj[key].get_object().get(child) != SUCCESS) {
-        return Error::None;
+        return Error::MissingField;
     }
 
     uint64_t index;

--- a/src/fastgltf_types.hpp
+++ b/src/fastgltf_types.hpp
@@ -214,6 +214,8 @@ namespace fastgltf {
     struct Animation {
         std::vector<AnimationChannel> channels;
         std::vector<AnimationSampler> samplers;
+
+        std::string name;
     };
 
     struct Skin {

--- a/tests/basic_test.cpp
+++ b/tests/basic_test.cpp
@@ -101,6 +101,9 @@ TEST_CASE("Loading some basic glTF", "[gltf-loader]") {
         REQUIRE(material.pbrData->baseColorTexture->textureIndex == 0);
         REQUIRE(material.pbrData->metallicRoughnessTexture.has_value());
         REQUIRE(material.pbrData->metallicRoughnessTexture->textureIndex == 1);
+        REQUIRE(!material.normalTexture.has_value());
+        REQUIRE(!material.emissiveTexture.has_value());
+        REQUIRE(!material.occlusionTexture.has_value());
     }
 
     SECTION("Loading basic Box.gltf") {

--- a/tests/basic_test.cpp
+++ b/tests/basic_test.cpp
@@ -207,6 +207,8 @@ TEST_CASE("Loading glTF animation", "[gltf-loader]") {
     REQUIRE(!asset->animations.empty());
 
     auto& animation = asset->animations.front();
+    REQUIRE(animation.name == "animation_AnimatedCube");
+
     REQUIRE(!animation.channels.empty());
     REQUIRE(animation.channels.front().nodeIndex == 0);
     REQUIRE(animation.channels.front().samplerIndex == 0);


### PR DESCRIPTION
Just a handful of fixes I put together while I was implementing fastgltf.

* Adds `parseAnimations()` to `parseAll()`.
* Adds `name` field to `Animation`.
* Fixes false error result when `AnimationSampler.interpolation` is missing.
* Material textures now stay at `std::nullopt` when not specified in glTF.
* Fix unaligned memory access in Base64 decoding.