### PR TITLE
Include and use GNUInstallDirs in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ else()
     set(FASTGLTF_COMPILE_TARGET cxx_std_17)
 endif()
 
+include(GNUInstallDirs)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/add_source_directory.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/compilers.cmake)
 
@@ -147,17 +148,17 @@ install(
 install(
     TARGETS fastgltf
     EXPORT fastgltf-targets
-    LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib
-    RUNTIME DESTINATION bin
-    INCLUDES DESTINATION include
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
 install(
     EXPORT fastgltf-targets
     FILE fastgltfConfig.cmake
     NAMESPACE fastgltf::
-    DESTINATION lib/cmake/fastgltf
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/fastgltf
 )
 
 if (FASTGLTF_ENABLE_TESTS OR FASTGLTF_ENABLE_EXAMPLES)


### PR DESCRIPTION
This installs libfastgltf.a in the expected directory. On many Linux distros this will be /usr/lib64, not /usr/lib. And this is important when the distro supports both 32 and 64 bits (32 libs go to /usr/lib)