### PR TITLE
Fix namespacing for DirectXMath element traits

### DIFF
--- a/include/fastgltf/dxmath_element_traits.hpp
+++ b/include/fastgltf/dxmath_element_traits.hpp
@@ -21,28 +21,22 @@ template <>
 struct ElementTraits<DirectX::XMFLOAT4> : ElementTraitsBase<DirectX::XMFLOAT4, AccessorType::Vec4, float> {};
 
 template<>
-struct ElementTraits<DirectX::XMBYTE2> : ElementTraitsBase<DirectX::XMBYTE2, AccessorType::Vec2, std::uint8_t> {};
+struct ElementTraits<DirectX::PackedVector::XMBYTE2> : ElementTraitsBase<DirectX::PackedVector::XMBYTE2, AccessorType::Vec2, std::uint8_t> {};
 
 template<>
-struct ElementTraits<DirectX::XMBYTE4> : ElementTraitsBase<DirectX::XMBYTE4, AccessorType::Vec4, std::uint8_t> {};
+struct ElementTraits<DirectX::PackedVector::XMBYTE4> : ElementTraitsBase<DirectX::PackedVector::XMBYTE4, AccessorType::Vec4, std::uint8_t> {};
 
 template<>
-struct ElementTraits<DirectX::XMBYTE2> : ElementTraitsBase<DirectX::XMBYTE2, AccessorType::Vec2, std::uint8_t> {};
+struct ElementTraits<DirectX::PackedVector::XMSHORT2> : ElementTraitsBase<DirectX::PackedVector::XMSHORT2, AccessorType::Vec2, std::uint16_t> {};
 
 template<>
-struct ElementTraits<DirectX::XMBYTE4> : ElementTraitsBase<DirectX::XMBYTE4, AccessorType::Vec4, std::uint8_t> {};
+struct ElementTraits<DirectX::PackedVector::XMSHORT4> : ElementTraitsBase<DirectX::PackedVector::XMSHORT4, AccessorType::Vec4, std::uint16_t> {};
 
 template<>
-struct ElementTraits<DirectX::XMSHORT2> : ElementTraitsBase<DirectX::XMSHORT2, AccessorType::Vec2, std::uint16_t> {};
+struct ElementTraits<DirectX::PackedVector::XMUSHORT2> : ElementTraitsBase<DirectX::PackedVector::XMUSHORT2, AccessorType::Vec2, std::uint16_t> {};
 
 template<>
-struct ElementTraits<DirectX::XMSHORT4> : ElementTraitsBase<DirectX::XMSHORT4, AccessorType::Vec4, std::uint16_t> {};
-
-template<>
-struct ElementTraits<DirectX::XMUSHORT2> : ElementTraitsBase<DirectX::XMUSHORT2, AccessorType::Vec2, std::uint16_t> {};
-
-template<>
-struct ElementTraits<DirectX::XMUSHORT4> : ElementTraitsBase<DirectX::XMUSHORT4, AccessorType::Vec4, std::uint16_t> {};
+struct ElementTraits<DirectX::PackedVector::XMUSHORT4> : ElementTraitsBase<DirectX::PackedVector::XMUSHORT4, AccessorType::Vec4, std::uint16_t> {};
 
 template<>
 struct ElementTraits<DirectX::XMUINT2> : ElementTraitsBase<DirectX::XMUINT2, AccessorType::Vec2, std::uint32_t> {};
@@ -54,7 +48,7 @@ template<>
 struct ElementTraits<DirectX::XMUINT4> : ElementTraitsBase<DirectX::XMUINT4, AccessorType::Vec4, std::uint32_t> {};
 
 template<>
-struct ElementTraits<DirectX::XMFLOAT3x3> : TransposedElementTraits<DirectX::XMFLOAT3x3, AccessorType::Mat3, float> {};
+struct ElementTraits<DirectX::XMFLOAT3X3> : TransposedElementTraits<DirectX::XMFLOAT3X3, AccessorType::Mat3, float> {};
 
 template<>
 struct ElementTraits<DirectX::XMFLOAT4X4> : TransposedElementTraits<DirectX::XMFLOAT4X4, AccessorType::Mat4, float> {};


### PR DESCRIPTION
This commit corrects the namespacing for the DirectXMath element traits as some of the XM types come from the DirectX::PackedVector namespace.