### PR TITLE
Add: Animation support to Exporter; Fix: Vector source not allowed as embedded buffer

### DIFF
--- a/include/fastgltf/core.hpp
+++ b/include/fastgltf/core.hpp
@@ -861,6 +861,7 @@ namespace fastgltf {
         std::vector<std::optional<std::filesystem::path>> imagePaths;
 
         void writeAccessors(const Asset& asset, std::string& json);
+        void writeAnimations(const Asset& asset, std::string& json);
         void writeBuffers(const Asset& asset, std::string& json);
         void writeBufferViews(const Asset& asset, std::string& json);
         void writeCameras(const Asset& asset, std::string& json);

--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -4256,7 +4256,7 @@ void fg::Exporter::writeAnimations(const Asset& asset, std::string& json)
 		json += ']';
 
 		if (extrasWriteCallback != nullptr) {
-			auto extras = extrasWriteCallback(uabs(std::distance(asset.buffers.begin(), it)), fastgltf::Category::Buffers, userPointer);
+			auto extras = extrasWriteCallback(uabs(std::distance(asset.animations.begin(), it)), fastgltf::Category::Buffers, userPointer);
 			if (extras.has_value()) {
 				json += std::string(",\"extras\":") + *extras;
 			}

--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -5491,7 +5491,7 @@ fg::Expected<fg::ExportResult<std::vector<std::byte>>> fg::Exporter::writeGltfBi
 	// TODO: Add ExportOption enumeration for disabling this?
     const bool withEmbeddedBuffer = !asset.buffers.empty()
 			// We only support writing Vectors and ByteViews as embedded buffers
-			&& (std::holds_alternative<sources::Array>(asset.buffers.front().data) || std::holds_alternative<sources::ByteView>(asset.buffers.front().data))
+			&& (std::holds_alternative<sources::Array>(asset.buffers.front().data) || std::holds_alternative<sources::ByteView>(asset.buffers.front().data) || std::holds_alternative<sources::Vector>(asset.buffers.front().data))
 			&& asset.buffers.front().byteLength < std::numeric_limits<decltype(BinaryGltfChunk::chunkLength)>::max();
 
     std::size_t binarySize = 0;

--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -4233,7 +4233,7 @@ void fg::Exporter::writeAnimations(const Asset& asset, std::string& json)
 		}
 		json += "],";
 
-		json += R"("name":")" + it->name + ",";
+		json += R"("name":")" + it->name + "\",";
 
 		json += R"("samplers":[)";
 		for (auto si = it->samplers.begin(); si != it->samplers.end(); ++si) {

--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -4256,7 +4256,7 @@ void fg::Exporter::writeAnimations(const Asset& asset, std::string& json)
 		json += ']';
 
 		if (extrasWriteCallback != nullptr) {
-			auto extras = extrasWriteCallback(uabs(std::distance(asset.animations.begin(), it)), fastgltf::Category::Buffers, userPointer);
+			auto extras = extrasWriteCallback(uabs(std::distance(asset.animations.begin(), it)), fastgltf::Category::Animations, userPointer);
 			if (extras.has_value()) {
 				json += std::string(",\"extras\":") + *extras;
 			}


### PR DESCRIPTION
This PR adds support for animations to the `Exporter`, and also fixes an issue with the `Exporter` where a `sources::Vector` buffer would not pass the check for using an embedded buffer, even though documentation states it should be usable for an embedded buffer.