### PR TITLE
Update gl_viewer.cpp

### DIFF
--- a/examples/gl_viewer/gl_viewer.cpp
+++ b/examples/gl_viewer/gl_viewer.cpp
@@ -102,7 +102,7 @@ constexpr std::string_view fragmentShaderSource = R"(
     const uint HAS_BASE_COLOR_TEXTURE = 1;
 
     layout(location = 0) uniform sampler2D albedoTexture;
-    layout(location = 0, std140) uniform MaterialUniforms {
+    layout(binding = 0, std140) uniform MaterialUniforms {
         vec4 baseColorFactor;
         float alphaCutoff;
         uint flags;


### PR DESCRIPTION
Use binding parameter for uniform block instead of location parameter. 

https://registry.khronos.org/OpenGL/specs/gl/GLSLangSpec.4.60.pdf 
Section 4.4 - Layout Qualifiers mentions `location =` as not applicable for blocks

Error:
```
GL Renderer: AMD Radeon(TM) Graphics
GL Version: 4.6.0 Compatibility Profile Context 22.20.44.37.230215
Shader compilation error: 
ERROR: 0:13: 'location' : cannot apply to uniform or buffer block
ERROR: 0:13: 'location' : overlapping use of location 0
ERROR: 2 compilation errors.  No code generated.
```