### PR TITLE
Add KHR_mesh_quantization

### DIFF
--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -167,10 +167,11 @@ bool fg::glTF::checkAssetField() {
 }
 
 // clang-format off
-constexpr std::array<std::pair<std::string_view, fastgltf::Extensions>, 3> extensionStrings = {{
+constexpr std::array<std::pair<std::string_view, fastgltf::Extensions>, 4> extensionStrings = {{
     { "KHR_texture_basisu",     fastgltf::Extensions::KHR_texture_basisu },
     { "KHR_texture_transform",  fastgltf::Extensions::KHR_texture_transform },
     { "MSFT_texture_dds",       fastgltf::Extensions::MSFT_texture_dds },
+    { "KHR_mesh_quantization",  fastgltf::Extensions::KHR_mesh_quantization },
 }};
 // clang-format on
 

--- a/src/fastgltf_parser.hpp
+++ b/src/fastgltf_parser.hpp
@@ -49,6 +49,7 @@ namespace fastgltf {
         KHR_texture_transform = 1 << 1,
         KHR_texture_basisu = 1 << 2,
         MSFT_texture_dds = 1 << 3,
+        KHR_mesh_quantization = 1 << 4,
     };
 
     constexpr Extensions operator&(Extensions a, Extensions b) noexcept {


### PR DESCRIPTION
Really all that's needed is to let fastgltf know about the extension.

The only changes it brings is allowing more types in accessors for mesh data.