### PR TITLE
Fix fastgltf::URIView::fspath() error when path contains non-ascii character in Windows.

### DIFF
--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -518,7 +518,16 @@ std::string_view fg::URIView::fragment() const noexcept { return _fragment; }
 fs::path fg::URIView::fspath() const {
 	if (!isLocalPath())
 		return {};
+#ifdef _WIN32
+#if __cplusplus >= 202002L
+	const std::string_view charPath = path();
+	return { std::u8string_view { reinterpret_cast<char8_t>(charPath.data()), charPath.size() } };
+#else
+	return fs::u8path(path());
+#endif
+#else
 	return { path() };
+#endif
 }
 
 bool fg::URIView::valid() const noexcept {


### PR DESCRIPTION
Reinterpreted the returned value of `path()` as `std::u8string_view` to use the platform-specific encoded `std::filesystem::path`.

I think the better option would be change the return type of `fastgltf::URIView::path()` as `char8_t`, but it is C++20 feature and therefore will break the backward compatibility.