### PR TITLE
Load external glTF buffers from Android assets

### DIFF
--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -456,7 +456,7 @@ std::pair<fg::Error, fg::DataSource> fg::glTF::loadFileFromApk(URI& uri) const n
         auto info = data->config.mapCallback(static_cast<std::uint64_t>(length), data->config.userPointer);
         if (info.mappedMemory != nullptr) {
             const sources::CustomBuffer customBufferSource = { info.customId, MimeType::None };
-            file.read(reinterpret_cast<char*>(info.mappedMemory), length);
+            AAsset_read(file.get(), info.mappedMemory, length);
             if (data->config.unmapCallback != nullptr) {
                 data->config.unmapCallback(&info, data->config.userPointer);
             }

--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -404,7 +404,7 @@ std::pair<fg::Error, fg::DataSource> fg::glTF::loadFileFromUri(URI& uri) const n
 
 #if defined(__ANDROID__)
     // Try to load external buffers from the APK. If they're not there, fall through to the file case
-    const auto android_result = loadFileFromApk(uri);
+    const auto android_result = loadFileFromApk(path);
     if(android_result.first == Error::None) {
         return android_result;
     }

--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -440,9 +440,10 @@ std::pair<fg::Error, fg::DataSource> fg::glTF::loadFileFromUri(URI& uri) const n
 }
 
 #if defined(__ANDROID__)
-std::pair<fg::Error, fg::DataSource> fg::glTF::loadFileFromApk(URI& uri) const noexcept {
+std::pair<fg::Error, fg::DataSource> fg::glTF::loadFileFromApk(const std::filesystem::path& filepath) const noexcept {
+    const auto fileString = filepath.string();
     auto assetDeleter = [](AAsset* file) { AAsset_close(file); };
-    auto file = std::unique_ptr<AAsset, decltype(assetDeleter)>(AAssetManager_open(androidAssetManager, uri.c_str(), AASSET_MODE_BUFFER), assetDeleter);
+    auto file = std::unique_ptr<AAsset, decltype(assetDeleter)>(AAssetManager_open(androidAssetManager, fileString.c_str(), AASSET_MODE_BUFFER), assetDeleter);
     if (file == nullptr) {
         return std::make_pair(Error::MissingExternalBuffer, std::monostate{});
     }

--- a/src/fastgltf_parser.hpp
+++ b/src/fastgltf_parser.hpp
@@ -217,7 +217,7 @@ namespace fastgltf {
         [[nodiscard]] auto decodeDataUri(URI& uri) const noexcept -> std::pair<Error, DataSource>;
         [[nodiscard]] auto loadFileFromUri(URI& uri) const noexcept -> std::pair<Error, DataSource>;
 #if defined(__ANDROID__)
-        [[nodiscard]] auto loadFileFromApk(URI& uri) const noexcept -> std::pair<Error, DataSource>;
+        [[nodiscard]] auto loadFileFromApk(const std::filesystem::path& filepath) const noexcept -> std::pair<Error, DataSource>;
 #endif
         [[gnu::always_inline]] inline Error parseTextureObject(void* object, std::string_view key, TextureInfo* info) noexcept;
 

--- a/src/fastgltf_parser.hpp
+++ b/src/fastgltf_parser.hpp
@@ -216,6 +216,9 @@ namespace fastgltf {
 
         [[nodiscard]] auto decodeDataUri(URI& uri) const noexcept -> std::pair<Error, DataSource>;
         [[nodiscard]] auto loadFileFromUri(URI& uri) const noexcept -> std::pair<Error, DataSource>;
+#if defined(__ANDROID__)
+        [[nodiscard]] auto loadFileFromApk(URI& uri) const noexcept -> std::pair<Error, DataSource>;
+#endif
         [[gnu::always_inline]] inline Error parseTextureObject(void* object, std::string_view key, TextureInfo* info) noexcept;
 
         void parseAccessors(simdjson::dom::array& array);
@@ -329,8 +332,6 @@ namespace fastgltf {
 
     #if defined(__ANDROID__)
     class AndroidGltfDataBuffer : public GltfDataBuffer {
-        AAssetManager* assetManager;
-
     public:
         explicit AndroidGltfDataBuffer(AAssetManager* assetManager) noexcept;
         ~AndroidGltfDataBuffer() noexcept = default;

--- a/src/fastgltf_types.hpp
+++ b/src/fastgltf_types.hpp
@@ -660,6 +660,7 @@ namespace fastgltf {
         static void decodePercents(std::string& x) noexcept;
 
         [[nodiscard]] auto raw() const noexcept -> std::string_view;
+        [[nodiscard]] auto c_str() const noexcept -> const char*;
 
         [[nodiscard]] auto scheme() const noexcept -> std::string_view;
         [[nodiscard]] auto userinfo() const noexcept -> std::string_view;


### PR DESCRIPTION
This PR adds support for loading external buffers from within an APK

The method `fastgltf::glTF::loadFileFromUri` will try to load the file from the APK. If that fails, it will try to load the file from the filesystem as before

I've also removed a check for if the glTF's parent path is a filesystem directory. It is not a filesystem directory if it's in an APK