### PR TITLE
Added include to fix compilation in Docker (Alpine)

### DIFF
--- a/src/io.cpp
+++ b/src/io.cpp
@@ -29,6 +29,7 @@
 #include <fastgltf/core.hpp>
 
 #if defined(__APPLE__) || defined(__linux__)
+#include <fcntl.h>
 #include <unistd.h>
 #include <sys/file.h>
 #include <sys/mman.h>


### PR DESCRIPTION
I was trying to compile fastgltf into an Alpine Docker container (based on ghcr.io/osgeo/gdal:alpine-small-latest to be exact) but it would complain it couldn't find definitions for O_RDWR and open.

After including fcntl.h the compilation worked.