### PR TITLE
Utilities to extract data from accessors

### DIFF
--- a/src/fastgltf_tools.hpp
+++ b/src/fastgltf_tools.hpp
@@ -1,0 +1,206 @@
+/*
+ * Copyright (C) 2022 - 2023 spnda
+ * This file is part of fastgltf <https://github.com/spnda/fastgltf>.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+#include "fastgltf_types.hpp"
+
+namespace fastgltf {
+
+template <typename>
+struct ElementTraits;
+
+template<>
+struct ElementTraits<std::int8_t> {
+	using element_type = std::int8_t;
+	using component_type = std::int8_t;
+	static constexpr auto type = AccessorType::Scalar;
+	static constexpr auto componentType = ComponentType::Byte;
+};
+
+template<>
+struct ElementTraits<std::uint8_t> {
+	using element_type = std::uint8_t;
+	using component_type = std::uint8_t;
+	static constexpr auto type = AccessorType::Scalar;
+	static constexpr auto componentType = ComponentType::UnsignedByte;
+};
+
+template<>
+struct ElementTraits<std::int16_t> {
+	using element_type = std::int16_t;
+	using component_type = std::int16_t;
+	static constexpr auto type = AccessorType::Scalar;
+	static constexpr auto componentType = ComponentType::Short;
+};
+
+template<>
+struct ElementTraits<std::uint16_t> {
+	using element_type = std::uint16_t;
+	using component_type = std::uint16_t;
+	static constexpr auto type = AccessorType::Scalar;
+	static constexpr auto componentType = ComponentType::UnsignedShort;
+};
+
+template<>
+struct ElementTraits<std::int32_t> {
+	using element_type = std::int32_t;
+	using component_type = std::int32_t;
+	static constexpr auto type = AccessorType::Scalar;
+	static constexpr auto componentType = ComponentType::Int;
+};
+
+template<>
+struct ElementTraits<std::uint32_t> {
+	using element_type = std::uint32_t;
+	using component_type = std::uint32_t;
+	static constexpr auto type = AccessorType::Scalar;
+	static constexpr auto componentType = ComponentType::UnsignedInt;
+};
+
+template<>
+struct ElementTraits<float> {
+	using element_type = float;
+	using component_type = float;
+	static constexpr auto type = AccessorType::Scalar;
+	static constexpr auto componentType = ComponentType::Float;
+};
+
+template<>
+struct ElementTraits<double> {
+	using element_type = double;
+	using component_type = double;
+	static constexpr auto type = AccessorType::Scalar;
+	static constexpr auto componentType = ComponentType::Double;
+};
+
+namespace internal {
+
+template <typename SourceType, typename DestType, std::size_t Index>
+constexpr DestType convertComponent(const std::byte* bytes) {
+	return static_cast<DestType>(reinterpret_cast<const SourceType*>(bytes)[Index]);
+}
+
+template <typename ElementType, typename SourceType, std::size_t... I>
+constexpr ElementType convertAccessorElement(const std::byte* bytes, std::index_sequence<I...>) {
+	using DestType = typename ElementTraits<ElementType>::component_type;
+
+	if constexpr (std::is_aggregate_v<ElementType>) {
+		return {convertComponent<SourceType, DestType, I>(bytes)...};
+	}
+	else {
+		return ElementType{convertComponent<SourceType, DestType, I>(bytes)...};
+	}
+}
+
+template <typename ElementType,
+		typename Seq = std::make_index_sequence<getNumComponents(ElementTraits<ElementType>::type)>>
+ElementType getAccessorElementAt(ComponentType componentType, const std::byte* bytes) {
+	switch (componentType) {
+		// This is undefined behavior if component type is invalid
+		default:
+		case ComponentType::Byte:
+			return convertAccessorElement<ElementType, std::int8_t>(bytes, Seq{});
+		case ComponentType::UnsignedByte:
+			return convertAccessorElement<ElementType, std::uint8_t>(bytes, Seq{});
+		case ComponentType::Short:
+			return convertAccessorElement<ElementType, std::int16_t>(bytes, Seq{});
+		case ComponentType::UnsignedShort:
+			return convertAccessorElement<ElementType, std::uint16_t>(bytes, Seq{});
+		case ComponentType::Int:
+			return convertAccessorElement<ElementType, std::int32_t>(bytes, Seq{});
+		case ComponentType::UnsignedInt:
+			return convertAccessorElement<ElementType, std::uint32_t>(bytes, Seq{});
+		case ComponentType::Float:
+			return convertAccessorElement<ElementType, float>(bytes, Seq{});
+		case ComponentType::Double:
+			return convertAccessorElement<ElementType, double>(bytes, Seq{});
+	}
+}
+
+}
+
+template <typename ElementType>
+ElementType getAccessorElement(const Asset& asset, const Accessor& accessor, const void* bufferData, size_t index) {
+	auto* bytes = reinterpret_cast<const std::byte*>(bufferData);
+
+	// FIXME: Assuming that I have a buffer view index, but what do I do if I don't?
+	auto& view = asset.bufferViews[*accessor.bufferViewIndex];
+	auto stride = view.byteStride ? *view.byteStride : getElementByteSize(accessor.type, accessor.componentType);
+
+	bytes += view.byteOffset + accessor.byteOffset;
+
+	return internal::getAccessorElementAt<ElementType>(accessor.componentType, bytes + index * stride);
+}
+
+template <typename ElementType, typename Functor>
+void iterateAccessor(const Asset& asset, const Accessor& accessor, const void* bufferData, Functor&& func) {
+	if (accessor.type != ElementTraits<ElementType>::type) {
+		return;
+	}
+
+	for (std::size_t i = 0; i < accessor.count; ++i) {
+		func(getAccessorElement<ElementType>(asset, accessor, bufferData));
+	}
+}
+
+template <typename ElementType, std::size_t TargetStride = sizeof(ElementType)>
+void fillTargetFromAccessor(const Asset& asset, const Accessor& accessor, const void* sourceBufferData,
+		void* dest) {
+	if (accessor.type != ElementTraits<ElementType>::type) {
+		return;
+	}
+
+	// FIXME: Assuming that I have a buffer view index, but what do I do if I don't?
+	auto& view = asset.bufferViews[*accessor.bufferViewIndex];
+	auto srcStride = view.byteStride && *view.byteStride != 0 ? *view.byteStride
+			: getElementByteSize(accessor.type, accessor.componentType);
+
+	auto elemSize = getElementByteSize(accessor.type, accessor.componentType);
+
+	auto* srcBytes = reinterpret_cast<const std::byte*>(sourceBufferData) + view.byteOffset + accessor.byteOffset;
+	auto* dstBytes = reinterpret_cast<std::byte*>(dest);
+
+	if constexpr (std::is_trivially_copyable_v<ElementType>) {
+		if (srcStride == elemSize && srcStride == TargetStride) {
+			std::memcpy(dest, sourceBufferData, elemSize * accessor.count);
+		}
+		else {
+			for (std::size_t i = 0; i < accessor.count; ++i) {
+				std::memcpy(dstBytes + TargetStride * i, srcBytes + srcStride * i, elemSize);
+			}
+		}
+	}
+	else {
+		for (std::size_t i = 0; i < accessor.count; ++i) {
+			auto* pDest = reinterpret_cast<ElementType*>(dstBytes + TargetStride * i);
+			*pDest = internal::getAccessorElementAt<ElementType>(accessor.componentType, srcBytes + srcStride * i);
+		}
+	}
+}
+
+} // namespace fastgltf
+

--- a/src/fastgltf_types.hpp
+++ b/src/fastgltf_types.hpp
@@ -260,7 +260,7 @@ namespace fastgltf {
     }
 
     constexpr std::uint32_t getElementByteSize(AccessorType type, ComponentType componentType) noexcept {
-        return getNumComponents(type) * (getComponentBitSize(componentType) / 8);
+        return (getNumComponents(type) * getComponentBitSize(componentType) + 7u) / 8u;
     }
 
     constexpr std::uint32_t getGLComponentType(ComponentType type) noexcept {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,7 +3,7 @@ set_directory_properties(PROPERTIES EXCLUDE_FROM_ALL TRUE)
 # We want these tests to be a optional executable.
 add_executable(fastgltf_tests EXCLUDE_FROM_ALL
     "base64_tests.cpp" "basic_test.cpp" "benchmarks.cpp" "glb_tests.cpp" "gltf_path.hpp"
-    "vector_tests.cpp" "uri_tests.cpp" "extension_tests.cpp")
+    "vector_tests.cpp" "uri_tests.cpp" "extension_tests.cpp" "accessor_tests.cpp")
 target_compile_features(fastgltf_tests PRIVATE cxx_std_17)
 target_link_libraries(fastgltf_tests PRIVATE fastgltf fastgltf_simdjson)
 target_link_libraries(fastgltf_tests PRIVATE glm::glm Catch2::Catch2WithMain)

--- a/tests/accessor_tests.cpp
+++ b/tests/accessor_tests.cpp
@@ -74,7 +74,7 @@ TEST_CASE("Test accessor ", "[gltf-tools]") {
 		auto* checkData = reinterpret_cast<const unsigned short*>(bufferData + view.byteOffset
 				+ firstAccessor.byteOffset);
 
-		REQUIRE(*checkData == fastgltf::getAccessorElement<unsigned short>(*asset, firstAccessor, bufferData, 0));
+		REQUIRE(*checkData == fastgltf::getAccessorElement<unsigned short>(*asset, firstAccessor, 0));
     }
 
 	{
@@ -90,7 +90,7 @@ TEST_CASE("Test accessor ", "[gltf-tools]") {
 
 		auto* checkData = reinterpret_cast<const glm::vec3*>(bufferData + view.byteOffset
 				+ secondAccessor.byteOffset);
-		REQUIRE(*checkData == fastgltf::getAccessorElement<glm::vec3>(*asset, secondAccessor, bufferData, 0));
+		REQUIRE(*checkData == fastgltf::getAccessorElement<glm::vec3>(*asset, secondAccessor, 0));
 	}
 }
 

--- a/tests/accessor_tests.cpp
+++ b/tests/accessor_tests.cpp
@@ -1,0 +1,96 @@
+#include <cstdlib>
+#include <random>
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/benchmark/catch_benchmark.hpp>
+
+#include <glm/glm.hpp>
+#include <glm/gtc/type_ptr.hpp>
+#include <glm/gtx/quaternion.hpp>
+#include <glm/gtx/matrix_decompose.hpp>
+
+#include "base64_decode.hpp"
+#include "fastgltf_parser.hpp"
+#include "fastgltf_types.hpp"
+#include "fastgltf_tools.hpp"
+#include "gltf_path.hpp"
+
+template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
+template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
+
+template<>
+struct fastgltf::ElementTraits<glm::vec3> {
+	using element_type = glm::vec3;
+	using component_type = float;
+	static constexpr auto type = AccessorType::Vec3;
+	static constexpr auto componentType = ComponentType::Float;
+};
+
+static const std::byte* getBufferData(const fastgltf::Buffer& buffer) {
+	const std::byte* result = nullptr;
+
+	std::visit(overloaded {
+		[](auto&) {},
+		[&](const fastgltf::sources::Vector& vec) {
+			result = reinterpret_cast<const std::byte*>(vec.bytes.data());
+		},
+		[&](const fastgltf::sources::ByteView& bv) {
+			result = bv.bytes.data();
+		},
+	}, buffer.data);
+	
+	return result;
+}
+
+TEST_CASE("Test accessor ", "[gltf-tools]") {
+    auto lightsLamp = sampleModels / "2.0" / "LightsPunctualLamp" / "glTF";
+    fastgltf::GltfDataBuffer jsonData;
+    REQUIRE(jsonData.loadFromFile(lightsLamp / "LightsPunctualLamp.gltf"));
+
+    fastgltf::Parser parser(fastgltf::Extensions::KHR_lights_punctual);
+    auto model = parser.loadGLTF(&jsonData, lightsLamp, fastgltf::Options::LoadExternalBuffers);
+    REQUIRE(parser.getError() == fastgltf::Error::None);
+    REQUIRE(model->parse() == fastgltf::Error::None);
+    //REQUIRE(model->parse(fastgltf::Category::Buffers | fastgltf::Category::BufferViews
+			//| fastgltf::Category::Accessors) == fastgltf::Error::None);
+    REQUIRE(model->validate() == fastgltf::Error::None);
+
+    auto asset = model->getParsedAsset();
+    REQUIRE(asset->accessors.size() == 15);
+    auto& accessors = asset->accessors;
+
+    {
+        auto& firstAccessor = accessors[0];
+		REQUIRE(firstAccessor.type == fastgltf::AccessorType::Scalar);
+		REQUIRE(firstAccessor.componentType == fastgltf::ComponentType::UnsignedShort);
+
+		REQUIRE(firstAccessor.bufferViewIndex.has_value());
+		auto& view = asset->bufferViews[*firstAccessor.bufferViewIndex];
+
+		auto* bufferData = getBufferData(asset->buffers[view.bufferIndex]);
+		REQUIRE(bufferData != nullptr);
+
+		auto* checkData = reinterpret_cast<const unsigned short*>(bufferData + view.byteOffset
+				+ firstAccessor.byteOffset);
+
+		REQUIRE(*checkData == fastgltf::getAccessorElement<unsigned short>(*asset, firstAccessor, bufferData, 0));
+    }
+
+	{
+        auto& secondAccessor = accessors[1];
+		REQUIRE(secondAccessor.type == fastgltf::AccessorType::Vec3);
+		REQUIRE(secondAccessor.componentType == fastgltf::ComponentType::Float);
+
+		REQUIRE(secondAccessor.bufferViewIndex.has_value());
+		auto& view = asset->bufferViews[*secondAccessor.bufferViewIndex];
+
+		auto* bufferData = getBufferData(asset->buffers[view.bufferIndex]);
+		REQUIRE(bufferData != nullptr);
+
+		auto* checkData = reinterpret_cast<const glm::vec3*>(bufferData + view.byteOffset
+				+ secondAccessor.byteOffset);
+		REQUIRE(*checkData == fastgltf::getAccessorElement<glm::vec3>(*asset, secondAccessor, bufferData, 0));
+	}
+}
+


### PR DESCRIPTION
This PR adds fastgltf_tools.hpp, a header containing several utility functions such as `getAccessorElement`, `iterateAccessor`, and `fillTargetFromAccessor`, the `ElementTraits<T>` struct for matching metadata about the desired type, and the `DefaultBufferDataAdapter`, a minimal default implementation of the `BufferDataAdapter` pattern which allows the accessor indexing functions to resolve used buffer memory.

Currently this PR lacks support for sparse accessors and compressed buffer views.