### PR TITLE
Fix CMake debug optimization flags on MinGW

### DIFF
--- a/cmake/compilers.cmake
+++ b/cmake/compilers.cmake
@@ -13,7 +13,7 @@ macro(fastgltf_compiler_flags TARGET)
 
             if (MINGW)
                 # Issue with MinGW: https://github.com/simdjson/simdjson/issues/1963
-                target_compile_options(${TARGET} PUBLIC $<$<CONFIG:DEBUG>:-Og>)
+                target_compile_options(${TARGET} PRIVATE $<$<CONFIG:DEBUG>:-Og>)
             endif()
 
             # https://github.com/simdjson/simdjson/blob/master/doc/basics.md#performance-tips


### PR DESCRIPTION
I have been working on a MinGW CMake project and noticed that my debug optimization level was ``-Og`` as opposed to ``-O0`` without changing it myself. I found out that fastgltf declares ``-Og`` as a PUBLIC compilation flag on debug builds in MinGW.

This pull request simply replaces the PUBLIC specifier to PRIVATE, stopping this flag from leaking to users of the library. With this change the library still correctly compiles and loads models correctly, but it is worth testing if this doesn't break any specific use case.
