### PR TITLE
Added new error message 

### DIFF
--- a/include/fastgltf/core.hpp
+++ b/include/fastgltf/core.hpp
@@ -133,7 +133,7 @@ namespace fastgltf {
             case Error::InvalidFileData: return "The file data is invalid, or the file type could not be determined.";
             case Error::FailedWritingFiles: return "The exporter failed to write some files (buffers/images) to disk.";
 			case Error::FileBufferAllocationFailed: return "The constructor of GltfDataBuffer failed to allocate a sufficiently large buffer.";
-			case Error::FileBufferReadingFailed: return "The buffer that was attempted to read had no data in it or was corrupted";
+			case Error::FileBufferReadingFailed: return "The buffer read attempt failed due to either being empty or containing corrupted data.";
 			default: FASTGLTF_UNREACHABLE
 		}
 	}

--- a/include/fastgltf/core.hpp
+++ b/include/fastgltf/core.hpp
@@ -91,6 +91,7 @@ namespace fastgltf {
 		InvalidFileData = 12, ///< The file data is invalid, or the file type could not be determined.
 		FailedWritingFiles = 13, ///< The exporter failed to write some files (buffers/images) to disk.
 		FileBufferAllocationFailed = 14, ///< The constructor of GltfDataBuffer failed to allocate a sufficiently large buffer.
+    	FileBufferReadingFailed = 15, ///< The buffer that was attempted to read had no data in it or was corrupted
     };
 
 	FASTGLTF_EXPORT constexpr std::string_view getErrorName(Error error) {
@@ -110,6 +111,7 @@ namespace fastgltf {
             case Error::InvalidFileData: return "InvalidFileData";
             case Error::FailedWritingFiles: return "FailedWritingFiles";
 			case Error::FileBufferAllocationFailed: return "FileBufferAllocationFailed";
+			case Error::FileBufferReadingFailed: return "FileBufferReadingFailed";
 			default: FASTGLTF_UNREACHABLE
 		}
 	}
@@ -131,6 +133,7 @@ namespace fastgltf {
             case Error::InvalidFileData: return "The file data is invalid, or the file type could not be determined.";
             case Error::FailedWritingFiles: return "The exporter failed to write some files (buffers/images) to disk.";
 			case Error::FileBufferAllocationFailed: return "The constructor of GltfDataBuffer failed to allocate a sufficiently large buffer.";
+			case Error::FileBufferReadingFailed: return "The buffer that was attempted to read had no data in it or was corrupted";
 			default: FASTGLTF_UNREACHABLE
 		}
 	}

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -98,6 +98,8 @@ void fg::GltfDataBuffer::read(void *ptr, std::size_t count) {
 	{
 		std::memcpy(ptr, buffer.get() + idx, count);
 		idx += count;
+	}else{
+		error = Error::FileBufferAllocationFailed;
 	}
 }
 

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -99,7 +99,7 @@ void fg::GltfDataBuffer::read(void *ptr, std::size_t count) {
 		std::memcpy(ptr, buffer.get() + idx, count);
 		idx += count;
 	}else{
-		error = Error::FileBufferAllocationFailed;
+		error = Error::FileBufferReadingFailed;
 	}
 }
 

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -94,8 +94,11 @@ void fg::GltfDataBuffer::allocateAndCopy(const std::byte *bytes) noexcept {
 }
 
 void fg::GltfDataBuffer::read(void *ptr, std::size_t count) {
-	std::memcpy(ptr, buffer.get() + idx, count);
-	idx += count;
+	if (buffer != nullptr)
+	{
+		std::memcpy(ptr, buffer.get() + idx, count);
+		idx += count;
+	}
 }
 
 fg::span<std::byte> fg::GltfDataBuffer::read(std::size_t count, std::size_t padding) {


### PR DESCRIPTION
```c++
void fg::GltfDataBuffer::read(void *ptr, std::size_t count) {
```

Following function did not have error handling and while I was attempting to use the library SEGV occurred on this function. I have added safety `if(buffer != nullptr)` check to prevent this.

Additionally I have also added new entry to the `enum class Error` that signalises that reading from the buffer failed. Lastly  `getErrorName` and `getErrorMessage` were updated so that they reflect new entry in the `enum` .