### PR TITLE
Const-ify GltfBufferData::copyBytes

### DIFF
--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -2063,7 +2063,7 @@ bool fg::GltfDataBuffer::fromByteView(uint8_t* bytes, size_t byteCount, size_t c
     return true;
 }
 
-bool fg::GltfDataBuffer::copyBytes(uint8_t* bytes, size_t byteCount) noexcept {
+bool fg::GltfDataBuffer::copyBytes(const uint8_t* bytes, size_t byteCount) noexcept {
     using namespace simdjson;
     if (bytes == nullptr || byteCount == 0)
         return false;

--- a/src/fastgltf_parser.hpp
+++ b/src/fastgltf_parser.hpp
@@ -293,7 +293,7 @@ namespace fastgltf {
         /**
          * This will create a copy of the passed bytes and allocate a adequately sized buffer.
          */
-        bool copyBytes(uint8_t* bytes, size_t byteCount) noexcept;
+        bool copyBytes(const uint8_t* bytes, size_t byteCount) noexcept;
         /**
          * Loads the file with a optional byte offset into a memory buffer.
          */


### PR DESCRIPTION
As this is a purely copy-only function, there's no reason to take a mutable pointer.