### PR TITLE
Fix CMake installation issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ else()
 endif()
 
 include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/add_source_directory.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/compilers.cmake)
 
@@ -140,9 +141,20 @@ elseif(FASTGLTF_ENABLE_CPP_MODULES)
     message(WARNING "FASTGLTF_ENABLE_CPP_MODULES is ON but compiler does not support them")
 endif()
 
+write_basic_package_version_file(
+    "${PROJECT_BINARY_DIR}/fastgltfConfigVersion.cmake"
+    VERSION ${PACKAGE_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+
 install(
     FILES ${FASTGLTF_HEADERS}
     DESTINATION include/fastgltf
+)
+
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/fastgltfConfigVersion.cmake"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/fastgltf
 )
 
 install(


### PR DESCRIPTION
## What is Being Fixed
This pull request fixes two issues I noticed when I installed the library for development:
1. The package version manifest isn't being installed.
2. There is no way to install debug and release builds of the library without manually forcing CMake to do so.

### Issue 1
A common practice when using `find_package` in CMake is to pin the minimum required version so there are no conflicts between the user code and libraries. This is generally achieved by doing `find_package(<name> <version>)`. This relies on the existence of a `<name>configVersion.cmake` file being installed into `lib/cmake/<name>`. With the current code, this file is never generated and so never installed, preventing users from requesting a specific version of `fastgltf`.

### Issue 2
When building in Windows with Visual Studio, it is common practice to build and install two sets of binaries: one for debug and one for release builds. In user code, CMake will then automatically link the correct binary for the appropriate build. In the current CMake code, there is no way to differentiate between the debug and release builds. This results in the following: if debug is built and installed first, followed by release, the debug library will be overwritten as both debug and release are called `fastgltf.lib`. Using this library in debug builds triggers compiler errors due to mismatched optimisation levels. 

This can be worked around by manually setting `CMAKE_DEBUG_POSTFIX=d` when building the library, which is error prone and is better set by the library itself. 

I have verified that both issues are solved with this pull request, and based on past experience with other libraries, doesn't negatively impact other platforms. I think this won't be an issue with `vcpkg` but I've never used it before.