### PR TITLE
Khr physics rigid bodies

### DIFF
--- a/.github/workflows/ci_x64.yml
+++ b/.github/workflows/ci_x64.yml
@@ -14,6 +14,7 @@ on:
 env:
   BUILD_TYPE: Release
   SAMPLE_ASSETS_LOCATION: tests/gltf/glTF-Sample-Assets
+  PHYSICS_SAMPLE_ASSETS_LOCATION: tests/gltf/glTF_Physics
 
 jobs:
   build_windows:
@@ -59,9 +60,20 @@ jobs:
       - name: Clone gltf-sample-assets
         if: steps.sample-assets-cache.outputs.cache-hit != 'true'
         run: git clone https://github.com/KhronosGroup/glTF-Sample-Assets ${{ github.workspace }}/${{ env.SAMPLE_ASSETS_LOCATION }}
+        
+      - name: Download cached physics sample assets
+        uses: actions/cache@v4
+        id: physics-sample-assets-cache
+        with:
+          path: ${{ github.workspace }}/${{ env.PHYSICS_SAMPLE_ASSETS_LOCATION }}
+          key: gltf-physics-sample-assets
+
+      - name: Clone gltf-physics
+        if: steps.physics-sample-assets-cache.outputs.cache-hit != 'true'
+        run: git clone https://github.com/eoineoineoin/glTF_Physics ${{ github.workspace }}/${{ env.PHYSICS_SAMPLE_ASSETS_LOCATION }}
 
       - name: Configure CMake
-        run: cmake -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DFASTGLTF_ENABLE_TESTS=ON -DFASTGLTF_ENABLE_DEPRECATED_EXT=ON
+        run: cmake -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DFASTGLTF_ENABLE_TESTS=ON -DFASTGLTF_ENABLE_DEPRECATED_EXT=ON -DFASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES=ON
 
       - name: Build (Windows)
         run: cmake --build ${{ github.workspace }}/build --config ${{ env.BUILD_TYPE }} --target tests/fastgltf_tests --verbose
@@ -164,9 +176,20 @@ jobs:
       - name: Clone gltf-sample-assets
         if: steps.sample-assets-cache.outputs.cache-hit != 'true'
         run: git clone https://github.com/KhronosGroup/glTF-Sample-Assets ${{ github.workspace }}/${{ env.SAMPLE_ASSETS_LOCATION }}
+        
+      - name: Download cached physics sample assets
+        uses: actions/cache@v4
+        id: physics-sample-assets-cache
+        with:
+          path: ${{ github.workspace }}/${{ env.PHYSICS_SAMPLE_ASSETS_LOCATION }}
+          key: gltf-physics-sample-assets
+
+      - name: Clone gltf-physics
+        if: steps.physics-sample-assets-cache.outputs.cache-hit != 'true'
+        run: git clone https://github.com/eoineoineoin/glTF_Physics ${{ github.workspace }}/${{ env.PHYSICS_SAMPLE_ASSETS_LOCATION }}
 
       - name: Configure CMake
-        run: cmake -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DFASTGLTF_ENABLE_TESTS=ON -DFASTGLTF_ENABLE_DEPRECATED_EXT=ON
+        run: cmake -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DFASTGLTF_ENABLE_TESTS=ON -DFASTGLTF_ENABLE_DEPRECATED_EXT=ON -DFASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES=ON
 
       - name: Build
         run: cmake --build ${{ github.workspace }}/build --config ${{ env.BUILD_TYPE }} --target fastgltf_tests --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ deps/
 tests/gltf/intel_sponza
 tests/gltf/glTF-Sample-Models
 tests/gltf/glTF-Sample-Assets
+tests/gltf/glTF_Physics
 tests/gltf/good-froge
 tests/gltf/deccer-cubes
 tests/gltf/bistro

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ option(FASTGLTF_COMPILE_AS_CPP20 "Have the library compile as C++20" OFF)
 option(FASTGLTF_ENABLE_CPP_MODULES "Enables the fastgltf::module target, which uses C++20 modules" OFF)
 option(FASTGLTF_USE_STD_MODULE "Use the std module when compiling using C++ modules" OFF)
 option(FASTGLTF_ENABLE_KHR_IMPLICIT_SHAPES "Enable support for the experimental KHR_implicit_shapes extension" OFF)
-option(FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES "Enable support for the experimental KHR_physics_rigid_bodies extension" ON)
+option(FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES "Enable support for the experimental KHR_physics_rigid_bodies extension" OFF)
 
 if (FASTGLTF_COMPILE_AS_CPP20)
     set(FASTGLTF_COMPILE_TARGET cxx_std_20)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ option(FASTGLTF_USE_64BIT_FLOAT "Default to 64-bit double precision floats for e
 option(FASTGLTF_COMPILE_AS_CPP20 "Have the library compile as C++20" OFF)
 option(FASTGLTF_ENABLE_CPP_MODULES "Enables the fastgltf::module target, which uses C++20 modules" OFF)
 option(FASTGLTF_USE_STD_MODULE "Use the std module when compiling using C++ modules" OFF)
+option(FASTGLTF_ENABLE_KHR_PHYSICS_RIGIDBODY "Enable support for the experimental KHR_physics_ridigbody extension", OFF)
 
 if (FASTGLTF_COMPILE_AS_CPP20)
     set(FASTGLTF_COMPILE_TARGET cxx_std_20)
@@ -111,6 +112,7 @@ target_compile_definitions(fastgltf PUBLIC "FASTGLTF_USE_CUSTOM_SMALLVECTOR=$<BO
 target_compile_definitions(fastgltf PUBLIC "FASTGLTF_ENABLE_DEPRECATED_EXT=$<BOOL:${FASTGLTF_ENABLE_DEPRECATED_EXT}>")
 target_compile_definitions(fastgltf PUBLIC "FASTGLTF_DISABLE_CUSTOM_MEMORY_POOL=$<BOOL:${FASTGLTF_DISABLE_CUSTOM_MEMORY_POOL}>")
 target_compile_definitions(fastgltf PUBLIC "FASTGLTF_USE_64BIT_FLOAT=$<BOOL:${FASTGLTF_USE_64BIT_FLOAT}>")
+target_compile_definitions(fastgltf PUBLIC "FASTGLTF_ENABLE_KHR_PHYSICS_RIGIDBODY=$<BOOL:${FASTGLTF_ENABLE_KHR_PHYSICS_RIGIDBODY}>")
 
 fastgltf_check_modules_support()
 if (FASTGLTF_ENABLE_CPP_MODULES AND FASTGLTF_SUPPORTS_MODULES AND CMAKE_VERSION VERSION_GREATER_EQUAL "3.28")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,13 +20,18 @@ option(FASTGLTF_USE_64BIT_FLOAT "Default to 64-bit double precision floats for e
 option(FASTGLTF_COMPILE_AS_CPP20 "Have the library compile as C++20" OFF)
 option(FASTGLTF_ENABLE_CPP_MODULES "Enables the fastgltf::module target, which uses C++20 modules" OFF)
 option(FASTGLTF_USE_STD_MODULE "Use the std module when compiling using C++ modules" OFF)
-option(FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES "Enable support for the experimental KHR_physics_ridig_bodies extension" ON)
-
+option(FASTGLTF_ENABLE_KHR_IMPLICIT_SHAPES "Enable support for the experimental KHR_implicit_shapes extension" OFF)
+option(FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES "Enable support for the experimental KHR_physics_rigid_bodies extension" ON)
 
 if (FASTGLTF_COMPILE_AS_CPP20)
     set(FASTGLTF_COMPILE_TARGET cxx_std_20)
 else()
     set(FASTGLTF_COMPILE_TARGET cxx_std_17)
+endif()
+
+# physics rigid bodies depends on implicit shapes
+if(FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES) 
+    set(FASTGLTF_ENABLE_KHR_IMPLICIT_SHAPES ON)
 endif()
 
 include(GNUInstallDirs)
@@ -113,6 +118,7 @@ target_compile_definitions(fastgltf PUBLIC "FASTGLTF_USE_CUSTOM_SMALLVECTOR=$<BO
 target_compile_definitions(fastgltf PUBLIC "FASTGLTF_ENABLE_DEPRECATED_EXT=$<BOOL:${FASTGLTF_ENABLE_DEPRECATED_EXT}>")
 target_compile_definitions(fastgltf PUBLIC "FASTGLTF_DISABLE_CUSTOM_MEMORY_POOL=$<BOOL:${FASTGLTF_DISABLE_CUSTOM_MEMORY_POOL}>")
 target_compile_definitions(fastgltf PUBLIC "FASTGLTF_USE_64BIT_FLOAT=$<BOOL:${FASTGLTF_USE_64BIT_FLOAT}>")
+target_compile_definitions(fastgltf PUBLIC "FASTGLTF_ENABLE_KHR_IMPLICIT_SHAPES=$<BOOL:${FASTGLTF_ENABLE_KHR_IMPLICIT_SHAPES}>")
 target_compile_definitions(fastgltf PUBLIC "FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES=$<BOOL:${FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES}>")
 
 fastgltf_check_modules_support()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,8 @@ option(FASTGLTF_USE_64BIT_FLOAT "Default to 64-bit double precision floats for e
 option(FASTGLTF_COMPILE_AS_CPP20 "Have the library compile as C++20" OFF)
 option(FASTGLTF_ENABLE_CPP_MODULES "Enables the fastgltf::module target, which uses C++20 modules" OFF)
 option(FASTGLTF_USE_STD_MODULE "Use the std module when compiling using C++ modules" OFF)
-option(FASTGLTF_ENABLE_KHR_PHYSICS_RIGIDBODY "Enable support for the experimental KHR_physics_ridigbody extension", OFF)
+option(FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES "Enable support for the experimental KHR_physics_ridig_bodies extension" ON)
+
 
 if (FASTGLTF_COMPILE_AS_CPP20)
     set(FASTGLTF_COMPILE_TARGET cxx_std_20)
@@ -112,7 +113,7 @@ target_compile_definitions(fastgltf PUBLIC "FASTGLTF_USE_CUSTOM_SMALLVECTOR=$<BO
 target_compile_definitions(fastgltf PUBLIC "FASTGLTF_ENABLE_DEPRECATED_EXT=$<BOOL:${FASTGLTF_ENABLE_DEPRECATED_EXT}>")
 target_compile_definitions(fastgltf PUBLIC "FASTGLTF_DISABLE_CUSTOM_MEMORY_POOL=$<BOOL:${FASTGLTF_DISABLE_CUSTOM_MEMORY_POOL}>")
 target_compile_definitions(fastgltf PUBLIC "FASTGLTF_USE_64BIT_FLOAT=$<BOOL:${FASTGLTF_USE_64BIT_FLOAT}>")
-target_compile_definitions(fastgltf PUBLIC "FASTGLTF_ENABLE_KHR_PHYSICS_RIGIDBODY=$<BOOL:${FASTGLTF_ENABLE_KHR_PHYSICS_RIGIDBODY}>")
+target_compile_definitions(fastgltf PUBLIC "FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES=$<BOOL:${FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES}>")
 
 fastgltf_check_modules_support()
 if (FASTGLTF_ENABLE_CPP_MODULES AND FASTGLTF_SUPPORTS_MODULES AND CMAKE_VERSION VERSION_GREATER_EQUAL "3.28")

--- a/docs/options.rst
+++ b/docs/options.rst
@@ -99,10 +99,17 @@ When this ``BOOL`` option is set to ``YES`` fastgltf will use `corrosion`_, whic
 to link against the `gltf-rs`_ Rust library for comparison within the benchmarks.
 Note that this option has no effect when ``FASTGLTF_ENABLE_TESTS`` is set to ``NO``.
 
+``FASTGLTF_ENABLE_IMPLICIT_SHAPES``
+--------------------------------------------
+
+This option enables support for the draft KHR_implicit_shapes <https://github.com/KhronosGroup/glTF/pull/2370> extension
+
 ``FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES``
 --------------------------------------------
 
 This option enables support for the draft KHR_physics_rigid_bodies <https://github.com/KhronosGroup/glTF/pull/2424> extension
+
+KHR_physics_rigid_bodies relies on KHR_implicit_shapes, so this option implicitly enables `FASTGLTF_ENABLE_IMPLICIT_SHAPES`
 
 Parsing options
 ===============

--- a/docs/options.rst
+++ b/docs/options.rst
@@ -99,6 +99,11 @@ When this ``BOOL`` option is set to ``YES`` fastgltf will use `corrosion`_, whic
 to link against the `gltf-rs`_ Rust library for comparison within the benchmarks.
 Note that this option has no effect when ``FASTGLTF_ENABLE_TESTS`` is set to ``NO``.
 
+``FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES``
+--------------------------------------------
+
+This option enables support for the draft KHR_physics_rigid_bodies <https://github.com/KhronosGroup/glTF/pull/2424> extension
+
 Parsing options
 ===============
 

--- a/include/fastgltf/core.hpp
+++ b/include/fastgltf/core.hpp
@@ -216,6 +216,11 @@ namespace fastgltf {
 
 		// See https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_draco_mesh_compression
 		KHR_draco_mesh_compression = 1 << 26,
+
+#if FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES
+		// See https://github.com/KhronosGroup/glTF/pull/2424
+		KHR_physics_rigid_bodies = 1 << 27
+#endif
     };
     // clang-format on
 
@@ -343,17 +348,23 @@ namespace fastgltf {
 #if FASTGLTF_ENABLE_DEPRECATED_EXT
         constexpr std::string_view KHR_materials_pbrSpecularGlossiness = "KHR_materials_pbrSpecularGlossiness";
 #endif
+
+#if FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES
+		constexpr std::string_view KHR_physics_rigid_bodies = "KHR_physics_rigid_bodies";
+#endif
     } // namespace extensions
 
 	// clang-format off
 	// An array of pairs of string representations of extension identifiers and their respective enum
 	// value used for enabling/disabling the loading of it. This also represents all extensions that
 	// fastgltf supports and understands.
-#if FASTGLTF_ENABLE_DEPRECATED_EXT
-	static constexpr std::size_t SUPPORTED_EXTENSION_COUNT = 25;
-#else
-	static constexpr std::size_t SUPPORTED_EXTENSION_COUNT = 24;
+    static constexpr std::size_t SUPPORTED_EXTENSION_COUNT = 24
+#if FASTGLTF_ENABLE_DEPRECATED_EXT 
+	+ 1
+#elif FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES
+	+ 1
 #endif
+	;
 	static constexpr std::array<std::pair<std::string_view, Extensions>, SUPPORTED_EXTENSION_COUNT> extensionStrings = {{
 		{ extensions::EXT_mesh_gpu_instancing,                  Extensions::EXT_mesh_gpu_instancing },
 		{ extensions::EXT_meshopt_compression,                  Extensions::EXT_meshopt_compression },
@@ -382,6 +393,10 @@ namespace fastgltf {
 
 #if FASTGLTF_ENABLE_DEPRECATED_EXT
 		{ extensions::KHR_materials_pbrSpecularGlossiness,Extensions::KHR_materials_pbrSpecularGlossiness },
+#endif
+
+#if FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES
+		{ extensions::KHR_physics_rigid_bodies,					Extensions::KHR_physics_rigid_bodies },
 #endif
 	}};
 	// clang-format on

--- a/include/fastgltf/core.hpp
+++ b/include/fastgltf/core.hpp
@@ -843,6 +843,11 @@ namespace fastgltf {
 		Error parseScenes(simdjson::dom::array& array, Asset& asset);
 		Error parseSkins(simdjson::dom::array& array, Asset& asset);
 		Error parseTextures(simdjson::dom::array& array, Asset& asset);
+#if FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES
+		Error parsePhysicsMaterials(simdjson::dom::array& physicsMaterials, Asset& asset);
+		Error parseCollisionFilters(simdjson::dom::array& collisionFilters, Asset& asset);
+		Error parsePhysicsJoints(simdjson::dom::array& physicsJoints, Asset& asset);
+#endif
 		Expected<Asset> parse(simdjson::dom::object root, Category categories);
 
     public:

--- a/include/fastgltf/core.hpp
+++ b/include/fastgltf/core.hpp
@@ -991,6 +991,14 @@ namespace fastgltf {
         void writeScenes(const Asset& asset, std::string& json);
         void writeSkins(const Asset& asset, std::string& json);
         void writeTextures(const Asset& asset, std::string& json);
+#if FASTGLTF_ENABLE_KHR_IMPLICIT_SHAPES
+		void writeShapes(const Asset& asset, std::string& json);
+#endif
+#if FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES
+		void writePhysicsMaterials(const Asset& asset, std::string& json);
+		void writeCollisionFilters(const Asset& asset, std::string& json);
+		void writePhysicsJoints(const Asset& asset, std::string& json);
+#endif
         void writeExtensions(const Asset& asset, std::string& json);
 
         std::filesystem::path getBufferFilePath(const Asset& asset, std::size_t index);

--- a/include/fastgltf/core.hpp
+++ b/include/fastgltf/core.hpp
@@ -867,6 +867,8 @@ namespace fastgltf {
 		Error parsePhysicsMaterials(simdjson::dom::array& physicsMaterials, Asset& asset);
 		Error parseCollisionFilters(simdjson::dom::array& collisionFilters, Asset& asset);
 		Error parsePhysicsJoints(simdjson::dom::array& physicsJoints, Asset& asset);
+
+		Error parsePhysicsRigidBody(simdjson::dom::object& khr_physics_rigid_bodies, Node& node);
 #endif
 		Expected<Asset> parse(simdjson::dom::object root, Category categories);
 

--- a/include/fastgltf/core.hpp
+++ b/include/fastgltf/core.hpp
@@ -217,9 +217,14 @@ namespace fastgltf {
 		// See https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_draco_mesh_compression
 		KHR_draco_mesh_compression = 1 << 26,
 
+#if FASTGLTF_ENABLE_KHR_IMPLICIT_SHAPES
+		// See https://github.com/KhronosGroup/glTF/pull/2370
+		KHR_implicit_shapes = 1 << 27,
+#endif
+
 #if FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES
 		// See https://github.com/KhronosGroup/glTF/pull/2424
-		KHR_physics_rigid_bodies = 1 << 27
+		KHR_physics_rigid_bodies = 1 << 28
 #endif
     };
     // clang-format on
@@ -349,6 +354,10 @@ namespace fastgltf {
         constexpr std::string_view KHR_materials_pbrSpecularGlossiness = "KHR_materials_pbrSpecularGlossiness";
 #endif
 
+#if FASTGLTF_ENABLE_KHR_IMPLICIT_SHAPES
+		constexpr std::string_view KHR_implicit_shapes = "KHR_implicit_shapes";
+#endif
+
 #if FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES
 		constexpr std::string_view KHR_physics_rigid_bodies = "KHR_physics_rigid_bodies";
 #endif
@@ -361,7 +370,11 @@ namespace fastgltf {
     static constexpr std::size_t SUPPORTED_EXTENSION_COUNT = 24
 #if FASTGLTF_ENABLE_DEPRECATED_EXT 
 	+ 1
-#elif FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES
+#endif
+#if FASTGLTF_ENABLE_KHR_IMPLICIT_SHAPES
+	+ 1
+#endif
+#if FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES
 	+ 1
 #endif
 	;
@@ -393,6 +406,10 @@ namespace fastgltf {
 
 #if FASTGLTF_ENABLE_DEPRECATED_EXT
 		{ extensions::KHR_materials_pbrSpecularGlossiness,Extensions::KHR_materials_pbrSpecularGlossiness },
+#endif
+
+#if FASTGLTF_ENABLE_KHR_IMPLICIT_SHAPES
+        {extensions::KHR_implicit_shapes,						Extensions::KHR_implicit_shapes},
 #endif
 
 #if FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES
@@ -843,6 +860,9 @@ namespace fastgltf {
 		Error parseScenes(simdjson::dom::array& array, Asset& asset);
 		Error parseSkins(simdjson::dom::array& array, Asset& asset);
 		Error parseTextures(simdjson::dom::array& array, Asset& asset);
+#if FASTGLTF_ENABLE_KHR_IMPLICIT_SHAPES
+		Error parseShapes(simdjson::dom::array& shapes, Asset& asset);
+#endif
 #if FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES
 		Error parsePhysicsMaterials(simdjson::dom::array& physicsMaterials, Asset& asset);
 		Error parseCollisionFilters(simdjson::dom::array& collisionFilters, Asset& asset);

--- a/include/fastgltf/types.hpp
+++ b/include/fastgltf/types.hpp
@@ -557,11 +557,9 @@ namespace fastgltf {
 	[[nodiscard]] constexpr auto getDriveType(const std::string_view name) noexcept {
 		if (name[0] == 'l') {
 			return DriveType::Linear;
-		}
-		else if (name[0] == 'a') {
+		} else if (name[0] == 'a') {
 			return DriveType::Angular;
-		}
-		else {
+		} else {
 			return DriveType::Invalid;
 		}
 	}
@@ -2269,7 +2267,7 @@ namespace fastgltf {
         FASTGLTF_STD_PMR_NS::string name;
 
 #if FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES
-		Optional<PhysicsRigidBody> physicsRigidBody;
+		std::unique_ptr<PhysicsRigidBody> physicsRigidBody;
 #endif
 
         [[nodiscard]] auto findInstancingAttribute(std::string_view attributeName) noexcept {

--- a/include/fastgltf/types.hpp
+++ b/include/fastgltf/types.hpp
@@ -2240,7 +2240,7 @@ namespace fastgltf {
     FASTGLTF_EXPORT struct PhysicsRigidBody {
 		Optional<Motion> motion;
 
-		Collider collider;
+		Optional<Collider> collider;
 
 		Optional<std::variant<GeometryTrigger, NodeTrigger>> trigger;
 

--- a/include/fastgltf/types.hpp
+++ b/include/fastgltf/types.hpp
@@ -320,16 +320,6 @@ namespace fastgltf {
     FASTGLTF_UNARY_OP_TEMPLATE_MACRO(Category, ~)
     // clang-format on
 
-#if FASTGLTF_ENABLE_KHR_IMPLICIT_SHAPES
-	enum class ShapeType : std::uint8_t {
-        Sphere,
-		Box,
-		Cylinder,
-		Capsule,
-        Invalid,
-    };
-#endif
-
 #if FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES
 	FASTGLTF_EXPORT enum class CombineMode : std::uint8_t {
         Average,
@@ -341,12 +331,14 @@ namespace fastgltf {
 
 	FASTGLTF_EXPORT enum class DriveType : std::uint8_t {
 	    Linear,
-		Angular
+		Angular,
+		Invalid
 	};
 
 	FASTGLTF_EXPORT enum class DriveMode : std::uint8_t {
 	    Force,
-		Acceleration
+		Acceleration,
+	    Invalid
 	};
 #endif
 #pragma endregion
@@ -528,25 +520,8 @@ namespace fastgltf {
 		}
 	}
 
-#if FASTGLTF_ENABLE_KHR_IMPLICIT_SHAPES
-	constexpr auto getShapeType(std::string_view name) noexcept {
-		assert(!name.empty());
-		if(name[0] == 's') {
-			return ShapeType::Sphere;
-		} else if(name[0] == 'b') {
-			return ShapeType::Box;
-		} else if(name[1] == 'y') {
-			return ShapeType::Cylinder;
-		} else if(name[1] == 'a') {
-			return ShapeType::Capsule;
-		}
-
-		return ShapeType::Invalid;
-	}
-#endif
-
 #if FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES
-	constexpr auto getCombineMode(std::string_view name) noexcept {
+	[[nodiscard]] constexpr auto getCombineMode(const std::string_view name) noexcept {
 		assert(!name.empty());
 	    if(name[0] == 'a') {
 			return CombineMode::Average;
@@ -573,10 +548,32 @@ namespace fastgltf {
         "multiply"
 	};
 
-	constexpr std::string_view getFrictionCombineName(CombineMode frictionCombine) noexcept {
+	[[nodiscard]] constexpr std::string_view getFrictionCombineName(const CombineMode frictionCombine) noexcept {
 		static_assert(std::is_same_v<std::underlying_type_t<CombineMode>, std::uint8_t>);
 		const auto idx = to_underlying(frictionCombine) & 0x3;
 		return frictionCombineNames[idx];
+	}
+
+	[[nodiscard]] constexpr auto getDriveType(const std::string_view name) noexcept {
+		if (name[0] == 'l') {
+			return DriveType::Linear;
+		}
+		else if (name[0] == 'a') {
+			return DriveType::Angular;
+		}
+		else {
+			return DriveType::Invalid;
+		}
+	}
+
+	[[nodiscard]] constexpr auto getDriveMode(const std::string_view name) noexcept {
+	    if (name[0] == 'f') {
+			return DriveMode::Force;
+	    } else if (name[0] == 'a') {
+			return DriveMode::Acceleration;
+	    } else {
+			return DriveMode::Invalid;
+	    }
 	}
 #endif
 #pragma endregion
@@ -2013,11 +2010,7 @@ namespace fastgltf {
 		num radiusTop = 0.25;
 	};
 
-	FASTGLTF_EXPORT struct Shape {
-		std::variant<SphereShape, BoxShape, CapsuleShape, CylinderShape> shape;
-
-		ShapeType type;
-	};
+	using Shape = std::variant<SphereShape, BoxShape, CapsuleShape, CylinderShape>;
 #endif
 
 #if FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES

--- a/include/fastgltf/types.hpp
+++ b/include/fastgltf/types.hpp
@@ -2032,20 +2032,20 @@ namespace fastgltf {
          */
         Optional<num> mass;
 
+		/**
+		 * Center of mass of the rigid body in node space
+		 */
+		math::fvec3 centerOfMass = { 0, 0, 0 };
+
+		/**
+		 * The principal moments of inertia. Larger values imply the rigid body is harder to rotate
+		 */
+		Optional<math::fvec3> inertialDiagonal;
+
         /**
          * The quaternion rotating from inertia major axis space to node space
          */
         Optional<math::fvec4> inertialOrientation;
-
-        /**
-         * The principal moments of inertia. Larger values imply the rigid body is harder to rotate
-         */
-        Optional<math::fvec3> inertialDiagonal;
-
-        /**
-         * Center of mass of the rigid body in node space
-         */
-        math::fvec3 centerOfMass = {0, 0, 0};
 
         /**
          * Initial linear velocity of the rigid body in node space
@@ -2118,29 +2118,32 @@ namespace fastgltf {
         /**
          * Indexes into the top-level `physicsMaterials` and describes how the collider should respond to collisions
          */
-        std::size_t physicsMaterial;
+        Optional<std::size_t> physicsMaterial;
 
         /**
          * Indexes into the top-level `collisionFilters` and describes a filter which determines if this collider should perform collision detection against another collider
          */
-        std::size_t collisionFilter;
+        Optional<std::size_t> collisionFilter;
 	};
 
-	FASTGLTF_EXPORT struct Trigger {
+	FASTGLTF_EXPORT struct GeometryTrigger {
 		/**
 		 * An object describing the geometrical representation of this collider
 		 */
 		Geometry geometry;
 
-        /**
-         * For compound triggers, the set of descendant glTF nodes with a trigger property that make up this compound trigger
-         */
-        FASTGLTF_FG_PMR_NS::MaybeSmallVector<std::size_t> nodes;
+		/**
+		 * Indexes into the top-level `collisionFilters` and describes a filter which determines if this collider should perform collision detection against another collider
+		 */
+		Optional<std::size_t> collisionFilter;
+	};
 
-        /**
-         * Indexes into the top-level `collisionFilters` and describes a filter which determines if this collider should perform collision detection against another collider
-         */
-        std::size_t collisionFilter;
+	FASTGLTF_EXPORT struct NodeTrigger {
+
+		/**
+		 * For compound triggers, the set of descendant glTF nodes with a trigger property that make up this compound trigger
+		 */
+		FASTGLTF_FG_PMR_NS::MaybeSmallVector<std::size_t> nodes;
 	};
 
 	FASTGLTF_EXPORT struct JointLimit {
@@ -2239,7 +2242,7 @@ namespace fastgltf {
 
 		Collider collider;
 
-		Optional<Trigger> trigger;
+		Optional<std::variant<GeometryTrigger, NodeTrigger>> trigger;
 
 		Optional<Joint> joint;
 	};

--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -2330,7 +2330,7 @@ fg::Error fg::Parser::parseExtensions(simdjson::dom::object& extensionsObject, A
 				}
 
 				dom::array shapesArray;
-				if (auto arrayError = extensionsObject["shapes"].get_array().get(shapesArray); arrayError == SUCCESS) FASTGLTF_LIKELY {
+				if (auto arrayError = extensionObject["shapes"].get_array().get(shapesArray); arrayError == SUCCESS) FASTGLTF_LIKELY {
 					if (auto shapesError = parseShapes(shapesArray, asset); shapesError != Error::None) FASTGLTF_UNLIKELY {
 						return shapesError;
 					}
@@ -2347,7 +2347,7 @@ fg::Error fg::Parser::parseExtensions(simdjson::dom::object& extensionsObject, A
 				}
 
 				dom::array materialsArray;
-				if (auto arrayError = extensionsObject["physicsMaterials"].get_array().get(materialsArray); arrayError == SUCCESS) {
+				if (auto arrayError = extensionObject["physicsMaterials"].get_array().get(materialsArray); arrayError == SUCCESS) {
 					if (auto materialsError = parsePhysicsMaterials(materialsArray, asset); materialsError != Error::None) FASTGLTF_UNLIKELY {
 						return materialsError;
 					}
@@ -2356,7 +2356,7 @@ fg::Error fg::Parser::parseExtensions(simdjson::dom::object& extensionsObject, A
 				}
 
 				dom::array filtersArray;
-				if (auto arrayError = extensionsObject["collisionFilters"].get_array().get(filtersArray); arrayError == SUCCESS) {
+				if (auto arrayError = extensionObject["collisionFilters"].get_array().get(filtersArray); arrayError == SUCCESS) {
 					if (auto filtersError = parseCollisionFilters(filtersArray, asset); filtersError != Error::None) FASTGLTF_UNLIKELY {
 						return filtersError;
 					}
@@ -2365,7 +2365,7 @@ fg::Error fg::Parser::parseExtensions(simdjson::dom::object& extensionsObject, A
 				}
 
 				dom::array jointsArray;
-				if (auto arrayError = extensionsObject["physicsJoints"].get_array().get(jointsArray); arrayError == SUCCESS) {
+				if (auto arrayError = extensionObject["physicsJoints"].get_array().get(jointsArray); arrayError == SUCCESS) {
 					if (auto jointsError = parsePhysicsJoints(jointsArray, asset); jointsError != Error::None) FASTGLTF_UNLIKELY {
 						return jointsError;
 					}

--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -3861,7 +3861,7 @@ fg::Error fg::Parser::parseShapes(simdjson::dom::array& shapes, Asset& asset) {
 	using namespace simdjson;
 
 	asset.shapes.resize(shapes.size());
-	for(auto shapeValue : shapes) {
+	for (auto shapeValue : shapes) {
 		auto& shape = asset.shapes.emplace_back();
 
 		dom::object shapeObject;
@@ -3870,7 +3870,7 @@ fg::Error fg::Parser::parseShapes(simdjson::dom::array& shapes, Asset& asset) {
 		}
 
 		std::string_view shapeTypeName;
-		if(shapeObject["type"].get_string().get(shapeTypeName) == SUCCESS) {
+		if (shapeObject["type"].get_string().get(shapeTypeName) == SUCCESS) {
 		    shape.type = getShapeType(shapeTypeName);
 		} else {
 			return Error::InvalidGltf;
@@ -3893,22 +3893,22 @@ fg::Error fg::Parser::parseShapes(simdjson::dom::array& shapes, Asset& asset) {
 		}
 
 		dom::object boxObject;
-		if(auto error = shapeObject["box"].get_object().get(boxObject); error == SUCCESS) {
-		    if(shape.type != ShapeType::Box) {
+		if (auto error = shapeObject["box"].get_object().get(boxObject); error == SUCCESS) {
+		    if (shape.type != ShapeType::Box) {
 				return Error::InvalidGltf;
 		    }
 
 			dom::array sizeArray;
-			if(error = boxObject["size"].get_array().get(sizeArray); error == SUCCESS) {
-			    if(sizeArray.size() != 3) {
+			if (error = boxObject["size"].get_array().get(sizeArray); error == SUCCESS) {
+			    if (sizeArray.size() != 3) {
 					return Error::InvalidGltf;
 			    }
 
 				auto box = BoxShape{};
 				auto curIndex = 0;
-				for(auto sizeNum : sizeArray) {
+				for (auto sizeNum : sizeArray) {
 					double value;
-					if(sizeNum.get_double().get(value) == SUCCESS) {
+					if (sizeNum.get_double().get(value) == SUCCESS) {
 						box.size[curIndex] = static_cast<num>(value);
 					} else {
 						return Error::InvalidGltf;
@@ -3919,22 +3919,22 @@ fg::Error fg::Parser::parseShapes(simdjson::dom::array& shapes, Asset& asset) {
 
 				shape.shape = box;
 			}
-		} else if(error != NO_SUCH_FIELD) {
+		} else if (error != NO_SUCH_FIELD) {
 			return Error::InvalidGltf;
 		}
 
 		dom::object capsuleObject;
-		if(auto error = shapeObject["capsule"].get_object().get(capsuleObject); error == SUCCESS) {
-			if(shape.type != ShapeType::Capsule) {
+		if (auto error = shapeObject["capsule"].get_object().get(capsuleObject); error == SUCCESS) {
+			if (shape.type != ShapeType::Capsule) {
 				return Error::InvalidGltf;
 			}
 
 			auto capsule = CapsuleShape{};
 
 			double height;
-			if(error = capsuleObject["height"].get_double().get(height); error == SUCCESS) {
+			if (error = capsuleObject["height"].get_double().get(height); error == SUCCESS) {
 				capsule.height = static_cast<num>(height);
-			} else if(error != NO_SUCH_FIELD) {
+			} else if (error != NO_SUCH_FIELD) {
 				return Error::InvalidGltf;
 			}
 
@@ -4013,7 +4013,7 @@ fg::Error fg::Parser::parsePhysicsMaterials(simdjson::dom::array& physicsMateria
 	using namespace simdjson;
 
 	asset.physicsMaterials.reserve(physicsMaterials.size());
-	for(auto materialValue : physicsMaterials) {
+	for (auto materialValue : physicsMaterials) {
 		PhysicsMaterial& material = asset.physicsMaterials.emplace_back();
 		dom::object materialObject;
 		if (materialValue.get_object().get(materialObject) != SUCCESS) FASTGLTF_UNLIKELY {
@@ -4023,7 +4023,7 @@ fg::Error fg::Parser::parsePhysicsMaterials(simdjson::dom::array& physicsMateria
 		double staticFriction;
 		if (auto error = materialObject["staticFriction"].get_double().get(staticFriction); error == SUCCESS) FASTGLTF_LIKELY {
 		   material.staticFriction = static_cast<num>(staticFriction);
-		} else if(error != NO_SUCH_FIELD) {
+		} else if (error != NO_SUCH_FIELD) {
 			return Error::InvalidGltf;
 		}
 
@@ -4059,8 +4059,7 @@ fg::Error fg::Parser::parsePhysicsMaterials(simdjson::dom::array& physicsMateria
 			dom::object extrasObject;
 			if (auto extrasError = materialObject["extras"].get_object().get(extrasObject); extrasError == SUCCESS) {
 				config.extrasCallback(&extrasObject, asset.physicsMaterials.size() - 1, Category::PhysicsMaterials, config.userPointer);
-			}
-			else if (extrasError != NO_SUCH_FIELD) {
+			} else if (extrasError != NO_SUCH_FIELD) {
 				return Error::InvalidGltf;
 			}
 		}
@@ -4073,7 +4072,7 @@ fg::Error fg::Parser::parseCollisionFilters(simdjson::dom::array& collisionFilte
 	using namespace simdjson;
 
 	asset.collisionFilters.reserve(collisionFilters.size());
-	for(auto collisionFilterValue : collisionFilters) {
+	for (auto collisionFilterValue : collisionFilters) {
 		auto& collisionFilter = asset.collisionFilters.emplace_back();
 
 		dom::object collisionFilterObject;
@@ -4086,25 +4085,31 @@ fg::Error fg::Parser::parseCollisionFilters(simdjson::dom::array& collisionFilte
 			collisionFilter.collisionSystems.reserve(collisionSystems.size());
 			for (auto systemNameValue : collisionSystems) {
 				std::string_view systemName;
-				systemNameValue.get_string().get(systemName);
-				collisionFilter.collisionSystems.emplace_back(systemName);
+				if (systemNameValue.get_string().get(systemName) == SUCCESS) {
+					collisionFilter.collisionSystems.emplace_back(systemName);
+				} else {
+					return Error::InvalidGltf;
+				}
 			}
 		} else if (error != NO_SUCH_FIELD) {
 			return Error::InvalidGltf;
 		}
 
 	    // A glTF isn't allowed to have both
-		if(collisionFilterObject["collideWithSystems"].error() == SUCCESS && collisionFilterObject["notCollideWithSystems"].error() == SUCCESS) {
+		if (collisionFilterObject["collideWithSystems"].error() == SUCCESS && collisionFilterObject["notCollideWithSystems"].error() == SUCCESS) {
 			return Error::InvalidGltf;
 		}
 
 		dom::array collideWithSystems;
 		if (auto error = collisionFilterObject["collideWithSystems"].get_array().get(collideWithSystems); error == SUCCESS) FASTGLTF_LIKELY {
 			collisionFilter.collideWithSystems.reserve(collideWithSystems.size());
-			for(auto systemNameValue : collideWithSystems) {
+			for (auto systemNameValue : collideWithSystems) {
 				std::string_view systemName;
-				systemNameValue.get_string().get(systemName);
-				collisionFilter.collideWithSystems.emplace_back(systemName);
+				if (systemNameValue.get_string().get(systemName) == SUCCESS) {
+					collisionFilter.collideWithSystems.emplace_back(systemName);
+				} else {
+					return Error::InvalidGltf;
+				}
 			}
 		} else if (error != NO_SUCH_FIELD) {
 			return Error::InvalidGltf;
@@ -4115,8 +4120,11 @@ fg::Error fg::Parser::parseCollisionFilters(simdjson::dom::array& collisionFilte
 			collisionFilter.notCollideWithSystems.reserve(notCollideWithSystems.size());
 			for (auto systemNameValue : notCollideWithSystems) {
 				std::string_view systemName;
-				systemNameValue.get_string().get(systemName);
-				collisionFilter.notCollideWithSystems.emplace_back(systemName);
+				if (systemNameValue.get_string().get(systemName) == SUCCESS) {
+					collisionFilter.notCollideWithSystems.emplace_back(systemName);
+				} else {
+					return Error::InvalidGltf;
+				}
 			}
 		} else if (error != NO_SUCH_FIELD) {
 			return Error::InvalidGltf;
@@ -4139,7 +4147,7 @@ fg::Error fg::Parser::parsePhysicsJoints(simdjson::dom::array& physicsJoints, As
 	using namespace simdjson; 
 
 	asset.physicsJoints.reserve(physicsJoints.size());
-	for(auto physicsJointValue : physicsJoints) {
+	for (auto physicsJointValue : physicsJoints) {
 	    auto& physicsJoint = asset.physicsJoints.emplace_back();
 
 		dom::object physicsJointObject;
@@ -4148,9 +4156,9 @@ fg::Error fg::Parser::parsePhysicsJoints(simdjson::dom::array& physicsJoints, As
 		}
 
 		dom::array limitsArray;
-		if(physicsJointValue["limits"].get_array().get(limitsArray) == SUCCESS) FASTGLTF_LIKELY {
+		if (physicsJointValue["limits"].get_array().get(limitsArray) == SUCCESS) FASTGLTF_LIKELY {
 			physicsJoint.limits.reserve(limitsArray.size());
-            for(auto limitValue : limitsArray) {
+            for (auto limitValue : limitsArray) {
 				auto& limit = physicsJoint.limits.emplace_back();
 				dom::object limitObject;
 				if (limitValue.get_object().get(limitObject) != SUCCESS) FASTGLTF_UNLIKELY {
@@ -4168,7 +4176,7 @@ fg::Error fg::Parser::parsePhysicsJoints(simdjson::dom::array& physicsJoints, As
 				}
 
 				double limitMin;
-				if(limitObject["min"].get_double().get(limitMin) == SUCCESS) {
+				if (limitObject["min"].get_double().get(limitMin) == SUCCESS) {
 					limit.min = static_cast<num>(limitMin);
 				}
 
@@ -4216,22 +4224,22 @@ fg::Error fg::Parser::parsePhysicsJoints(simdjson::dom::array& physicsJoints, As
 		}
 
 		dom::array driveArray;
-		if(auto error = physicsJointValue["drives"].get_array().get(driveArray); error == SUCCESS) {
+		if (auto error = physicsJointValue["drives"].get_array().get(driveArray); error == SUCCESS) {
 			physicsJoint.drives.reserve(driveArray.size());
-			for(auto driveValue : driveArray) {
+			for (auto driveValue : driveArray) {
 			    auto& drive = physicsJoint.drives.emplace_back();
 				dom::object driveObject;
-				if(driveValue.get_object().get(driveObject) != SUCCESS) {
+				if (driveValue.get_object().get(driveObject) != SUCCESS) {
 					return Error::InvalidGltf;
 				}
 
 				// Type, mode, and axis are required
 
 				std::string_view type;
-				if(driveValue["type"].get_string().get(type) == SUCCESS) {
-				    if(type == "linear") {
+				if (driveValue["type"].get_string().get(type) == SUCCESS) {
+				    if (type == "linear") {
 						drive.type = DriveType::Linear;
-				    } else if(type == "angular") {
+				    } else if (type == "angular") {
 						drive.type = DriveType::Angular;
 				    } else {
 						return Error::InvalidGltf;
@@ -4241,10 +4249,10 @@ fg::Error fg::Parser::parsePhysicsJoints(simdjson::dom::array& physicsJoints, As
 				}
 
 				std::string_view mode;
-				if(driveValue["mode"].get_string().get(mode) == SUCCESS) {
-				    if(type == "force") {
+				if (driveValue["mode"].get_string().get(mode) == SUCCESS) {
+				    if (type == "force") {
 						drive.mode = DriveMode::Force;
-				    } else if(type == "acceleration") {
+				    } else if (type == "acceleration") {
 						drive.mode = DriveMode::Acceleration;
 				    } else {
 						return Error::InvalidGltf;
@@ -4254,8 +4262,8 @@ fg::Error fg::Parser::parsePhysicsJoints(simdjson::dom::array& physicsJoints, As
 				}
 
 				uint64_t axis;
-				if(driveValue["axis"].get_uint64().get(axis) == SUCCESS) {
-				    if(axis < 3) {
+				if (driveValue["axis"].get_uint64().get(axis) == SUCCESS) {
+				    if (axis < 3) {
 						drive.axis = static_cast<uint8_t>(axis);
 				    } else {
 						return Error::InvalidGltf;
@@ -4269,50 +4277,49 @@ fg::Error fg::Parser::parsePhysicsJoints(simdjson::dom::array& physicsJoints, As
 				double maxForce;
 				if (error = driveValue["maxForce"].get_double().get(maxForce); error == SUCCESS) {
 					drive.maxForce = static_cast<num>(maxForce);
-				}
-				else if (error != NO_SUCH_FIELD) {
+				} else if (error != NO_SUCH_FIELD) {
 					return Error::InvalidGltf;
 				}
 
 				// If the thing has positionTarget, it must also have stiffness
 				const auto hasPositionTarget = driveValue["positionTarget"].error() == SUCCESS;
 				const auto hasStiffness = driveValue["stiffness"].error() == SUCCESS;
-				if(hasPositionTarget != hasStiffness) {
+				if (hasPositionTarget != hasStiffness) {
 					return Error::InvalidGltf;
 				}
 
 				double positionTarget;
-				if(error = driveValue["positionTarget"].get_double().get(positionTarget); error == SUCCESS) {
+				if (error = driveValue["positionTarget"].get_double().get(positionTarget); error == SUCCESS) {
 				    drive.positionTarget = static_cast<num>(positionTarget);
-				} else if(error != NO_SUCH_FIELD) {
+				} else if (error != NO_SUCH_FIELD) {
 					return Error::InvalidGltf;
 				}
 
 				double stiffness;
-				if(error = driveValue["stiffness"].get_double().get(stiffness); error == SUCCESS) {
+				if (error = driveValue["stiffness"].get_double().get(stiffness); error == SUCCESS) {
 					drive.stiffness = static_cast<num>(stiffness);
-				} else if(error != NO_SUCH_FIELD) {
+				} else if (error != NO_SUCH_FIELD) {
 					return Error::InvalidGltf;
 				}
 
 				// If the thing has velocityTarget, it must also have damping
 				const auto hasVelocityTarget = driveValue["velocityTarget"].error() == SUCCESS;
 				const auto hasDamping = driveValue["damping"].error() == SUCCESS;
-				if(hasVelocityTarget != hasDamping) {
+				if (hasVelocityTarget != hasDamping) {
 					return Error::InvalidGltf;
 				}
 
 				double velocityTarget;
-				if(error = driveValue["velocityTarget"].get_double().get(velocityTarget); error == SUCCESS) {
+				if (error = driveValue["velocityTarget"].get_double().get(velocityTarget); error == SUCCESS) {
 					drive.velocityTarget = static_cast<num>(velocityTarget);
-				} else if(error != NO_SUCH_FIELD) {
+				} else if (error != NO_SUCH_FIELD) {
 					return Error::InvalidGltf;
 				}
 
 				double damping;
-				if(error = driveValue["damping"].get_double().get(damping); error == SUCCESS) {
-					drive.damping == static_cast<num>(damping);
-				} else if(error != NO_SUCH_FIELD) {
+				if (error = driveValue["damping"].get_double().get(damping); error == SUCCESS) {
+					drive.damping = static_cast<num>(damping);
+				} else if (error != NO_SUCH_FIELD) {
 					return Error::InvalidGltf;
 				}
 			}
@@ -5874,30 +5881,48 @@ void fg::Exporter::writeShapes(const Asset& asset, std::string& json) {
 	}
 
 	json += R"("KHR_implicit_shapes":{"shapes":[)";
-	for (auto it = asset.shapes.begin(); it < asset.shapes.end(); ++it) {
+	for (auto it = asset.shapes.begin(); it != asset.shapes.end(); ++it) {
 		const auto& shape = *it;
 		json += "{";
 
 		switch(shape.type) {
-        case ShapeType::Sphere:
-			const auto& sphere = std::get<SphereShape>(shape.shape);
-			json += R"("type"="sphere","sphere"={"radius"=)" + std::to_string(sphere.radius) + "}";
+		case ShapeType::Sphere:
+		    {
+			    const auto& sphere = std::get<SphereShape>(shape.shape);
+			    json += R"("type":"sphere","sphere":{"radius":)" + std::to_string(sphere.radius) + "}";
+		    }
             break;
 		case ShapeType::Box:
-			const auto& box = std::get<BoxShape>(shape.shape);
-			json += R"("type"="box","box"={"size"=[)" + std::to_string(box.size.x) + "," + std::to_string(box.size.y) + "," + std::to_string(box.size.z) + "]}";
-            break;
+		    {
+			    const auto& box = std::get<BoxShape>(shape.shape);
+			    json += R"("type":"box","box":{"size":[)" + std::to_string(box.size.x()) + "," + std::to_string(box.size.y()) + "," + std::to_string(box.size.z()) + "]}";
+		    }
+		    break;
 		case ShapeType::Cylinder:
-			const auto& cylinder = std::get<CylinderShape>(shape.shape);
-			json += R"("type"="cylinder","cylinder"={"height"=)" + std::to_string(cylinder.height) + R"(,"radiusBottom"=)" + std::to_string(cylinder.radiusBottom) + R"(,"radiusTop"=)" + std::to_string(cylinder.radiusTop) + "}";
-            break;
+		    {
+			    const auto& cylinder = std::get<CylinderShape>(shape.shape);
+			    json += R"("type":"cylinder","cylinder":{"height":)" + std::to_string(cylinder.height) + R"(,"radiusBottom":)" + std::to_string(cylinder.radiusBottom) + R"(,"radiusTop":)" + std::to_string(cylinder.radiusTop) + "}";
+		    }
+		    break;
 		case ShapeType::Capsule:
-			const auto& capsule = std::get<CapsuleShape>(shape.shape);
-			json += R"("type"="capsule","capsule"={"height"=)" + std::to_string(capsule.height) + R"(,"radiusBottom"=)" + std::to_string(capsule.radiusBottom) + R"(,"radiusTop"=)" + std::to_string(capsule.radiusTop) + "}";
+		    {
+			    const auto& capsule = std::get<CapsuleShape>(shape.shape);
+			    json += R"("type":"capsule","capsule":{"height":)" + std::to_string(capsule.height) + R"(,"radiusBottom":)" + std::to_string(capsule.radiusBottom) + R"(,"radiusTop":)" + std::to_string(capsule.radiusTop) + "}";
+		    }
             break;
         case ShapeType::Invalid:
             break;
         }
+
+		if (extrasWriteCallback != nullptr) {
+			auto extras = extrasWriteCallback(uabs(std::distance(asset.shapes.begin(), it)), fastgltf::Category::Shapes, userPointer);
+			if (extras.has_value()) {
+				if (json.back() != '{') {
+					json += ',';
+				}
+				json += std::string("\"extras\":") + *extras;
+			}
+		}
 
 		json += "}";
 
@@ -5906,6 +5931,283 @@ void fg::Exporter::writeShapes(const Asset& asset, std::string& json) {
 		}
 	}
 	json += "]}";    
+}
+#endif
+
+#if FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES
+void fg::Exporter::writePhysicsMaterials(const Asset& asset, std::string& json) {
+    if (asset.physicsMaterials.empty()) {
+        return;
+    }
+	if (json.back() == ']' || json.back() == '}') {
+		json += ',';
+	}
+
+	json += R"("physicsMaterials":[)";
+
+	for (auto it = asset.physicsMaterials.begin(); it != asset.physicsMaterials.end(); ++it) {
+		const auto& material = *it;
+
+		json += R"({"staticFriction":)" + std::to_string(material.staticFriction) + R"(,"dynamicFriction":)" + std::to_string(material.dynamicFriction) + R"(,"restitution":)" + std::to_string(material.restitution) + R"(,"frictionCombine":)";
+		switch (material.frictionCombine) {
+        case CombineMode::Average:
+			json += R"("average")";
+            break;
+        case CombineMode::Minimum:
+			json += R"("minimum")";
+            break;
+        case CombineMode::Maximum:
+			json += R"("maximum")";
+            break;
+        case CombineMode::Multiply:
+			json += R"("multiply")";
+            break;
+        }
+		json += R"(,"restitutionCombine":)";
+		switch (material.restitutionCombine) {
+		case CombineMode::Average:
+			json += R"("average")";
+			break;
+		case CombineMode::Minimum:
+			json += R"("minimum")";
+			break;
+		case CombineMode::Maximum:
+			json += R"("maximum")";
+			break;
+		case CombineMode::Multiply:
+			json += R"("multiply")";
+			break;
+		}
+
+		if (extrasWriteCallback != nullptr) {
+			auto extras = extrasWriteCallback(uabs(std::distance(asset.physicsMaterials.begin(), it)), fastgltf::Category::PhysicsMaterials, userPointer);
+			if (extras.has_value()) {
+				if (json.back() != '{') {
+					json += ',';
+				}
+				json += std::string("\"extras\":") + *extras;
+			}
+		}
+
+		json += "}";
+
+		if (uabs(std::distance(asset.physicsMaterials.begin(), it)) + 1 < asset.physicsMaterials.size()) {
+			json += ',';
+		}
+	}
+
+	json += "]";
+}
+
+void fg::Exporter::writeCollisionFilters(const Asset& asset, std::string& json) {
+	if (asset.collisionFilters.empty()) {
+		return;
+	}
+	if (json.back() == ']' || json.back() == '}') {
+		json += ',';
+	}
+
+	json += R"("collisionFilters":[)";
+
+	for (auto it = asset.collisionFilters.begin(); it != asset.collisionFilters.end(); ++it) {
+		const auto& filter = *it;
+
+		json += "{";
+
+		if (!filter.collisionSystems.empty()) {
+			json += R"("collisionSystems":[)";
+			for (auto systemIt = filter.collisionSystems.begin(); systemIt != filter.collisionSystems.end(); ++systemIt) {
+				json += R"(")";
+				json += *systemIt;
+				json += R"(")";
+
+				if (uabs(std::distance(filter.collisionSystems.begin(), systemIt)) + 1 < filter.collisionSystems.size()) {
+					json += ',';
+				}
+			}
+			json += "]";
+		}
+		if (json.back() == ']') {
+			json += ',';
+		}
+
+		if (!filter.collideWithSystems.empty()) {
+			json += R"("collideWithSystems":[)";
+			for (auto systemIt = filter.collideWithSystems.begin(); systemIt != filter.collideWithSystems.end(); ++systemIt) {
+				json += R"(")";
+				json += *systemIt;
+				json += R"(")";
+
+				if (uabs(std::distance(filter.collideWithSystems.begin(), systemIt)) + 1 < filter.collideWithSystems.size()) {
+					json += ',';
+				}
+			}
+			json += "]";
+		}
+		if (json.back() == ']') {
+			json += ',';
+		}
+
+		if (!filter.notCollideWithSystems.empty()) {
+			json += R"("notCollideWithSystems":[)";
+			for (auto systemIt = filter.notCollideWithSystems.begin(); systemIt != filter.notCollideWithSystems.end(); ++systemIt) {
+				json += R"(")";
+				json += *systemIt;
+				json += R"(")";
+
+				if (uabs(std::distance(filter.notCollideWithSystems.begin(), systemIt)) + 1 < filter.notCollideWithSystems.size()) {
+					json += ',';
+				}
+			}
+			json += "]";
+		}
+
+		if (extrasWriteCallback != nullptr) {
+			auto extras = extrasWriteCallback(uabs(std::distance(asset.collisionFilters.begin(), it)), fastgltf::Category::Shapes, userPointer);
+			if (extras.has_value()) {
+				if (json.back() != '{') {
+					json += ',';
+				}
+				json += std::string("\"extras\":") + *extras;
+			}
+		}
+
+		json += "}";
+
+		if (uabs(std::distance(asset.collisionFilters.begin(), it)) + 1 < asset.collisionFilters.size()) {
+			json += ',';
+		}
+	}
+
+	json += "]";
+}
+
+void fg::Exporter::writePhysicsJoints(const Asset& asset, std::string& json) {
+	if (asset.physicsJoints.empty()) {
+		return;
+	}
+	if (json.back() == ']' || json.back() == '}') {
+		json += ',';
+	}
+
+	json += R"("physicsJoints":[)";
+
+	for (auto it = asset.physicsJoints.begin(); it != asset.physicsJoints.end(); ++it) {
+		const auto& joint = *it;
+
+		json += "{";
+
+		if (!joint.limits.empty()) {
+			json += R"("limits":[)";
+			for (auto limitIt = joint.limits.begin(); limitIt != joint.limits.end(); ++limitIt) {
+				const auto& limit = *limitIt;
+
+				json += "{";
+				if (!limit.linearAxes.empty()) {
+					json += R"("linearAxes":[)";
+					for (auto axisIt = limit.linearAxes.begin(); axisIt != limit.linearAxes.end(); ++axisIt) {
+						json += std::to_string(*axisIt);
+
+						if (uabs(std::distance(limit.linearAxes.begin(), axisIt)) + 1 < limit.linearAxes.size()) {
+							json += ',';
+						}
+					}
+					json += "],";
+				}
+				if (!limit.angularAxes.empty()) {
+					json += R"("angularAxes":[)";
+					for (auto axisIt = limit.angularAxes.begin(); axisIt != limit.angularAxes.end(); ++axisIt) {
+						json += std::to_string(*axisIt);
+
+						if (uabs(std::distance(limit.angularAxes.begin(), axisIt)) + 1 < limit.angularAxes.size()) {
+							json += ',';
+						}
+					}
+					json += "],";
+				}
+				if (limit.min) {
+					json += R"("min":)" + std::to_string(*limit.min) + ",";
+				}
+				if (limit.max) {
+					json += R"("max":)" + std::to_string(*limit.max) + ",";
+				}
+				if (limit.stiffness) {
+					json += R"("stiffness":)" + std::to_string(*limit.stiffness) + ",";
+				}
+			    json += R"("damping":)" + std::to_string(limit.damping);
+				json += "}";
+
+				if (uabs(std::distance(joint.limits.begin(), limitIt)) + 1 < joint.limits.size()) {
+					json += ',';
+				}
+			}
+			json += "]";
+
+			if(!joint.drives.empty()) {
+				json += ",";
+			}
+		}
+
+		if (!joint.drives.empty()) {
+			json += R"("drives":[)";
+			for (auto driveIt = joint.drives.begin(); driveIt != joint.drives.end(); ++driveIt) {
+				const auto& drive = *driveIt;
+
+				json += R"({"type":)";
+				switch(drive.type) {
+                case DriveType::Linear:
+					json += R"("linear")";
+                    break;
+                case DriveType::Angular:
+					json += R"("angular")";
+                    break;
+                }
+
+				json += R"(,"mode":)";
+				switch (drive.mode) {
+				case DriveMode::Force:
+					json += R"("force")";
+					break;
+				case DriveMode::Acceleration:
+					json += R"("acceleration")";
+					break;
+				}
+
+				json += R"(,"axis":)" + std::to_string(drive.axis)
+			        + R"(,"maxForce":)" + std::to_string(drive.maxForce)
+			        + R"(,"positionTarget":)" + std::to_string(drive.positionTarget)
+			        + R"(,"velocityTarget":)" + std::to_string(drive.velocityTarget)
+			        + R"(,"stiffness":)" + std::to_string(drive.stiffness)
+			        + R"(,"damping":)" + std::to_string(drive.damping);
+
+				json += '}';
+
+				if (uabs(std::distance(joint.drives.begin(), driveIt)) + 1 < joint.drives.size()) {
+					json += ',';
+				}
+			}
+
+			json += "]";
+		}
+
+		if (extrasWriteCallback != nullptr) {
+			auto extras = extrasWriteCallback(uabs(std::distance(asset.physicsJoints.begin(), it)), fastgltf::Category::PhysicsJoints, userPointer);
+			if (extras.has_value()) {
+				if (json.back() != '{') {
+					json += ',';
+				}
+				json += std::string("\"extras\":") + *extras;
+			}
+		}
+
+		json += "}";
+
+		if (uabs(std::distance(asset.physicsJoints.begin(), it)) + 1 < asset.physicsJoints.size()) {
+			json += ',';
+		}
+	}
+
+	json += "]";
 }
 #endif
 
@@ -5921,9 +6223,14 @@ void fg::Exporter::writeExtensions(const fastgltf::Asset& asset, std::string& js
 #endif
 
 #if FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES
+	if (json.back() == ']' || json.back() == '}') {
+		json += ',';
+	}
+	json += R"("KHR_physics_rigid_bodies":{)";
 	writePhysicsMaterials(asset, json);
 	writeCollisionFilters(asset, json);
     writePhysicsJoints(asset, json);
+	json += "}";
 #endif
 
 	if (!asset.materialVariants.empty()) {
@@ -5961,7 +6268,7 @@ fs::path fg::Exporter::getImageFilePath(const Asset& asset, std::size_t index, M
 		case MimeType::KTX2:
 			extension = ".ktx2";
 			break;
-		case MimeType::DDS:
+		case MimeType::DDS: 
 			extension = ".dds";
 			break;
 		default:

--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -5942,7 +5942,7 @@ void fg::Exporter::writeNodes(const Asset& asset, std::string& json) {
 			}
 			if (it->lightIndex.has_value()) {
 				if (json.back() != '{') json += ',';
-				json += R"("KHR_lights_punctual":{"light":)" + std::to_string(it->lightIndex.value()) + "}";
+				json += R"("KHR_lights_punctual":{"light":)" + std::to_string(it->lightIndex.value()) + '}';
 			}
 
 #if FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES
@@ -5955,16 +5955,16 @@ void fg::Exporter::writeNodes(const Asset& asset, std::string& json) {
 					if (motion.mass.has_value()) {
 						json += R"(,"mass":)" + to_string_fp(*motion.mass);
 					}
-					json += R"(,"centerOfMass":[)" + to_string(motion.centerOfMass) + "]";
+					json += R"(,"centerOfMass":[)" + to_string(motion.centerOfMass) + ']';
 					if (motion.inertialDiagonal.has_value()) {
-						json += R"(,"inertialDiagonal":[)" + to_string(*motion.inertialDiagonal) + "]";
+						json += R"(,"inertialDiagonal":[)" + to_string(*motion.inertialDiagonal) + ']';
 					}
 					if (motion.inertialOrientation.has_value()) {
-						json += R"(,"inertialOrientation":[)" + to_string(*motion.inertialOrientation) + "]";
+						json += R"(,"inertialOrientation":[)" + to_string(*motion.inertialOrientation) + ']';
 					}
 					json += R"(,"linearVelocity":)" + to_string(motion.linearVelocity)
 				        + R"(],"angularVelocity":[)" + to_string(motion.angularVelocity)
-				        + R"(],"gravityFactor":[)" + to_string_fp(motion.gravityFactor) + "}";
+				        + R"(],"gravityFactor":[)" + to_string_fp(motion.gravityFactor) + '}';
 				}
 
 				if (it->physicsRigidBody->trigger.has_value()) {
@@ -5975,11 +5975,11 @@ void fg::Exporter::writeNodes(const Asset& asset, std::string& json) {
 						[&](const GeometryTrigger& geometry) {
 							json += R"("geometry":{)";
 							if (geometry.geometry.shape.has_value()) {
-								json += R"("shape":)" + std::to_string(*geometry.geometry.shape) + ",";
+								json += R"("shape":)" + std::to_string(*geometry.geometry.shape) + ',';
 							} else if(geometry.geometry.node.has_value()) {
-								json += R"("node":)" + std::to_string(*geometry.geometry.node) + ",";
+								json += R"("node":)" + std::to_string(*geometry.geometry.node) + ',';
 							}
-							json += R"("convexHull":)" + std::to_string(geometry.geometry.convexHull) + "}";
+							json += R"("convexHull":)" + std::to_string(geometry.geometry.convexHull) + '}';
 
 							if (geometry.collisionFilter.has_value()) {
 								json += R"(,"collisionFilter":)" + std::to_string(*geometry.collisionFilter);
@@ -5995,7 +5995,7 @@ void fg::Exporter::writeNodes(const Asset& asset, std::string& json) {
 							json += ']';
 						},
 						}, trigger);
-					json += "}";
+					json += '}';
 				}
 
 				if (it->physicsRigidBody->joint.has_value()) {
@@ -6003,7 +6003,7 @@ void fg::Exporter::writeNodes(const Asset& asset, std::string& json) {
 					const auto& joint = *it->physicsRigidBody->joint;
 					json += R"("joint":{"connectedNode":)" + std::to_string(joint.connectedNode)
 				        + R"(,"joint":)" + std::to_string(joint.joint)
-				        + R"(,"enableCollision":)" + std::to_string(joint.enableCollision) + "}";
+				        + R"(,"enableCollision":)" + std::to_string(joint.enableCollision) + '}';
 				}
 
 				if (it->physicsRigidBody->collider.has_value()) {
@@ -6013,11 +6013,11 @@ void fg::Exporter::writeNodes(const Asset& asset, std::string& json) {
 
 					json += R"("geometry":{)";
 					if (collider.geometry.shape.has_value()) {
-						json += R"("shape":)" + std::to_string(*collider.geometry.shape) + ",";
+						json += R"("shape":)" + std::to_string(*collider.geometry.shape) + ',';
 					} else if (collider.geometry.node.has_value()) {
-						json += R"("node":)" + std::to_string(*collider.geometry.node) + ",";
+						json += R"("node":)" + std::to_string(*collider.geometry.node) + ',';
 					}
-					json += R"("convexHull":)" + std::to_string(collider.geometry.convexHull) + "}";
+					json += R"("convexHull":)" + std::to_string(collider.geometry.convexHull) + '}';
 
 					if (collider.physicsMaterial.has_value()) {
 						json += R"(,"physicsMaterial":)" + std::to_string(*collider.physicsMaterial);
@@ -6025,7 +6025,7 @@ void fg::Exporter::writeNodes(const Asset& asset, std::string& json) {
 					if (collider.collisionFilter) {
 						json += R"(,"collisionFilter":)" + std::to_string(*collider.collisionFilter);
 					}
-					json += "}";
+					json += '}';
 				}
 			}
 #endif
@@ -6251,13 +6251,13 @@ void fg::Exporter::writeShapes(const Asset& asset, std::string& json) {
 	json += R"("KHR_implicit_shapes":{"shapes":[)";
 	for (auto it = asset.shapes.begin(); it != asset.shapes.end(); ++it) {
 		const auto& shape = *it;
-		json += "{";
+		json += '{';
 
 		switch(shape.type) {
 		case ShapeType::Sphere:
 		    {
 			    const auto& sphere = std::get<SphereShape>(shape.shape);
-			    json += R"("type":"sphere","sphere":{"radius":)" + to_string_fp(sphere.radius) + "}";
+			    json += R"("type":"sphere","sphere":{"radius":)" + to_string_fp(sphere.radius) + '}';
 		    }
             break;
 		case ShapeType::Box:
@@ -6279,7 +6279,7 @@ void fg::Exporter::writeShapes(const Asset& asset, std::string& json) {
 			    const auto& capsule = std::get<CapsuleShape>(shape.shape);
 			    json += R"("type":"capsule","capsule":{"height":)" + to_string_fp(capsule.height)
 		            + R"(,"radiusBottom":)" + to_string_fp(capsule.radiusBottom)
-		            + R"(,"radiusTop":)" + to_string_fp(capsule.radiusTop) + "}";
+		            + R"(,"radiusTop":)" + to_string_fp(capsule.radiusTop) + '}';
 		    }
             break;
         case ShapeType::Invalid:
@@ -6296,7 +6296,7 @@ void fg::Exporter::writeShapes(const Asset& asset, std::string& json) {
 			}
 		}
 
-		json += "}";
+		json += '};
 
 		if (uabs(std::distance(asset.shapes.begin(), it)) + 1 < asset.shapes.size()) {
 			json += ',';
@@ -6364,14 +6364,14 @@ void fg::Exporter::writePhysicsMaterials(const Asset& asset, std::string& json) 
 			}
 		}
 
-		json += "}";
+		json += '}';
 
 		if (uabs(std::distance(asset.physicsMaterials.begin(), it)) + 1 < asset.physicsMaterials.size()) {
 			json += ',';
 		}
 	}
 
-	json += "]";
+	json += ']';
 }
 
 void fg::Exporter::writeCollisionFilters(const Asset& asset, std::string& json) {
@@ -6387,20 +6387,20 @@ void fg::Exporter::writeCollisionFilters(const Asset& asset, std::string& json) 
 	for (auto it = asset.collisionFilters.begin(); it != asset.collisionFilters.end(); ++it) {
 		const auto& filter = *it;
 
-		json += "{";
+		json += '{';
 
 		if (!filter.collisionSystems.empty()) {
 			json += R"("collisionSystems":[)";
 			for (auto systemIt = filter.collisionSystems.begin(); systemIt != filter.collisionSystems.end(); ++systemIt) {
-				json += R"(")";
+				json += '"';
 				json += *systemIt;
-				json += R"(")";
+				json += '"';
 
 				if (uabs(std::distance(filter.collisionSystems.begin(), systemIt)) + 1 < filter.collisionSystems.size()) {
 					json += ',';
 				}
 			}
-			json += "]";
+			json += ']';
 		}
 		if (json.back() == ']') {
 			json += ',';
@@ -6409,15 +6409,15 @@ void fg::Exporter::writeCollisionFilters(const Asset& asset, std::string& json) 
 		if (!filter.collideWithSystems.empty()) {
 			json += R"("collideWithSystems":[)";
 			for (auto systemIt = filter.collideWithSystems.begin(); systemIt != filter.collideWithSystems.end(); ++systemIt) {
-				json += R"(")";
+				json += '"';
 				json += *systemIt;
-				json += R"(")";
+				json += '"';
 
 				if (uabs(std::distance(filter.collideWithSystems.begin(), systemIt)) + 1 < filter.collideWithSystems.size()) {
 					json += ',';
 				}
 			}
-			json += "]";
+			json += ']';
 		}
 		if (json.back() == ']') {
 			json += ',';
@@ -6426,15 +6426,15 @@ void fg::Exporter::writeCollisionFilters(const Asset& asset, std::string& json) 
 		if (!filter.notCollideWithSystems.empty()) {
 			json += R"("notCollideWithSystems":[)";
 			for (auto systemIt = filter.notCollideWithSystems.begin(); systemIt != filter.notCollideWithSystems.end(); ++systemIt) {
-				json += R"(")";
+				json += '"';
 				json += *systemIt;
-				json += R"(")";
+				json += '"';
 
 				if (uabs(std::distance(filter.notCollideWithSystems.begin(), systemIt)) + 1 < filter.notCollideWithSystems.size()) {
 					json += ',';
 				}
 			}
-			json += "]";
+			json += ']';
 		}
 
 		if (extrasWriteCallback != nullptr) {
@@ -6447,14 +6447,14 @@ void fg::Exporter::writeCollisionFilters(const Asset& asset, std::string& json) 
 			}
 		}
 
-		json += "}";
+		json += '}';
 
 		if (uabs(std::distance(asset.collisionFilters.begin(), it)) + 1 < asset.collisionFilters.size()) {
 			json += ',';
 		}
 	}
 
-	json += "]";
+	json += ']';
 }
 
 void fg::Exporter::writePhysicsJoints(const Asset& asset, std::string& json) {
@@ -6470,14 +6470,14 @@ void fg::Exporter::writePhysicsJoints(const Asset& asset, std::string& json) {
 	for (auto it = asset.physicsJoints.begin(); it != asset.physicsJoints.end(); ++it) {
 		const auto& joint = *it;
 
-		json += "{";
+		json += '{';
 
 		if (!joint.limits.empty()) {
 			json += R"("limits":[)";
 			for (auto limitIt = joint.limits.begin(); limitIt != joint.limits.end(); ++limitIt) {
 				const auto& limit = *limitIt;
 
-				json += "{";
+				json += '{';
 				if (!limit.linearAxes.empty()) {
 					json += R"("linearAxes":[)";
 					for (auto axisIt = limit.linearAxes.begin(); axisIt != limit.linearAxes.end(); ++axisIt) {
@@ -6501,25 +6501,25 @@ void fg::Exporter::writePhysicsJoints(const Asset& asset, std::string& json) {
 					json += "],";
 				}
 				if (limit.min) {
-					json += R"("min":)" + to_string_fp(*limit.min) + ",";
+					json += R"("min":)" + to_string_fp(*limit.min) + ',';
 				}
 				if (limit.max) {
-					json += R"("max":)" + to_string_fp(*limit.max) + ",";
+					json += R"("max":)" + to_string_fp(*limit.max) + ',';
 				}
 				if (limit.stiffness) {
-					json += R"("stiffness":)" + to_string_fp(*limit.stiffness) + ",";
+					json += R"("stiffness":)" + to_string_fp(*limit.stiffness) + ',';
 				}
 			    json += R"("damping":)" + to_string_fp(limit.damping);
-				json += "}";
+				json += '}';
 
 				if (uabs(std::distance(joint.limits.begin(), limitIt)) + 1 < joint.limits.size()) {
 					json += ',';
 				}
 			}
-			json += "]";
+			json += ']';
 
 			if(!joint.drives.empty()) {
-				json += ",";
+				json += ',';
 			}
 		}
 
@@ -6562,7 +6562,7 @@ void fg::Exporter::writePhysicsJoints(const Asset& asset, std::string& json) {
 				}
 			}
 
-			json += "]";
+			json += ']';
 		}
 
 		if (extrasWriteCallback != nullptr) {
@@ -6605,7 +6605,7 @@ void fg::Exporter::writeExtensions(const fastgltf::Asset& asset, std::string& js
 	writePhysicsMaterials(asset, json);
 	writeCollisionFilters(asset, json);
     writePhysicsJoints(asset, json);
-	json += "}";
+	json += '}';
 #endif
 
 	if (!asset.materialVariants.empty()) {

--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -4484,7 +4484,55 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 		return Error::InvalidGltf;
 	}
 
-	
+	dom::object colliderObject;
+	if (auto error = khr_physics_rigid_bodies["collider"].get_object().get(colliderObject); error == SUCCESS) {
+		Collider collider;
+
+		dom::object geometryObject;
+		if (colliderObject["geometry"].get_object().get(geometryObject) == SUCCESS) {
+			uint64_t shape;
+			if (error = geometryObject["shape"].get_uint64().get(shape); error == SUCCESS) {
+				collider.geometry.shape = static_cast<std::size_t>(shape);
+			} else if (error != NO_SUCH_FIELD) {
+				return Error::InvalidGltf;
+			}
+			uint64_t geometryNode;
+			if (error = geometryObject["node"].get_uint64().get(geometryNode); error == SUCCESS) {
+				collider.geometry.node = static_cast<std::size_t>(geometryNode);
+			} else if (error != NO_SUCH_FIELD) {
+				return Error::InvalidGltf;
+			}
+			bool convexHull;
+			if (error = geometryObject["convexHull"].get_bool().get(convexHull); error == SUCCESS) {
+				collider.geometry.convexHull = convexHull;
+			} else if (error != NO_SUCH_FIELD) {
+				return Error::InvalidGltf;
+			}
+		} else {
+			return Error::InvalidGltf;
+		}
+
+		std::size_t physicsMaterial;
+		if (error = colliderObject["physicsMaterial"].get_uint64().get(physicsMaterial); error == SUCCESS) {
+			collider.physicsMaterial = physicsMaterial;
+		} else if (error != NO_SUCH_FIELD) {
+			return Error::InvalidGltf;
+		}
+
+		std::size_t collisionFilter;
+		if (error = colliderObject["collisionFilter"].get_uint64().get(collisionFilter); error == SUCCESS) {
+			collider.collisionFilter = collisionFilter;
+		} else if (error != NO_SUCH_FIELD) {
+			return Error::InvalidGltf;
+		}
+
+		rigid_body.collider = collider;
+
+	} else if (error != NO_SUCH_FIELD) {
+		return Error::InvalidGltf;
+	}
+
+	TODO: Trigger, Joint
 }
 #endif
 

--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -3912,7 +3912,7 @@ fg::Error fg::Parser::parseTextures(simdjson::dom::array& textures, Asset& asset
 fg::Error fg::Parser::parseShapes(simdjson::dom::array& shapes, Asset& asset) {
 	using namespace simdjson;
 
-	asset.shapes.resize(shapes.size());
+	asset.shapes.reserve(shapes.size());
 	for (auto shapeValue : shapes) {
 		auto& shape = asset.shapes.emplace_back();
 
@@ -4008,7 +4008,7 @@ fg::Error fg::Parser::parseShapes(simdjson::dom::array& shapes, Asset& asset) {
 
 		dom::object cylinderObject;
 		if (auto error = shapeObject["cylinder"].get_object().get(cylinderObject); error == SUCCESS) {
-			if (shape.type != ShapeType::Capsule) FASTGLTF_UNLIKELY {
+			if (shape.type != ShapeType::Cylinder) FASTGLTF_UNLIKELY {
 				return Error::InvalidGltf;
 			}
 

--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -4020,37 +4020,37 @@ fg::Error fg::Parser::parsePhysicsMaterials(simdjson::dom::array& physicsMateria
 		}
 
 		double staticFriction;
-		if (auto error = materialObject["staticFriction"].get_double().get(staticFriction); error == SUCCESS) FASTGLTF_LIKELY {
+		if (auto error = materialObject["staticFriction"].get_double().get(staticFriction); error == SUCCESS) {
 		   material.staticFriction = static_cast<num>(staticFriction);
-		} else if (error != NO_SUCH_FIELD) {
+		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
 			return Error::InvalidGltf;
 		}
 
 		double dynamicFriction;
-		if (auto error = materialObject["dynamicFriction"].get_double().get(dynamicFriction); error == SUCCESS) FASTGLTF_LIKELY {
+		if (auto error = materialObject["dynamicFriction"].get_double().get(dynamicFriction); error == SUCCESS) {
 		   material.dynamicFriction = static_cast<num>(dynamicFriction);
-		} else if (error != NO_SUCH_FIELD) {
+		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
 			return Error::InvalidGltf;
 		}
 
 		double restitution;
-		if (auto error = materialObject["restitution"].get_double().get(restitution); error == SUCCESS) FASTGLTF_LIKELY {
+		if (auto error = materialObject["restitution"].get_double().get(restitution); error == SUCCESS) {
 		   material.restitution = static_cast<num>(restitution);
-		} else if (error != NO_SUCH_FIELD) {
+		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
 			return Error::InvalidGltf;
 		}
 
 		std::string_view frictionCombine;
-		if (auto error = materialObject["frictionCombine"].get_string().get(frictionCombine); error == SUCCESS) FASTGLTF_LIKELY {
+		if (auto error = materialObject["frictionCombine"].get_string().get(frictionCombine); error == SUCCESS) {
 			material.frictionCombine = getCombineMode(frictionCombine);
-		} else if (error != NO_SUCH_FIELD) {
+		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
 			return Error::InvalidGltf;
 		}
 
 		std::string_view restitutionCombine;
-		if (auto error = materialObject["restitutionCombine"].get_string().get(restitutionCombine); error == SUCCESS) FASTGLTF_LIKELY {
+		if (auto error = materialObject["restitutionCombine"].get_string().get(restitutionCombine); error == SUCCESS) {
 		   material.restitutionCombine = getCombineMode(restitutionCombine);
-		} else if (error != NO_SUCH_FIELD) {
+		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
 			return Error::InvalidGltf;
 		}
 
@@ -4080,7 +4080,7 @@ fg::Error fg::Parser::parseCollisionFilters(simdjson::dom::array& collisionFilte
 		}
 
 		dom::array collisionSystems;
-		if (auto error = collisionFilterObject["collisionSystems"].get_array().get(collisionSystems); error == SUCCESS) FASTGLTF_LIKELY {
+		if (auto error = collisionFilterObject["collisionSystems"].get_array().get(collisionSystems); error == SUCCESS) {
 			collisionFilter.collisionSystems.reserve(collisionSystems.size());
 			for (auto systemNameValue : collisionSystems) {
 				std::string_view systemName;
@@ -4100,7 +4100,7 @@ fg::Error fg::Parser::parseCollisionFilters(simdjson::dom::array& collisionFilte
 		}
 
 		dom::array collideWithSystems;
-		if (auto error = collisionFilterObject["collideWithSystems"].get_array().get(collideWithSystems); error == SUCCESS) FASTGLTF_LIKELY {
+		if (auto error = collisionFilterObject["collideWithSystems"].get_array().get(collideWithSystems); error == SUCCESS) {
 			collisionFilter.collideWithSystems.reserve(collideWithSystems.size());
 			for (auto systemNameValue : collideWithSystems) {
 				std::string_view systemName;
@@ -4110,12 +4110,12 @@ fg::Error fg::Parser::parseCollisionFilters(simdjson::dom::array& collisionFilte
 					return Error::InvalidGltf;
 				}
 			}
-		} else if (error != NO_SUCH_FIELD) {
+		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
 			return Error::InvalidGltf;
 		}
 
 		dom::array notCollideWithSystems;
-		if (auto error = collisionFilterObject["notCollideWithSystems"].get_array().get(notCollideWithSystems); error == SUCCESS) FASTGLTF_LIKELY {
+		if (auto error = collisionFilterObject["notCollideWithSystems"].get_array().get(notCollideWithSystems); error == SUCCESS) {
 			collisionFilter.notCollideWithSystems.reserve(notCollideWithSystems.size());
 			for (auto systemNameValue : notCollideWithSystems) {
 				std::string_view systemName;
@@ -4125,7 +4125,7 @@ fg::Error fg::Parser::parseCollisionFilters(simdjson::dom::array& collisionFilte
 					return Error::InvalidGltf;
 				}
 			}
-		} else if (error != NO_SUCH_FIELD) {
+		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
 			return Error::InvalidGltf;
 		}
 
@@ -4155,7 +4155,7 @@ fg::Error fg::Parser::parsePhysicsJoints(simdjson::dom::array& physicsJoints, As
 		}
 
 		dom::array limitsArray;
-		if (physicsJointValue["limits"].get_array().get(limitsArray) == SUCCESS) FASTGLTF_LIKELY {
+		if (physicsJointValue["limits"].get_array().get(limitsArray) == SUCCESS) {
 			physicsJoint.limits.reserve(limitsArray.size());
             for (auto limitValue : limitsArray) {
 				auto& limit = physicsJoint.limits.emplace_back();
@@ -4175,27 +4175,35 @@ fg::Error fg::Parser::parsePhysicsJoints(simdjson::dom::array& physicsJoints, As
 				}
 
 				double limitMin;
-				if (limitObject["min"].get_double().get(limitMin) == SUCCESS) FASTGLTF_LIKELY {
+				if (auto error = limitObject["min"].get_double().get(limitMin); error == SUCCESS) {
 					limit.min = static_cast<num>(limitMin);
+				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+				    return Error::InvalidGltf;
 				}
 
 				double limitMax;
-				if (limitObject["max"].get_double().get(limitMax) == SUCCESS) FASTGLTF_LIKELY {
+				if (auto error = limitObject["max"].get_double().get(limitMax); error == SUCCESS) {
 					limit.max = static_cast<num>(limitMax);
+				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+					return Error::InvalidGltf;
 				}
 
 				double stiffness;
-				if (limitObject["stiffness"].get_double().get(stiffness) == SUCCESS) FASTGLTF_LIKELY {
+				if (auto error = limitObject["stiffness"].get_double().get(stiffness); error == SUCCESS) {
 					limit.stiffness = static_cast<num>(stiffness);
+				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+					return Error::InvalidGltf;
 				}
 
 				double damping;
-				if (limitObject["damping"].get_double().get(damping) == SUCCESS) FASTGLTF_LIKELY {
+				if (auto error = limitObject["damping"].get_double().get(damping); error == SUCCESS) {
 					limit.damping = static_cast<num>(damping);
+				} else if (error == NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+				    return Error::InvalidGltf;
 				}
 
 				dom::array linearAxesArray;
-				if (limitObject["linearAxes"].get_array().get(linearAxesArray) == SUCCESS) FASTGLTF_LIKELY {
+				if (auto error = limitObject["linearAxes"].get_array().get(linearAxesArray); error == SUCCESS) {
 					limit.linearAxes.reserve(linearAxesArray.size());
 					for(auto axisValue : linearAxesArray) {
 						uint64_t axis;
@@ -4205,10 +4213,12 @@ fg::Error fg::Parser::parsePhysicsJoints(simdjson::dom::array& physicsJoints, As
 							return Error::InvalidGltf;
 						}
 					}
+				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+					return Error::InvalidGltf;
 				}
 
 				dom::array angularAxesArray;
-				if (limitObject["angularAxes"].get_array().get(angularAxesArray) == SUCCESS) FASTGLTF_LIKELY {
+				if (auto error = limitObject["angularAxes"].get_array().get(angularAxesArray); error == SUCCESS) {
 					limit.angularAxes.reserve(angularAxesArray.size());
 					for (auto axisValue : angularAxesArray) {
 						uint64_t axis;
@@ -4218,12 +4228,14 @@ fg::Error fg::Parser::parsePhysicsJoints(simdjson::dom::array& physicsJoints, As
 							return Error::InvalidGltf;
 						}
 					}
+				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+					return Error::InvalidGltf;
 				}
             }
 		}
 
 		dom::array driveArray;
-		if (auto error = physicsJointValue["drives"].get_array().get(driveArray); error == SUCCESS) FASTGLTF_LIKELY {
+		if (auto error = physicsJointValue["drives"].get_array().get(driveArray); error == SUCCESS) {
 			physicsJoint.drives.reserve(driveArray.size());
 			for (auto driveValue : driveArray) {
 			    auto& drive = physicsJoint.drives.emplace_back();
@@ -4274,13 +4286,13 @@ fg::Error fg::Parser::parsePhysicsJoints(simdjson::dom::array& physicsJoints, As
 				// Other fields are not required
 
 				double maxForce;
-				if (error = driveValue["maxForce"].get_double().get(maxForce); error == SUCCESS) FASTGLTF_LIKELY {
+				if (error = driveValue["maxForce"].get_double().get(maxForce); error == SUCCESS) {
 					drive.maxForce = static_cast<num>(maxForce);
-				} else if (error != NO_SUCH_FIELD) {
+				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
 					return Error::InvalidGltf;
 				}
 
-				// If the thing has positionTarget, it must also have stiffness
+				// If the drive has positionTarget, it must also have stiffness
 				const auto hasPositionTarget = driveValue["positionTarget"].error() == SUCCESS;
 				const auto hasStiffness = driveValue["stiffness"].error() == SUCCESS;
 				if (hasPositionTarget != hasStiffness) FASTGLTF_UNLIKELY {
@@ -4288,20 +4300,20 @@ fg::Error fg::Parser::parsePhysicsJoints(simdjson::dom::array& physicsJoints, As
 				}
 
 				double positionTarget;
-				if (error = driveValue["positionTarget"].get_double().get(positionTarget); error == SUCCESS) FASTGLTF_LIKELY {
+				if (error = driveValue["positionTarget"].get_double().get(positionTarget); error == SUCCESS) {
 				    drive.positionTarget = static_cast<num>(positionTarget);
-				} else if (error != NO_SUCH_FIELD) {
+				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
 					return Error::InvalidGltf;
 				}
 
 				double stiffness;
-				if (error = driveValue["stiffness"].get_double().get(stiffness); error == SUCCESS) FASTGLTF_LIKELY {
+				if (error = driveValue["stiffness"].get_double().get(stiffness); error == SUCCESS) {
 					drive.stiffness = static_cast<num>(stiffness);
-				} else if (error != NO_SUCH_FIELD) {
+				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
 					return Error::InvalidGltf;
 				}
 
-				// If the thing has velocityTarget, it must also have damping
+				// If the drive has velocityTarget, it must also have damping
 				const auto hasVelocityTarget = driveValue["velocityTarget"].error() == SUCCESS;
 				const auto hasDamping = driveValue["damping"].error() == SUCCESS;
 				if (hasVelocityTarget != hasDamping) FASTGLTF_UNLIKELY {
@@ -4309,19 +4321,21 @@ fg::Error fg::Parser::parsePhysicsJoints(simdjson::dom::array& physicsJoints, As
 				}
 
 				double velocityTarget;
-				if (error = driveValue["velocityTarget"].get_double().get(velocityTarget); error == SUCCESS) FASTGLTF_LIKELY {
+				if (error = driveValue["velocityTarget"].get_double().get(velocityTarget); error == SUCCESS) {
 					drive.velocityTarget = static_cast<num>(velocityTarget);
-				} else if (error != NO_SUCH_FIELD) {
+				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
 					return Error::InvalidGltf;
 				}
 
 				double damping;
-				if (error = driveValue["damping"].get_double().get(damping); error == SUCCESS) FASTGLTF_LIKELY {
+				if (error = driveValue["damping"].get_double().get(damping); error == SUCCESS) {
 					drive.damping = static_cast<num>(damping);
-				} else if (error != NO_SUCH_FIELD) {
+				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
 					return Error::InvalidGltf;
 				}
 			}
+		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+    		return Error::InvalidGltf;
 		}
 
 		if (config.extrasCallback != nullptr) {
@@ -4347,22 +4361,22 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 		auto& motion = rigidBody.motion.emplace();
 
 		bool isKinematic;
-		if (error = motionObject["isKinematic"].get_bool().get(isKinematic); error == SUCCESS) FASTGLTF_LIKELY {
+		if (error = motionObject["isKinematic"].get_bool().get(isKinematic); error == SUCCESS) {
 			motion.isKinematic = isKinematic;
-		} else if (error != NO_SUCH_FIELD) {
+		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
 			return Error::InvalidGltf;
 		}
 
 		double mass;
-		if (error = motionObject["mass"].get_double().get(mass); error == SUCCESS) FASTGLTF_LIKELY {
+		if (error = motionObject["mass"].get_double().get(mass); error == SUCCESS) {
 			motion.mass = static_cast<num>(mass);
-		} else if (error != NO_SUCH_FIELD) {
+		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
 			return Error::InvalidGltf;
 		}
 
 		dom::array centerOfMassArray;
-		if (error = motionObject["centerOfMass"].get_array().get(centerOfMassArray); error == SUCCESS) FASTGLTF_LIKELY {
-			if (centerOfMassArray.size() != 3) {
+		if (error = motionObject["centerOfMass"].get_array().get(centerOfMassArray); error == SUCCESS) {
+			if (centerOfMassArray.size() != 3) FASTGLTF_UNLIKELY {
 				return Error::InvalidGltf;
 			}
 
@@ -4381,7 +4395,7 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 
 		dom::array inertiaDiagonalArray;
 		if (error = motionObject["inertiaDiagonal"].get_array().get(inertiaDiagonalArray); error == SUCCESS) {
-			if (inertiaDiagonalArray.size() != 3) {
+			if (inertiaDiagonalArray.size() != 3) FASTGLTF_UNLIKELY {
 				return Error::InvalidGltf;
 			}
 
@@ -4448,7 +4462,7 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 		}
 
 		dom::array angularVelocityArray;
-		if (error = motionObject["angularVelocity"].get_array().get(angularVelocityArray); error == SUCCESS) FASTGLTF_LIKELY {
+		if (error = motionObject["angularVelocity"].get_array().get(angularVelocityArray); error == SUCCESS) {
 			if (angularVelocityArray.size() != 3) FASTGLTF_UNLIKELY {
 				return Error::InvalidGltf;
 			}
@@ -4462,14 +4476,14 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 				motion.angularVelocity[i] = static_cast<fastgltf::num>(val);
 				++i;
 			}
-		} else if (error != NO_SUCH_FIELD) {
+		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
 			return Error::InvalidGltf;
 		}
 
 		double gravityFactor;
-		if (error = motionObject["gravityFactor"].get_double().get(gravityFactor); error == SUCCESS) FASTGLTF_LIKELY {
+		if (error = motionObject["gravityFactor"].get_double().get(gravityFactor); error == SUCCESS) {
 			motion.gravityFactor = static_cast<num>(gravityFactor);
-		} else if (error != NO_SUCH_FIELD) {
+		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
 			return Error::InvalidGltf;
 		}
 
@@ -4490,15 +4504,15 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 				return Error::InvalidGltf;
 			}
 			uint64_t geometryNode;
-			if (error = geometryObject["node"].get_uint64().get(geometryNode); error == SUCCESS) FASTGLTF_LIKELY {
+			if (error = geometryObject["node"].get_uint64().get(geometryNode); error == SUCCESS) {
 				collider.geometry.node = static_cast<std::size_t>(geometryNode);
-			} else if (error != NO_SUCH_FIELD) {
+			} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
 				return Error::InvalidGltf;
 			}
 			bool convexHull;
-			if (error = geometryObject["convexHull"].get_bool().get(convexHull); error == SUCCESS) FASTGLTF_LIKELY {
+			if (error = geometryObject["convexHull"].get_bool().get(convexHull); error == SUCCESS) {
 				collider.geometry.convexHull = convexHull;
-			} else if (error != NO_SUCH_FIELD) {
+			} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
 				return Error::InvalidGltf;
 			}
 		} else {
@@ -4506,16 +4520,16 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 		}
 
 		std::size_t physicsMaterial;
-		if (error = colliderObject["physicsMaterial"].get_uint64().get(physicsMaterial); error == SUCCESS) FASTGLTF_LIKELY {
+		if (error = colliderObject["physicsMaterial"].get_uint64().get(physicsMaterial); error == SUCCESS) {
 			collider.physicsMaterial = physicsMaterial;
-		} else if (error != NO_SUCH_FIELD) {
+		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
 			return Error::InvalidGltf;
 		}
 
 		std::size_t collisionFilter;
-		if (error = colliderObject["collisionFilter"].get_uint64().get(collisionFilter); error == SUCCESS) FASTGLTF_LIKELY {
+		if (error = colliderObject["collisionFilter"].get_uint64().get(collisionFilter); error == SUCCESS) {
 			collider.collisionFilter = collisionFilter;
-		} else if (error != NO_SUCH_FIELD) {
+		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
 			return Error::InvalidGltf;
 		}
 
@@ -4526,7 +4540,7 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 	dom::object triggerObject;
 	if (auto error = khr_physics_rigid_bodies["trigger"].get_object().get(triggerObject); error == SUCCESS) {
 		dom::object geometryObject;
-		if (error = triggerObject["geometry"].get_object().get(geometryObject); error == SUCCESS) FASTGLTF_LIKELY {
+		if (error = triggerObject["geometry"].get_object().get(geometryObject); error == SUCCESS) {
 			auto& geometryTrigger = rigidBody.trigger.emplace().emplace<GeometryTrigger>();
 
 			uint64_t shape;
@@ -4536,9 +4550,9 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 				return Error::InvalidGltf;
 			}
 			uint64_t geometryNode;
-			if (error = geometryObject["node"].get_uint64().get(geometryNode); error == SUCCESS) FASTGLTF_LIKELY {
+			if (error = geometryObject["node"].get_uint64().get(geometryNode); error == SUCCESS) {
 				geometryTrigger.geometry.node = static_cast<std::size_t>(geometryNode);
-			} else if (error != NO_SUCH_FIELD) {
+			} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
 				return Error::InvalidGltf;
 			}
 			bool convexHull;
@@ -4548,7 +4562,7 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 				return Error::InvalidGltf;
 			}
 
-			// The trigger can only have a collision filter if it has geometry, otherwise it deferes to the nodes
+			// The trigger can only have a collision filter if it has geometry, otherwise it defers to the nodes
 			std::size_t collisionFilter;
 			if (error = triggerObject["collisionFilter"].get_uint64().get(collisionFilter); error == SUCCESS) {
 				geometryTrigger.collisionFilter = collisionFilter;
@@ -6295,7 +6309,7 @@ void fg::Exporter::writeShapes(const Asset& asset, std::string& json) {
 			}
 		}
 
-		json += '};
+		json += '}';
 
 		if (uabs(std::distance(asset.shapes.begin(), it)) + 1 < asset.shapes.size()) {
 			json += ',';

--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -4396,7 +4396,8 @@ fg::Error fg::Parser::parsePhysicsJoints(simdjson::dom::array& physicsJoints, As
 fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_rigid_bodies, Node& node) {
 	using namespace simdjson;
 
-	auto& rigidBody = node.physicsRigidBody.emplace();
+	node.physicsRigidBody = std::make_unique<PhysicsRigidBody>();
+	auto& rigidBody = *node.physicsRigidBody;
 
 	dom::object motionObject;
 	if (auto error = khr_physics_rigid_bodies["motion"].get_object().get(motionObject); error == SUCCESS) {
@@ -5986,7 +5987,7 @@ void fg::Exporter::writeNodes(const Asset& asset, std::string& json) {
 
 	    if (!it->instancingAttributes.empty() || it->lightIndex.has_value()
 #if FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES
-			|| it->physicsRigidBody.has_value()
+			|| it->physicsRigidBody
 #endif
 			) {
 			if (json.back() != '{') json += ',';
@@ -6007,7 +6008,7 @@ void fg::Exporter::writeNodes(const Asset& asset, std::string& json) {
 			}
 
 #if FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES
-			if (it->physicsRigidBody.has_value()) {
+			if (it->physicsRigidBody) {
 				if (json.back() != '{') json += ',';
 				json += R"("KHR_physics_rigid_body":{)";
 				if (it->physicsRigidBody->motion.has_value()) {

--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -4210,12 +4210,12 @@ fg::Error fg::Parser::parsePhysicsJoints(simdjson::dom::array& physicsJoints, As
 			        return Error::InvalidGltf;
 				}
 
-				if(limitObject["linearAxis"].error() == SUCCESS && limitObject["angularAxes"].error() == SUCCESS) FASTGLTF_UNLIKELY {
+				if(limitObject["linearAxes"].error() == SUCCESS && limitObject["angularAxes"].error() == SUCCESS) FASTGLTF_UNLIKELY {
 				    // A limit may only have one of these
 					return Error::InvalidGltf;
 				}
 
-				if (limitObject["linearAxis"].error() != SUCCESS && limitObject["angularAxes"].error() != SUCCESS) FASTGLTF_UNLIKELY {
+				if (limitObject["linearAxes"].error() != SUCCESS && limitObject["angularAxes"].error() != SUCCESS) FASTGLTF_UNLIKELY {
 					// A limit MUST have one of these
 					return Error::InvalidGltf;
 				}
@@ -4244,7 +4244,7 @@ fg::Error fg::Parser::parsePhysicsJoints(simdjson::dom::array& physicsJoints, As
 				double damping;
 				if (auto error = limitObject["damping"].get_double().get(damping); error == SUCCESS) {
 					limit.damping = static_cast<num>(damping);
-				} else if (error == NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
 				    return Error::InvalidGltf;
 				}
 
@@ -4253,7 +4253,7 @@ fg::Error fg::Parser::parsePhysicsJoints(simdjson::dom::array& physicsJoints, As
 					limit.linearAxes.reserve(linearAxesArray.size());
 					for(auto axisValue : linearAxesArray) {
 						uint64_t axis;
-						if(axisValue.get_uint64().get(axis) == SUCCESS && axis > 0 && axis < 4) FASTGLTF_LIKELY {
+						if(axisValue.get_uint64().get(axis) == SUCCESS && axis >= 0 && axis <= 2) FASTGLTF_LIKELY {
 							limit.linearAxes.emplace_back(static_cast<uint8_t>(axis));
 						} else {
 							return Error::InvalidGltf;
@@ -4268,7 +4268,7 @@ fg::Error fg::Parser::parsePhysicsJoints(simdjson::dom::array& physicsJoints, As
 					limit.angularAxes.reserve(angularAxesArray.size());
 					for (auto axisValue : angularAxesArray) {
 						uint64_t axis;
-						if (axisValue.get_uint64().get(axis) == SUCCESS && axis > 0 && axis < 4) FASTGLTF_LIKELY {
+						if (axisValue.get_uint64().get(axis) == SUCCESS && axis >= 0 && axis <= 3) FASTGLTF_LIKELY {
 							limit.angularAxes.emplace_back(static_cast<uint8_t>(axis));
 						} else {
 							return Error::InvalidGltf;
@@ -4307,9 +4307,9 @@ fg::Error fg::Parser::parsePhysicsJoints(simdjson::dom::array& physicsJoints, As
 
 				std::string_view mode;
 				if (driveValue["mode"].get_string().get(mode) == SUCCESS) FASTGLTF_LIKELY {
-				    if (type == "force") {
+				    if (mode == "force") {
 						drive.mode = DriveMode::Force;
-				    } else if (type == "acceleration") {
+				    } else if (mode == "acceleration") {
 						drive.mode = DriveMode::Acceleration;
 				    } else {
 						return Error::InvalidGltf;

--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -3876,20 +3876,20 @@ fg::Error fg::Parser::parseShapes(simdjson::dom::array& shapes, Asset& asset) {
 		}
 
 		std::string_view shapeTypeName;
-		if (shapeObject["type"].get_string().get(shapeTypeName) == SUCCESS) {
+		if (shapeObject["type"].get_string().get(shapeTypeName) == SUCCESS) FASTGLTF_LIKELY {
 		    shape.type = getShapeType(shapeTypeName);
 		} else {
 			return Error::InvalidGltf;
 		}
 
 		dom::object sphereObject;
-		if (auto error = shapeObject["sphere"].get_object().get(sphereObject); error == SUCCESS) {
+		if (auto error = shapeObject["sphere"].get_object().get(sphereObject); error == SUCCESS) FASTGLTF_LIKELY {
 			if (shape.type != ShapeType::Sphere) {
 				return Error::InvalidGltf;
 			}
 
 			double radius;
-			if (error = sphereObject["radius"].get_double().get(radius); error == SUCCESS) {
+			if (error = sphereObject["radius"].get_double().get(radius); error == SUCCESS) FASTGLTF_LIKELY {
 				shape.shape = SphereShape{ static_cast<num>(radius) };
 			} else if(error != NO_SUCH_FIELD) {
 				return Error::InvalidGltf;
@@ -3905,7 +3905,7 @@ fg::Error fg::Parser::parseShapes(simdjson::dom::array& shapes, Asset& asset) {
 		    }
 
 			dom::array sizeArray;
-			if (error = boxObject["size"].get_array().get(sizeArray); error == SUCCESS) {
+			if (error = boxObject["size"].get_array().get(sizeArray); error == SUCCESS) FASTGLTF_LIKELY {
 			    if (sizeArray.size() != 3) {
 					return Error::InvalidGltf;
 			    }
@@ -3923,74 +3923,73 @@ fg::Error fg::Parser::parseShapes(simdjson::dom::array& shapes, Asset& asset) {
 					curIndex++;
 				}
 			}
-		} else if (error != NO_SUCH_FIELD) {
+		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
 			return Error::InvalidGltf;
 		}
 
 		dom::object capsuleObject;
 		if (auto error = shapeObject["capsule"].get_object().get(capsuleObject); error == SUCCESS) {
-			if (shape.type != ShapeType::Capsule) {
+			if (shape.type != ShapeType::Capsule) FASTGLTF_UNLIKELY {
 				return Error::InvalidGltf;
 			}
 
 			auto& capsule =shape.shape.emplace<CapsuleShape>();
 
 			double height;
-			if (error = capsuleObject["height"].get_double().get(height); error == SUCCESS) {
+			if (error = capsuleObject["height"].get_double().get(height); error == SUCCESS) FASTGLTF_LIKELY {
 				capsule.height = static_cast<num>(height);
 			} else if (error != NO_SUCH_FIELD) {
 				return Error::InvalidGltf;
 			}
 
 			double radiusBottom;
-			if (error = capsuleObject["radiusBottom"].get_double().get(radiusBottom); error == SUCCESS) {
+			if (error = capsuleObject["radiusBottom"].get_double().get(radiusBottom); error == SUCCESS) FASTGLTF_LIKELY {
 				capsule.radiusBottom = static_cast<num>(radiusBottom);
 			} else if (error != NO_SUCH_FIELD) {
 				return Error::InvalidGltf;
 			}
 
 			double radiusTop;
-			if (error = capsuleObject["radiusTop"].get_double().get(radiusTop); error == SUCCESS) {
+			if (error = capsuleObject["radiusTop"].get_double().get(radiusTop); error == SUCCESS) FASTGLTF_LIKELY {
 				capsule.radiusTop = static_cast<num>(radiusTop);
 			} else if (error != NO_SUCH_FIELD) {
 				return Error::InvalidGltf;
 			}
 
-		} else if (error != NO_SUCH_FIELD) {
+		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY{
 			return Error::InvalidGltf;
 		}
 
-
 		dom::object cylinderObject;
 		if (auto error = shapeObject["cylinder"].get_object().get(cylinderObject); error == SUCCESS) {
-			if (shape.type != ShapeType::Capsule) {
+			if (shape.type != ShapeType::Capsule) FASTGLTF_UNLIKELY {
 				return Error::InvalidGltf;
 			}
 
 			auto& cylinder = shape.shape.emplace<CylinderShape>();
 
 			double height;
-			if (error = cylinderObject["height"].get_double().get(height); error == SUCCESS) {
+			if (error = cylinderObject["height"].get_double().get(height); error == SUCCESS) FASTGLTF_LIKELY {
 				cylinder.height = static_cast<num>(height);
 			} else if (error != NO_SUCH_FIELD) {
 				return Error::InvalidGltf;
 			}
 
 			double radiusBottom;
-			if (error = cylinderObject["radiusBottom"].get_double().get(radiusBottom); error == SUCCESS) {
+			if (error = cylinderObject["radiusBottom"].get_double().get(radiusBottom); error == SUCCESS) FASTGLTF_LIKELY {
 				cylinder.radiusBottom = static_cast<num>(radiusBottom);
 			} else if (error != NO_SUCH_FIELD) {
 				return Error::InvalidGltf;
 			}
 
 			double radiusTop;
-			if (error = cylinderObject["radiusTop"].get_double().get(radiusTop); error == SUCCESS) {
+			if (error = cylinderObject["radiusTop"].get_double().get(radiusTop); error == SUCCESS) FASTGLTF_LIKELY {
 				cylinder.radiusTop = static_cast<num>(radiusTop);
 			} else if (error != NO_SUCH_FIELD) {
 				return Error::InvalidGltf;
 			}
 
-		} else if (error != NO_SUCH_FIELD) {
+		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
 			return Error::InvalidGltf;
 		}
 
@@ -3998,7 +3997,7 @@ fg::Error fg::Parser::parseShapes(simdjson::dom::array& shapes, Asset& asset) {
 			dom::object extrasObject;
 			if (auto extrasError = shapeObject["extras"].get_object().get(extrasObject); extrasError == SUCCESS) {
 				config.extrasCallback(&extrasObject, asset.shapes.size() - 1, Category::Shapes, config.userPointer);
-			} else if (extrasError != NO_SUCH_FIELD) {
+			} else if (extrasError != NO_SUCH_FIELD) FASTGLTF_UNLIKELY{
 				return Error::InvalidGltf;
 			}
 		}
@@ -4059,7 +4058,7 @@ fg::Error fg::Parser::parsePhysicsMaterials(simdjson::dom::array& physicsMateria
 			dom::object extrasObject;
 			if (auto extrasError = materialObject["extras"].get_object().get(extrasObject); extrasError == SUCCESS) {
 				config.extrasCallback(&extrasObject, asset.physicsMaterials.size() - 1, Category::PhysicsMaterials, config.userPointer);
-			} else if (extrasError != NO_SUCH_FIELD) {
+			} else if (extrasError != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
 				return Error::InvalidGltf;
 			}
 		}
@@ -4085,7 +4084,7 @@ fg::Error fg::Parser::parseCollisionFilters(simdjson::dom::array& collisionFilte
 			collisionFilter.collisionSystems.reserve(collisionSystems.size());
 			for (auto systemNameValue : collisionSystems) {
 				std::string_view systemName;
-				if (systemNameValue.get_string().get(systemName) == SUCCESS) {
+				if (systemNameValue.get_string().get(systemName) == SUCCESS) FASTGLTF_LIKELY {
 					collisionFilter.collisionSystems.emplace_back(systemName);
 				} else {
 					return Error::InvalidGltf;
@@ -4096,7 +4095,7 @@ fg::Error fg::Parser::parseCollisionFilters(simdjson::dom::array& collisionFilte
 		}
 
 	    // A glTF isn't allowed to have both
-		if (collisionFilterObject["collideWithSystems"].error() == SUCCESS && collisionFilterObject["notCollideWithSystems"].error() == SUCCESS) {
+		if (collisionFilterObject["collideWithSystems"].error() == SUCCESS && collisionFilterObject["notCollideWithSystems"].error() == SUCCESS) FASTGLTF_UNLIKELY {
 			return Error::InvalidGltf;
 		}
 
@@ -4105,7 +4104,7 @@ fg::Error fg::Parser::parseCollisionFilters(simdjson::dom::array& collisionFilte
 			collisionFilter.collideWithSystems.reserve(collideWithSystems.size());
 			for (auto systemNameValue : collideWithSystems) {
 				std::string_view systemName;
-				if (systemNameValue.get_string().get(systemName) == SUCCESS) {
+				if (systemNameValue.get_string().get(systemName) == SUCCESS) FASTGLTF_LIKELY {
 					collisionFilter.collideWithSystems.emplace_back(systemName);
 				} else {
 					return Error::InvalidGltf;
@@ -4120,7 +4119,7 @@ fg::Error fg::Parser::parseCollisionFilters(simdjson::dom::array& collisionFilte
 			collisionFilter.notCollideWithSystems.reserve(notCollideWithSystems.size());
 			for (auto systemNameValue : notCollideWithSystems) {
 				std::string_view systemName;
-				if (systemNameValue.get_string().get(systemName) == SUCCESS) {
+				if (systemNameValue.get_string().get(systemName) == SUCCESS) FASTGLTF_LIKELY {
 					collisionFilter.notCollideWithSystems.emplace_back(systemName);
 				} else {
 					return Error::InvalidGltf;
@@ -4134,7 +4133,7 @@ fg::Error fg::Parser::parseCollisionFilters(simdjson::dom::array& collisionFilte
 			dom::object extrasObject;
 			if (auto extrasError = collisionFilterObject["extras"].get_object().get(extrasObject); extrasError == SUCCESS) {
 				config.extrasCallback(&extrasObject, asset.collisionFilters.size() - 1, Category::CollisionFilters, config.userPointer);
-			} else if (extrasError != NO_SUCH_FIELD) {
+			} else if (extrasError != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
 				return Error::InvalidGltf;
 			}
 		}
@@ -4165,42 +4164,42 @@ fg::Error fg::Parser::parsePhysicsJoints(simdjson::dom::array& physicsJoints, As
 			        return Error::InvalidGltf;
 				}
 
-				if(limitObject["linearAxis"].error() == SUCCESS && limitObject["angularAxes"].error() == SUCCESS) {
+				if(limitObject["linearAxis"].error() == SUCCESS && limitObject["angularAxes"].error() == SUCCESS) FASTGLTF_UNLIKELY {
 				    // A limit may only have one of these
 					return Error::InvalidGltf;
 				}
 
-				if (limitObject["linearAxis"].error() != SUCCESS && limitObject["angularAxes"].error() != SUCCESS) {
+				if (limitObject["linearAxis"].error() != SUCCESS && limitObject["angularAxes"].error() != SUCCESS) FASTGLTF_UNLIKELY {
 					// A limit MUST have one of these
 					return Error::InvalidGltf;
 				}
 
 				double limitMin;
-				if (limitObject["min"].get_double().get(limitMin) == SUCCESS) {
+				if (limitObject["min"].get_double().get(limitMin) == SUCCESS) FASTGLTF_LIKELY {
 					limit.min = static_cast<num>(limitMin);
 				}
 
 				double limitMax;
-				if (limitObject["max"].get_double().get(limitMax) == SUCCESS) {
+				if (limitObject["max"].get_double().get(limitMax) == SUCCESS) FASTGLTF_LIKELY {
 					limit.max = static_cast<num>(limitMax);
 				}
 
 				double stiffness;
-				if (limitObject["stiffness"].get_double().get(stiffness) == SUCCESS) {
+				if (limitObject["stiffness"].get_double().get(stiffness) == SUCCESS) FASTGLTF_LIKELY {
 					limit.stiffness = static_cast<num>(stiffness);
 				}
 
 				double damping;
-				if (limitObject["damping"].get_double().get(damping) == SUCCESS) {
+				if (limitObject["damping"].get_double().get(damping) == SUCCESS) FASTGLTF_LIKELY {
 					limit.damping = static_cast<num>(damping);
 				}
 
 				dom::array linearAxesArray;
-				if (limitObject["linearAxes"].get_array().get(linearAxesArray) == SUCCESS) {
+				if (limitObject["linearAxes"].get_array().get(linearAxesArray) == SUCCESS) FASTGLTF_LIKELY {
 					limit.linearAxes.reserve(linearAxesArray.size());
 					for(auto axisValue : linearAxesArray) {
 						uint64_t axis;
-						if(axisValue.get_uint64().get(axis) == SUCCESS && axis > 0 && axis < 4) {
+						if(axisValue.get_uint64().get(axis) == SUCCESS && axis > 0 && axis < 4) FASTGLTF_LIKELY {
 							limit.linearAxes.emplace_back(static_cast<uint8_t>(axis));
 						} else {
 							return Error::InvalidGltf;
@@ -4209,11 +4208,11 @@ fg::Error fg::Parser::parsePhysicsJoints(simdjson::dom::array& physicsJoints, As
 				}
 
 				dom::array angularAxesArray;
-				if (limitObject["angularAxes"].get_array().get(angularAxesArray) == SUCCESS) {
+				if (limitObject["angularAxes"].get_array().get(angularAxesArray) == SUCCESS) FASTGLTF_LIKELY {
 					limit.angularAxes.reserve(angularAxesArray.size());
 					for (auto axisValue : angularAxesArray) {
 						uint64_t axis;
-						if (axisValue.get_uint64().get(axis) == SUCCESS && axis > 0 && axis < 4) {
+						if (axisValue.get_uint64().get(axis) == SUCCESS && axis > 0 && axis < 4) FASTGLTF_LIKELY {
 							limit.angularAxes.emplace_back(static_cast<uint8_t>(axis));
 						} else {
 							return Error::InvalidGltf;
@@ -4224,19 +4223,19 @@ fg::Error fg::Parser::parsePhysicsJoints(simdjson::dom::array& physicsJoints, As
 		}
 
 		dom::array driveArray;
-		if (auto error = physicsJointValue["drives"].get_array().get(driveArray); error == SUCCESS) {
+		if (auto error = physicsJointValue["drives"].get_array().get(driveArray); error == SUCCESS) FASTGLTF_LIKELY {
 			physicsJoint.drives.reserve(driveArray.size());
 			for (auto driveValue : driveArray) {
 			    auto& drive = physicsJoint.drives.emplace_back();
 				dom::object driveObject;
-				if (driveValue.get_object().get(driveObject) != SUCCESS) {
+				if (driveValue.get_object().get(driveObject) != SUCCESS) FASTGLTF_UNLIKELY {
 					return Error::InvalidGltf;
 				}
 
 				// Type, mode, and axis are required
 
 				std::string_view type;
-				if (driveValue["type"].get_string().get(type) == SUCCESS) {
+				if (driveValue["type"].get_string().get(type) == SUCCESS) FASTGLTF_LIKELY {
 				    if (type == "linear") {
 						drive.type = DriveType::Linear;
 				    } else if (type == "angular") {
@@ -4249,7 +4248,7 @@ fg::Error fg::Parser::parsePhysicsJoints(simdjson::dom::array& physicsJoints, As
 				}
 
 				std::string_view mode;
-				if (driveValue["mode"].get_string().get(mode) == SUCCESS) {
+				if (driveValue["mode"].get_string().get(mode) == SUCCESS) FASTGLTF_LIKELY {
 				    if (type == "force") {
 						drive.mode = DriveMode::Force;
 				    } else if (type == "acceleration") {
@@ -4262,7 +4261,7 @@ fg::Error fg::Parser::parsePhysicsJoints(simdjson::dom::array& physicsJoints, As
 				}
 
 				uint64_t axis;
-				if (driveValue["axis"].get_uint64().get(axis) == SUCCESS) {
+				if (driveValue["axis"].get_uint64().get(axis) == SUCCESS) FASTGLTF_LIKELY {
 				    if (axis < 3) {
 						drive.axis = static_cast<uint8_t>(axis);
 				    } else {
@@ -4275,7 +4274,7 @@ fg::Error fg::Parser::parsePhysicsJoints(simdjson::dom::array& physicsJoints, As
 				// Other fields are not required
 
 				double maxForce;
-				if (error = driveValue["maxForce"].get_double().get(maxForce); error == SUCCESS) {
+				if (error = driveValue["maxForce"].get_double().get(maxForce); error == SUCCESS) FASTGLTF_LIKELY {
 					drive.maxForce = static_cast<num>(maxForce);
 				} else if (error != NO_SUCH_FIELD) {
 					return Error::InvalidGltf;
@@ -4284,19 +4283,19 @@ fg::Error fg::Parser::parsePhysicsJoints(simdjson::dom::array& physicsJoints, As
 				// If the thing has positionTarget, it must also have stiffness
 				const auto hasPositionTarget = driveValue["positionTarget"].error() == SUCCESS;
 				const auto hasStiffness = driveValue["stiffness"].error() == SUCCESS;
-				if (hasPositionTarget != hasStiffness) {
+				if (hasPositionTarget != hasStiffness) FASTGLTF_UNLIKELY {
 					return Error::InvalidGltf;
 				}
 
 				double positionTarget;
-				if (error = driveValue["positionTarget"].get_double().get(positionTarget); error == SUCCESS) {
+				if (error = driveValue["positionTarget"].get_double().get(positionTarget); error == SUCCESS) FASTGLTF_LIKELY {
 				    drive.positionTarget = static_cast<num>(positionTarget);
 				} else if (error != NO_SUCH_FIELD) {
 					return Error::InvalidGltf;
 				}
 
 				double stiffness;
-				if (error = driveValue["stiffness"].get_double().get(stiffness); error == SUCCESS) {
+				if (error = driveValue["stiffness"].get_double().get(stiffness); error == SUCCESS) FASTGLTF_LIKELY {
 					drive.stiffness = static_cast<num>(stiffness);
 				} else if (error != NO_SUCH_FIELD) {
 					return Error::InvalidGltf;
@@ -4305,19 +4304,19 @@ fg::Error fg::Parser::parsePhysicsJoints(simdjson::dom::array& physicsJoints, As
 				// If the thing has velocityTarget, it must also have damping
 				const auto hasVelocityTarget = driveValue["velocityTarget"].error() == SUCCESS;
 				const auto hasDamping = driveValue["damping"].error() == SUCCESS;
-				if (hasVelocityTarget != hasDamping) {
+				if (hasVelocityTarget != hasDamping) FASTGLTF_UNLIKELY {
 					return Error::InvalidGltf;
 				}
 
 				double velocityTarget;
-				if (error = driveValue["velocityTarget"].get_double().get(velocityTarget); error == SUCCESS) {
+				if (error = driveValue["velocityTarget"].get_double().get(velocityTarget); error == SUCCESS) FASTGLTF_LIKELY {
 					drive.velocityTarget = static_cast<num>(velocityTarget);
 				} else if (error != NO_SUCH_FIELD) {
 					return Error::InvalidGltf;
 				}
 
 				double damping;
-				if (error = driveValue["damping"].get_double().get(damping); error == SUCCESS) {
+				if (error = driveValue["damping"].get_double().get(damping); error == SUCCESS) FASTGLTF_LIKELY {
 					drive.damping = static_cast<num>(damping);
 				} else if (error != NO_SUCH_FIELD) {
 					return Error::InvalidGltf;
@@ -4329,7 +4328,7 @@ fg::Error fg::Parser::parsePhysicsJoints(simdjson::dom::array& physicsJoints, As
 			dom::object extrasObject;
 			if (auto extrasError = physicsJointValue["extras"].get_object().get(extrasObject); extrasError == SUCCESS) {
 				config.extrasCallback(&extrasObject, asset.physicsJoints.size() - 1, Category::PhysicsJoints, config.userPointer);
-			} else if (extrasError != NO_SUCH_FIELD) {
+			} else if (extrasError != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
 				return Error::InvalidGltf;
 			}
 		}
@@ -4348,21 +4347,21 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 		auto& motion = rigidBody.motion.emplace();
 
 		bool isKinematic;
-		if (error = motionObject["isKinematic"].get_bool().get(isKinematic); error == SUCCESS) {
+		if (error = motionObject["isKinematic"].get_bool().get(isKinematic); error == SUCCESS) FASTGLTF_LIKELY {
 			motion.isKinematic = isKinematic;
 		} else if (error != NO_SUCH_FIELD) {
 			return Error::InvalidGltf;
 		}
 
 		double mass;
-		if (error = motionObject["mass"].get_double().get(mass); error == SUCCESS) {
+		if (error = motionObject["mass"].get_double().get(mass); error == SUCCESS) FASTGLTF_LIKELY {
 			motion.mass = static_cast<num>(mass);
 		} else if (error != NO_SUCH_FIELD) {
 			return Error::InvalidGltf;
 		}
 
 		dom::array centerOfMassArray;
-		if (error = motionObject["centerOfMass"].get_array().get(centerOfMassArray); error == SUCCESS) {
+		if (error = motionObject["centerOfMass"].get_array().get(centerOfMassArray); error == SUCCESS) FASTGLTF_LIKELY {
 			if (centerOfMassArray.size() != 3) {
 				return Error::InvalidGltf;
 			}
@@ -4370,13 +4369,13 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 			auto i = 0U;
 			for (auto num : centerOfMassArray) {
 				double val;
-				if (num.get_double().get(val) != SUCCESS) FASTGLTF_UNLIKELY{
+				if (num.get_double().get(val) != SUCCESS) FASTGLTF_UNLIKELY {
 					return Error::InvalidGltf;
 				}
 				motion.centerOfMass[i] = static_cast<fastgltf::num>(val);
 				++i;
 			}
-		} else if (error != NO_SUCH_FIELD) {
+		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
 			return Error::InvalidGltf;
 		}
 
@@ -4391,7 +4390,7 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 			auto i = 0U;
 			for (auto num : inertiaDiagonalArray) {
 				double val;
-				if (num.get_double().get(val) != SUCCESS) FASTGLTF_UNLIKELY{
+				if (num.get_double().get(val) != SUCCESS) FASTGLTF_UNLIKELY {
 					return Error::InvalidGltf;
 				}
 				inertialDiagonal[i] = static_cast<fastgltf::num>(val);
@@ -4400,13 +4399,13 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 
 			motion.inertialDiagonal = inertialDiagonal;
 
-		} else if (error != NO_SUCH_FIELD) {
+		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
 			return Error::InvalidGltf;
 		}
 
 		dom::array inertialOrientationArray;
 		if (error = motionObject["inertialOrientation"].get_array().get(inertialOrientationArray); error == SUCCESS) {
-			if (inertialOrientationArray.size() != 4) {
+			if (inertialOrientationArray.size() != 4) FASTGLTF_UNLIKELY {
 				return Error::InvalidGltf;
 			}
 
@@ -4415,7 +4414,7 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 			auto i = 0U;
 			for (auto num : inertialOrientationArray) {
 				double val;
-				if (num.get_double().get(val) != SUCCESS) FASTGLTF_UNLIKELY{
+				if (num.get_double().get(val) != SUCCESS) FASTGLTF_UNLIKELY {
 					return Error::InvalidGltf;
 				}
 				inertialOrientation[i] = static_cast<fastgltf::num>(val);
@@ -4424,40 +4423,40 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 
 			motion.inertialOrientation = inertialOrientation;
 
-		} else if (error != NO_SUCH_FIELD) {
+		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
 			return Error::InvalidGltf;
 		}
 
 		dom::array linearVelocityArray;
 		if (error = motionObject["linearVelocity"].get_array().get(linearVelocityArray); error == SUCCESS) {
-			if (linearVelocityArray.size() != 3) {
+			if (linearVelocityArray.size() != 3) FASTGLTF_UNLIKELY {
 				return Error::InvalidGltf;
 			}
 
 			auto i = 0U;
 			for (auto num : linearVelocityArray) {
 				double val;
-				if (num.get_double().get(val) != SUCCESS) FASTGLTF_UNLIKELY{
+				if (num.get_double().get(val) != SUCCESS) FASTGLTF_UNLIKELY {
 					return Error::InvalidGltf;
 				}
 				motion.linearVelocity[i] = static_cast<fastgltf::num>(val);
 				++i;
 			}
 
-		} else if (error != NO_SUCH_FIELD) {
+		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
 			return Error::InvalidGltf;
 		}
 
 		dom::array angularVelocityArray;
-		if (error = motionObject["angularVelocity"].get_array().get(angularVelocityArray); error == SUCCESS) {
-			if (angularVelocityArray.size() != 3) {
+		if (error = motionObject["angularVelocity"].get_array().get(angularVelocityArray); error == SUCCESS) FASTGLTF_LIKELY {
+			if (angularVelocityArray.size() != 3) FASTGLTF_UNLIKELY {
 				return Error::InvalidGltf;
 			}
 
 			auto i = 0U;
 			for (auto num : angularVelocityArray) {
 				double val;
-				if (num.get_double().get(val) != SUCCESS) FASTGLTF_UNLIKELY{
+				if (num.get_double().get(val) != SUCCESS) FASTGLTF_UNLIKELY {
 					return Error::InvalidGltf;
 				}
 				motion.angularVelocity[i] = static_cast<fastgltf::num>(val);
@@ -4468,13 +4467,13 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 		}
 
 		double gravityFactor;
-		if (error = motionObject["gravityFactor"].get_double().get(gravityFactor); error == SUCCESS) {
+		if (error = motionObject["gravityFactor"].get_double().get(gravityFactor); error == SUCCESS) FASTGLTF_LIKELY {
 			motion.gravityFactor = static_cast<num>(gravityFactor);
 		} else if (error != NO_SUCH_FIELD) {
 			return Error::InvalidGltf;
 		}
 
-	} else if (error != NO_SUCH_FIELD) {
+	} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
 		return Error::InvalidGltf;
 	}
 
@@ -4483,21 +4482,21 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 		auto& collider = rigidBody.collider.emplace();
 
 		dom::object geometryObject;
-		if (colliderObject["geometry"].get_object().get(geometryObject) == SUCCESS) {
+		if (colliderObject["geometry"].get_object().get(geometryObject) == SUCCESS) FASTGLTF_LIKELY {
 			uint64_t shape;
-			if (error = geometryObject["shape"].get_uint64().get(shape); error == SUCCESS) {
+			if (error = geometryObject["shape"].get_uint64().get(shape); error == SUCCESS) FASTGLTF_LIKELY {
 				collider.geometry.shape = static_cast<std::size_t>(shape);
 			} else if (error != NO_SUCH_FIELD) {
 				return Error::InvalidGltf;
 			}
 			uint64_t geometryNode;
-			if (error = geometryObject["node"].get_uint64().get(geometryNode); error == SUCCESS) {
+			if (error = geometryObject["node"].get_uint64().get(geometryNode); error == SUCCESS) FASTGLTF_LIKELY {
 				collider.geometry.node = static_cast<std::size_t>(geometryNode);
 			} else if (error != NO_SUCH_FIELD) {
 				return Error::InvalidGltf;
 			}
 			bool convexHull;
-			if (error = geometryObject["convexHull"].get_bool().get(convexHull); error == SUCCESS) {
+			if (error = geometryObject["convexHull"].get_bool().get(convexHull); error == SUCCESS) FASTGLTF_LIKELY {
 				collider.geometry.convexHull = convexHull;
 			} else if (error != NO_SUCH_FIELD) {
 				return Error::InvalidGltf;
@@ -4507,37 +4506,37 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 		}
 
 		std::size_t physicsMaterial;
-		if (error = colliderObject["physicsMaterial"].get_uint64().get(physicsMaterial); error == SUCCESS) {
+		if (error = colliderObject["physicsMaterial"].get_uint64().get(physicsMaterial); error == SUCCESS) FASTGLTF_LIKELY {
 			collider.physicsMaterial = physicsMaterial;
 		} else if (error != NO_SUCH_FIELD) {
 			return Error::InvalidGltf;
 		}
 
 		std::size_t collisionFilter;
-		if (error = colliderObject["collisionFilter"].get_uint64().get(collisionFilter); error == SUCCESS) {
+		if (error = colliderObject["collisionFilter"].get_uint64().get(collisionFilter); error == SUCCESS) FASTGLTF_LIKELY {
 			collider.collisionFilter = collisionFilter;
 		} else if (error != NO_SUCH_FIELD) {
 			return Error::InvalidGltf;
 		}
 
-	} else if (error != NO_SUCH_FIELD) {
+	} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
 		return Error::InvalidGltf;
 	}
 
 	dom::object triggerObject;
 	if (auto error = khr_physics_rigid_bodies["trigger"].get_object().get(triggerObject); error == SUCCESS) {
 		dom::object geometryObject;
-		if (error = triggerObject["geometry"].get_object().get(geometryObject); error == SUCCESS) {
+		if (error = triggerObject["geometry"].get_object().get(geometryObject); error == SUCCESS) FASTGLTF_LIKELY {
 			auto& geometryTrigger = rigidBody.trigger.emplace().emplace<GeometryTrigger>();
 
 			uint64_t shape;
-			if (error = geometryObject["shape"].get_uint64().get(shape); error == SUCCESS) {
+			if (error = geometryObject["shape"].get_uint64().get(shape); error == SUCCESS) FASTGLTF_LIKELY {
 				geometryTrigger.geometry.shape = static_cast<std::size_t>(shape);
 			} else if (error != NO_SUCH_FIELD) {
 				return Error::InvalidGltf;
 			}
 			uint64_t geometryNode;
-			if (error = geometryObject["node"].get_uint64().get(geometryNode); error == SUCCESS) {
+			if (error = geometryObject["node"].get_uint64().get(geometryNode); error == SUCCESS) FASTGLTF_LIKELY {
 				geometryTrigger.geometry.node = static_cast<std::size_t>(geometryNode);
 			} else if (error != NO_SUCH_FIELD) {
 				return Error::InvalidGltf;
@@ -4545,7 +4544,7 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 			bool convexHull;
 			if (error = geometryObject["convexHull"].get_bool().get(convexHull); error == SUCCESS) {
 				geometryTrigger.geometry.convexHull = convexHull;
-			} else if (error != NO_SUCH_FIELD) {
+			} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
 				return Error::InvalidGltf;
 			}
 
@@ -4553,11 +4552,11 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 			std::size_t collisionFilter;
 			if (error = triggerObject["collisionFilter"].get_uint64().get(collisionFilter); error == SUCCESS) {
 				geometryTrigger.collisionFilter = collisionFilter;
-			} else if (error != NO_SUCH_FIELD) {
+			} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
 				return Error::InvalidGltf;
 			}
 
-		} else if (error != NO_SUCH_FIELD) {
+		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
 			return Error::InvalidGltf;
 		}
 
@@ -4576,30 +4575,30 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 				++i;
 			}
 
-		} else if (error != NO_SUCH_FIELD) {
+		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
 			return Error::InvalidGltf;
 		}
 	    
-	} else if (error != NO_SUCH_FIELD) {
+	} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
 		return Error::InvalidGltf;
 	}
 
 	dom::object jointObject;
 	if (auto error = khr_physics_rigid_bodies["joint"].get_object().get(jointObject); error == SUCCESS) {
 		auto& joint = rigidBody.joint.emplace();
-		if (jointObject["connectedNode"].get_uint64().get(joint.connectedNode) != SUCCESS) {
+		if (jointObject["connectedNode"].get_uint64().get(joint.connectedNode) != SUCCESS) FASTGLTF_LIKELY {
 			return Error::InvalidGltf;
 		}
 
-		if (jointObject["joint"].get_uint64().get(joint.joint) != SUCCESS) {
+		if (jointObject["joint"].get_uint64().get(joint.joint) != SUCCESS) FASTGLTF_LIKELY {
 			return Error::InvalidGltf;
 		}
 
-		if (error = jointObject["enableCollision"].get_bool().get(joint.enableCollision); error != SUCCESS && error != NO_SUCH_FIELD) {
+		if (error = jointObject["enableCollision"].get_bool().get(joint.enableCollision); error != SUCCESS && error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
 			return Error::InvalidGltf;
 		}
 	    
-	} else if (error != NO_SUCH_FIELD) {
+	} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
 		return Error::InvalidGltf;
 	}
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 set_directory_properties(PROPERTIES EXCLUDE_FROM_ALL TRUE)
 
-message(STATUS "fastgltf: Adding executable fastgltf_tests")
+message(STATUS "fastgltf: Bulding tests")
 
 # We want these tests to be a optional executable.
 add_executable(fastgltf_tests EXCLUDE_FROM_ALL "main.cpp"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,7 @@
 set_directory_properties(PROPERTIES EXCLUDE_FROM_ALL TRUE)
 
+message(STATUS "fastgltf: Adding executable fastgltf_tests")
+
 # We want these tests to be a optional executable.
 add_executable(fastgltf_tests EXCLUDE_FROM_ALL "main.cpp"
     "base64_tests.cpp" "basic_test.cpp" "benchmarks.cpp" "glb_tests.cpp" "gltf_path.hpp" "util_tests.cpp"

--- a/tests/README.md
+++ b/tests/README.md
@@ -11,6 +11,11 @@ repository to test if the parser correctly maps data to the structs. The tests
 expect a copy of the aforementioned repository to be in the `tests/gltf/glTF-Sample-Models`
 folder. This can be a simple clone or a symlink to another copy you have locally.
 
+The tests for KHR_implicit_shapes and KHR_physics_rigid_body use various assets from the 
+[glTF_Physics](https://github.com/eoineoineoin/glTF_Physics/tree/master) repository. The 
+tests expect a copy of that repo to be in `tests/gltf/glTF_Physics` - as with the other sample
+assets, you may use a symlink if you so choose
+
 You can also directly change the paths where the test application searches by modifying
 `gltf_path.hpp` in this directory. It uses source-file-relative paths by default,
 regardless of where the binary is stored.
@@ -30,6 +35,11 @@ to `ON`. The CMake script will automatically fetch `Catch2` and other required l
 simply calling the following command will build the target with all tests:
 ```
 cmake --build . --target fastgltf_tests
+```
+
+If you're using Visual Studio you may need to use this command instead:
+```
+cmake --build . --target tests/fastgltf_tests
 ```
 
 **fastgltf** uses the `Catch2` test framework, which can take various command-line parameters when running.

--- a/tests/README.md
+++ b/tests/README.md
@@ -12,7 +12,7 @@ expect a copy of the aforementioned repository to be in the `tests/gltf/glTF-Sam
 folder. This can be a simple clone or a symlink to another copy you have locally.
 
 The tests for KHR_implicit_shapes and KHR_physics_rigid_body use various assets from the 
-[glTF_Physics](https://github.com/eoineoineoin/glTF_Physics/tree/master) repository. The 
+[glTF_Physics](https://github.com/eoineoineoin/glTF_Physics) repository. The 
 tests expect a copy of that repo to be in `tests/gltf/glTF_Physics` - as with the other sample
 assets, you may use a symlink if you so choose
 

--- a/tests/extension_tests.cpp
+++ b/tests/extension_tests.cpp
@@ -1,3 +1,5 @@
+#nclude <cmath>
+
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/benchmark/catch_benchmark.hpp>

--- a/tests/extension_tests.cpp
+++ b/tests/extension_tests.cpp
@@ -496,7 +496,6 @@ TEST_CASE("Extension KHR_implicit_shapes", "[gltf-loader]") {
 	REQUIRE(asset->shapes.size() == 7);
 
 	const auto& box0 = asset->shapes.at(0);
-	REQUIRE(box0.type == fastgltf::ShapeType::Box);
 	fastgltf::visit_exhaustive(fastgltf::visitor{
 	    [](const fastgltf::BoxShape& box) {
 			REQUIRE(box.size.x() == Catch::Approx(0.5285500288009644));
@@ -513,10 +512,9 @@ TEST_CASE("Extension KHR_implicit_shapes", "[gltf-loader]") {
 			REQUIRE(false);
 		}
 		},
-		box0.shape);
+		box0);
 
 	const auto& sphere4 = asset->shapes.at(4);
-	REQUIRE(sphere4.type == fastgltf::ShapeType::Sphere);
 	fastgltf::visit_exhaustive(fastgltf::visitor{
 		[](const fastgltf::BoxShape& box) {
 			REQUIRE(false);
@@ -531,10 +529,9 @@ TEST_CASE("Extension KHR_implicit_shapes", "[gltf-loader]") {
 			REQUIRE(false);
 		}
 		},
-		sphere4.shape);
+		sphere4);
 
 	const auto& capsule6 = asset->shapes.at(6);
-	REQUIRE(capsule6.type == fastgltf::ShapeType::Capsule);
 	fastgltf::visit_exhaustive(fastgltf::visitor{
 		[](const fastgltf::BoxShape& box) {
 			REQUIRE(false);
@@ -551,10 +548,9 @@ TEST_CASE("Extension KHR_implicit_shapes", "[gltf-loader]") {
 			REQUIRE(false);
 		}
 		},
-		capsule6.shape);
+		capsule6);
 
 	const auto& cylinder2 = asset->shapes.at(2);
-	REQUIRE(cylinder2.type == fastgltf::ShapeType::Cylinder);
 	fastgltf::visit_exhaustive(fastgltf::visitor{
 		[](const fastgltf::BoxShape& box) {
 			REQUIRE(false);
@@ -571,7 +567,7 @@ TEST_CASE("Extension KHR_implicit_shapes", "[gltf-loader]") {
 			REQUIRE(cylinder.radiusTop == Catch::Approx(0.15483441948890686));
 		}
 		},
-		cylinder2.shape);
+		cylinder2);
 }
 #endif
 
@@ -606,52 +602,43 @@ TEST_CASE("Extension KHR_physics_rigid_bodies simple", "[gltf-loader]") {
 	const auto& node = asset->nodes.at(0);
 
 	REQUIRE(node.physicsRigidBody.has_value());
-	if (node.physicsRigidBody) {
-		REQUIRE(node.physicsRigidBody->motion.has_value());
-		if (node.physicsRigidBody->motion) {
-			REQUIRE(node.physicsRigidBody->motion->mass == 1);
-			REQUIRE(!node.physicsRigidBody->motion->inertialDiagonal.has_value());
-			REQUIRE(!node.physicsRigidBody->motion->inertialOrientation.has_value());
-		}
+	REQUIRE(node.physicsRigidBody->motion.has_value());
+	REQUIRE(node.physicsRigidBody->motion->mass == 1);
+	REQUIRE(!node.physicsRigidBody->motion->inertialDiagonal.has_value());
+	REQUIRE(!node.physicsRigidBody->motion->inertialOrientation.has_value());
 
-		REQUIRE(node.physicsRigidBody->collider.has_value());
-		if (node.physicsRigidBody->collider) {
-			REQUIRE(node.physicsRigidBody->collider->geometry.shape.has_value());
-			REQUIRE(node.physicsRigidBody->collider->geometry.shape == 0);
-			REQUIRE(!node.physicsRigidBody->collider->geometry.node.has_value());
-			REQUIRE(node.physicsRigidBody->collider->physicsMaterial == 0);
-			REQUIRE(node.physicsRigidBody->collider->collisionFilter == 0);
-		}
+	REQUIRE(node.physicsRigidBody->collider.has_value());
+	REQUIRE(node.physicsRigidBody->collider->geometry.shape.has_value());
+	REQUIRE(node.physicsRigidBody->collider->geometry.shape == 0);
+	REQUIRE(!node.physicsRigidBody->collider->geometry.node.has_value());
+	REQUIRE(node.physicsRigidBody->collider->physicsMaterial == 0);
+	REQUIRE(node.physicsRigidBody->collider->collisionFilter == 0);
 
-		REQUIRE(!node.physicsRigidBody->trigger.has_value());
-		REQUIRE(!node.physicsRigidBody->joint.has_value());
-	}
+	REQUIRE(!node.physicsRigidBody->trigger.has_value());
+	REQUIRE(!node.physicsRigidBody->joint.has_value());
+
 
 	const auto& node10 = asset->nodes.at(11);
 
 	REQUIRE(node10.physicsRigidBody.has_value());
-	if (node10.physicsRigidBody) {
-		REQUIRE(!node10.physicsRigidBody->motion.has_value());
-		REQUIRE(!node10.physicsRigidBody->collider.has_value());
+	REQUIRE(!node10.physicsRigidBody->motion.has_value());
+	REQUIRE(!node10.physicsRigidBody->collider.has_value());
 
-	    REQUIRE(node10.physicsRigidBody->trigger.has_value());
-		if(node10.physicsRigidBody->trigger) {
-			fastgltf::visit_exhaustive(fastgltf::visitor{
-				[](const fastgltf::GeometryTrigger& geo) {
-					REQUIRE(geo.geometry.convexHull);
-					REQUIRE(geo.geometry.node == 10);
-					REQUIRE(geo.collisionFilter.has_value());
-					REQUIRE(geo.collisionFilter == 0);
-				},
-				[](const fastgltf::NodeTrigger& node) {
-					REQUIRE(false);
-				}
-			},
-			*node10.physicsRigidBody->trigger);
+	REQUIRE(node10.physicsRigidBody->trigger.has_value());
+	fastgltf::visit_exhaustive(fastgltf::visitor{
+		[](const fastgltf::GeometryTrigger& geo) {
+			REQUIRE(geo.geometry.convexHull);
+			REQUIRE(geo.geometry.node == 10);
+			REQUIRE(geo.collisionFilter.has_value());
+			REQUIRE(geo.collisionFilter == 0);
+		},
+		[](const fastgltf::NodeTrigger& node) {
+			REQUIRE(false);
 		}
+		},
+		*node10.physicsRigidBody->trigger);
 
-	    REQUIRE(!node10.physicsRigidBody->joint.has_value());
-	}
+	REQUIRE(!node10.physicsRigidBody->joint.has_value());
 }
 
 TEST_CASE("Extension KHR_physics_rigid_bodies complex", "[gltf-loader]") {
@@ -684,72 +671,64 @@ TEST_CASE("Extension KHR_physics_rigid_bodies complex", "[gltf-loader]") {
 	const auto& filter2 = asset->collisionFilters.at(2);
 	REQUIRE(filter2.collisionSystems.size() == 2);
 	REQUIRE(filter2.collisionSystems.at(0) == "System_0");
-    REQUIRE(filter2.collisionSystems.at(1) == "System_1");
+	REQUIRE(filter2.collisionSystems.at(1) == "System_1");
 	REQUIRE(filter2.collideWithSystems.size() == 2);
 	REQUIRE(filter2.collideWithSystems.at(0) == "System_0");
 	REQUIRE(filter2.collideWithSystems.at(1) == "System_1");
 	REQUIRE(filter0.notCollideWithSystems.size() == 0);
 
-	{
-		const auto& joint0 = asset->physicsJoints.at(0);
-		REQUIRE(joint0.limits.size() == 5);
+	const auto& joint0 = asset->physicsJoints.at(0);
+	REQUIRE(joint0.limits.size() == 5);
 
-	    const auto& limit0 = joint0.limits.at(0);
-		REQUIRE(limit0.linearAxes.size() == 1);
-		REQUIRE(limit0.linearAxes.at(0) == 0);
-		REQUIRE(limit0.angularAxes.size() == 0);
-		REQUIRE(limit0.min == Catch::Approx(0));
-		REQUIRE(limit0.max == Catch::Approx(0));
-		REQUIRE(!limit0.stiffness.has_value());
+	const auto& limit0 = joint0.limits.at(0);
+	REQUIRE(limit0.linearAxes.size() == 1);
+	REQUIRE(limit0.linearAxes.at(0) == 0);
+	REQUIRE(limit0.angularAxes.size() == 0);
+	REQUIRE(limit0.min == Catch::Approx(0));
+	REQUIRE(limit0.max == Catch::Approx(0));
+	REQUIRE(!limit0.stiffness.has_value());
 
-		const auto limit4 = joint0.limits.at(4);
-		REQUIRE(limit4.linearAxes.size() == 0);
-		REQUIRE(limit4.angularAxes.size() == 1);
-		REQUIRE(limit4.angularAxes.at(0) == 1);
-		REQUIRE(limit4.min == Catch::Approx(0));
-		REQUIRE(limit4.max == Catch::Approx(0));
-		REQUIRE(!limit4.stiffness.has_value());
+	const auto limit4 = joint0.limits.at(4);
+	REQUIRE(limit4.linearAxes.size() == 0);
+	REQUIRE(limit4.angularAxes.size() == 1);
+	REQUIRE(limit4.angularAxes.at(0) == 1);
+	REQUIRE(limit4.min == Catch::Approx(0));
+	REQUIRE(limit4.max == Catch::Approx(0));
+	REQUIRE(!limit4.stiffness.has_value());
 
-		REQUIRE(joint0.drives.size() == 1);
-		const auto& drive0 = joint0.drives.at(0);
+	REQUIRE(joint0.drives.size() == 1);
+	const auto& drive0 = joint0.drives.at(0);
 
-		REQUIRE(drive0.type == fastgltf::DriveType::Angular);
-		REQUIRE(drive0.mode == fastgltf::DriveMode::Acceleration);
-		REQUIRE(drive0.axis == 0);
-		REQUIRE(drive0.positionTarget == Catch::Approx(0));
-        REQUIRE(drive0.velocityTarget == Catch::Approx(-2));
-		REQUIRE(drive0.stiffness == Catch::Approx(0));
-		REQUIRE(drive0.damping == Catch::Approx(100));
-	}
+	REQUIRE(drive0.type == fastgltf::DriveType::Angular);
+	REQUIRE(drive0.mode == fastgltf::DriveMode::Acceleration);
+	REQUIRE(drive0.axis == 0);
+	REQUIRE(drive0.positionTarget == Catch::Approx(0));
+	REQUIRE(drive0.velocityTarget == Catch::Approx(-2));
+	REQUIRE(drive0.stiffness == Catch::Approx(0));
+	REQUIRE(drive0.damping == Catch::Approx(100));
 
-	{
-		const auto& joint9 = asset->physicsJoints.at(9);
-		REQUIRE(joint9.limits.size() == 3);
+	const auto& joint9 = asset->physicsJoints.at(9);
+	REQUIRE(joint9.limits.size() == 3);
 
-		const auto& limit1 = joint9.limits.at(1);
-		REQUIRE(limit1.linearAxes.size() == 1);
-		REQUIRE(limit1.linearAxes.at(0) == 2);
-		REQUIRE(limit1.angularAxes.size() == 0);
-		REQUIRE(limit1.min == Catch::Approx(0));
-		REQUIRE(limit1.max == Catch::Approx(0));
-		REQUIRE(!limit1.stiffness.has_value());
+	const auto& limit1 = joint9.limits.at(1);
+	REQUIRE(limit1.linearAxes.size() == 1);
+	REQUIRE(limit1.linearAxes.at(0) == 2);
+	REQUIRE(limit1.angularAxes.size() == 0);
+	REQUIRE(limit1.min == Catch::Approx(0));
+	REQUIRE(limit1.max == Catch::Approx(0));
+	REQUIRE(!limit1.stiffness.has_value());
 
-		REQUIRE(joint9.drives.size() == 0);
-	}
+	REQUIRE(joint9.drives.size() == 0);
 
 	const auto& node10 = asset->nodes.at(10);
 	REQUIRE(node10.physicsRigidBody.has_value());
-	if(node10.physicsRigidBody) {
-		REQUIRE(!node10.physicsRigidBody->collider.has_value());
-		REQUIRE(!node10.physicsRigidBody->motion.has_value());
-		REQUIRE(!node10.physicsRigidBody->trigger.has_value());
-		REQUIRE(node10.physicsRigidBody->joint.has_value());
-		if(node10.physicsRigidBody->joint) {
-			const auto& joint = *node10.physicsRigidBody->joint;
-		    REQUIRE(joint.connectedNode == 9);
-			REQUIRE(joint.joint == 0);
-			REQUIRE(joint.enableCollision == false);
-		}
-	}
+	REQUIRE(!node10.physicsRigidBody->collider.has_value());
+	REQUIRE(!node10.physicsRigidBody->motion.has_value());
+	REQUIRE(!node10.physicsRigidBody->trigger.has_value());
+	REQUIRE(node10.physicsRigidBody->joint.has_value());
+	const auto& joint = *node10.physicsRigidBody->joint;
+	REQUIRE(joint.connectedNode == 9);
+	REQUIRE(joint.joint == 0);
+	REQUIRE(joint.enableCollision == false);
 }
 #endif

--- a/tests/extension_tests.cpp
+++ b/tests/extension_tests.cpp
@@ -480,3 +480,95 @@ TEST_CASE("Extension KHR_materials_variant", "[gltf-loader]") {
 	REQUIRE(primitive.mappings[3] == 5U);
 	REQUIRE(primitive.mappings[4] == 6U);
 }
+
+#if FASTGLTF_ENABLE_KHR_IMPLICIT_SHAPES
+TEST_CASE("Extension KHR_implicit_shapes", "[gltf-loader]") {
+	auto shapeTypes = physicsSampleAssets / "samples" / "ShapeTypes" / "ShapeTypes.gltf";
+
+	fastgltf::GltfFileStream jsonData(shapeTypes);
+	REQUIRE(jsonData.isOpen());
+
+	fastgltf::Parser parser(fastgltf::Extensions::KHR_implicit_shapes | fastgltf::Extensions::KHR_lights_punctual);
+	auto asset = parser.loadGltfJson(jsonData, shapeTypes.parent_path());
+	REQUIRE(asset.error() == fastgltf::Error::None);
+	REQUIRE(fastgltf::validate(asset.get()) == fastgltf::Error::None);
+
+	REQUIRE(asset->shapes.size() == 7);
+
+	const auto& box0 = asset->shapes.at(0);
+	REQUIRE(box0.type == fastgltf::ShapeType::Box);
+	fastgltf::visit_exhaustive(fastgltf::visitor{
+	    [](const fastgltf::BoxShape& box) {
+			REQUIRE(box.size == fastgltf::math::fvec3(0.5285500288009644, 1, 0.5285500288009644));
+	    },
+		[](const fastgltf::SphereShape& sphere) {
+			REQUIRE(false);
+		},
+		[](const fastgltf::CapsuleShape& capsule) {
+			REQUIRE(false);
+		},
+		[](const fastgltf::CylinderShape& cylinder) {
+			REQUIRE(false);
+		}
+		},
+		box0.shape);
+
+	const auto& sphere4 = asset->shapes.at(4);
+	REQUIRE(sphere4.type == fastgltf::ShapeType::Sphere);
+	fastgltf::visit_exhaustive(fastgltf::visitor{
+		[](const fastgltf::BoxShape& box) {
+			REQUIRE(false);
+		},
+		[](const fastgltf::SphereShape& sphere) {
+			REQUIRE(abs(sphere.radius - 0.3417187615099374) < FLT_EPSILON);
+		},
+		[](const fastgltf::CapsuleShape& capsule) {
+			REQUIRE(false);
+		},
+		[](const fastgltf::CylinderShape& cylinder) {
+			REQUIRE(false);
+		}
+		},
+		sphere4.shape);
+
+	const auto& capsule6 = asset->shapes.at(6);
+	REQUIRE(capsule6.type == fastgltf::ShapeType::Capsule);
+	fastgltf::visit_exhaustive(fastgltf::visitor{
+		[](const fastgltf::BoxShape& box) {
+			REQUIRE(false);
+		},
+		[](const fastgltf::SphereShape& sphere) {
+			REQUIRE(false);
+		},
+		[](const fastgltf::CapsuleShape& capsule) {
+			REQUIRE(abs(capsule.height - 0.6000000238418579) < FLT_EPSILON);
+			REQUIRE(abs(capsule.radiusBottom - 0.25) < FLT_EPSILON);
+			REQUIRE(abs(capsule.radiusTop - 0.4000000059604645) < FLT_EPSILON);
+		},
+		[](const fastgltf::CylinderShape& cylinder) {
+			REQUIRE(false);
+		}
+		},
+		capsule6.shape);
+
+	const auto& cylinder2 = asset->shapes.at(2);
+	REQUIRE(cylinder2.type == fastgltf::ShapeType::Cylinder);
+	fastgltf::visit_exhaustive(fastgltf::visitor{
+		[](const fastgltf::BoxShape& box) {
+			REQUIRE(false);
+		},
+		[](const fastgltf::SphereShape& sphere) {
+			REQUIRE(false);
+		},
+		[](const fastgltf::CapsuleShape& capsule) {
+			REQUIRE(false);
+		},
+		[](const fastgltf::CylinderShape& cylinder) {
+			REQUIRE(abs(cylinder.height - 0.06662015616893768) < FLT_EPSILON);
+			REQUIRE(abs(cylinder.radiusBottom - 0.15483441948890686) < FLT_EPSILON);
+			REQUIRE(abs(cylinder.radiusTop - 0.15483441948890686) < FLT_EPSILON);
+		}
+		},
+		cylinder2.shape);
+}
+#endif

--- a/tests/extension_tests.cpp
+++ b/tests/extension_tests.cpp
@@ -601,7 +601,7 @@ TEST_CASE("Extension KHR_physics_rigid_bodies simple", "[gltf-loader]") {
 
 	const auto& node = asset->nodes.at(0);
 
-	REQUIRE(node.physicsRigidBody.has_value());
+	REQUIRE(node.physicsRigidBody);
 	REQUIRE(node.physicsRigidBody->motion.has_value());
 	REQUIRE(node.physicsRigidBody->motion->mass == 1);
 	REQUIRE(!node.physicsRigidBody->motion->inertialDiagonal.has_value());
@@ -620,7 +620,7 @@ TEST_CASE("Extension KHR_physics_rigid_bodies simple", "[gltf-loader]") {
 
 	const auto& node10 = asset->nodes.at(11);
 
-	REQUIRE(node10.physicsRigidBody.has_value());
+	REQUIRE(node10.physicsRigidBody);
 	REQUIRE(!node10.physicsRigidBody->motion.has_value());
 	REQUIRE(!node10.physicsRigidBody->collider.has_value());
 
@@ -721,7 +721,7 @@ TEST_CASE("Extension KHR_physics_rigid_bodies complex", "[gltf-loader]") {
 	REQUIRE(joint9.drives.size() == 0);
 
 	const auto& node10 = asset->nodes.at(10);
-	REQUIRE(node10.physicsRigidBody.has_value());
+	REQUIRE(node10.physicsRigidBody);
 	REQUIRE(!node10.physicsRigidBody->collider.has_value());
 	REQUIRE(!node10.physicsRigidBody->motion.has_value());
 	REQUIRE(!node10.physicsRigidBody->trigger.has_value());

--- a/tests/extension_tests.cpp
+++ b/tests/extension_tests.cpp
@@ -1,4 +1,4 @@
-#nclude <cmath>
+#include <cmath>
 
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>

--- a/tests/extension_tests.cpp
+++ b/tests/extension_tests.cpp
@@ -1,5 +1,3 @@
-#include <cmath>
-
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/benchmark/catch_benchmark.hpp>
@@ -501,7 +499,9 @@ TEST_CASE("Extension KHR_implicit_shapes", "[gltf-loader]") {
 	REQUIRE(box0.type == fastgltf::ShapeType::Box);
 	fastgltf::visit_exhaustive(fastgltf::visitor{
 	    [](const fastgltf::BoxShape& box) {
-			REQUIRE(box.size == fastgltf::math::fvec3(0.5285500288009644, 1, 0.5285500288009644));
+			REQUIRE(box.size.x() == Catch::Approx(0.5285500288009644));
+			REQUIRE(box.size.y() == Catch::Approx(1));
+	        REQUIRE(box.size.z() == Catch::Approx(0.5285500288009644));
 	    },
 		[](const fastgltf::SphereShape& sphere) {
 			REQUIRE(false);
@@ -522,7 +522,7 @@ TEST_CASE("Extension KHR_implicit_shapes", "[gltf-loader]") {
 			REQUIRE(false);
 		},
 		[](const fastgltf::SphereShape& sphere) {
-			REQUIRE(abs(sphere.radius - 0.3417187615099374) < FLT_EPSILON);
+			REQUIRE(sphere.radius == Catch::Approx(0.3417187615099374));
 		},
 		[](const fastgltf::CapsuleShape& capsule) {
 			REQUIRE(false);
@@ -543,9 +543,9 @@ TEST_CASE("Extension KHR_implicit_shapes", "[gltf-loader]") {
 			REQUIRE(false);
 		},
 		[](const fastgltf::CapsuleShape& capsule) {
-			REQUIRE(abs(capsule.height - 0.6000000238418579) < FLT_EPSILON);
-			REQUIRE(abs(capsule.radiusBottom - 0.25) < FLT_EPSILON);
-			REQUIRE(abs(capsule.radiusTop - 0.4000000059604645) < FLT_EPSILON);
+			REQUIRE(capsule.height == Catch::Approx(0.6000000238418579));
+			REQUIRE(capsule.radiusBottom == Catch::Approx(0.25));
+			REQUIRE(capsule.radiusTop == Catch::Approx(0.4000000059604645));
 		},
 		[](const fastgltf::CylinderShape& cylinder) {
 			REQUIRE(false);
@@ -566,9 +566,9 @@ TEST_CASE("Extension KHR_implicit_shapes", "[gltf-loader]") {
 			REQUIRE(false);
 		},
 		[](const fastgltf::CylinderShape& cylinder) {
-			REQUIRE(abs(cylinder.height - 0.06662015616893768) < FLT_EPSILON);
-			REQUIRE(abs(cylinder.radiusBottom - 0.15483441948890686) < FLT_EPSILON);
-			REQUIRE(abs(cylinder.radiusTop - 0.15483441948890686) < FLT_EPSILON);
+			REQUIRE(cylinder.height == Catch::Approx(0.06662015616893768));
+			REQUIRE(cylinder.radiusBottom == Catch::Approx(0.15483441948890686));
+			REQUIRE(cylinder.radiusTop == Catch::Approx(0.15483441948890686));
 		}
 		},
 		cylinder2.shape);
@@ -589,9 +589,9 @@ TEST_CASE("Extension KHR_physics_rigid_bodies simple", "[gltf-loader]") {
 
 	REQUIRE(asset->physicsMaterials.size() == 1);
 	const auto& material = asset->physicsMaterials.at(0);
-	REQUIRE(material.staticFriction == 0.5);
-	REQUIRE(material.dynamicFriction == 0.5);
-	REQUIRE(material.restitution == 0);
+	REQUIRE(material.staticFriction == Catch::Approx(0.5));
+	REQUIRE(material.dynamicFriction == Catch::Approx(0.5));
+	REQUIRE(material.restitution == Catch::Approx(0));
 
 	REQUIRE(asset->collisionFilters.size() == 1);
 	const auto& filter = asset->collisionFilters.at(0);
@@ -670,9 +670,9 @@ TEST_CASE("Extension KHR_physics_rigid_bodies complex", "[gltf-loader]") {
 	REQUIRE(asset->physicsJoints.size() == 10);
 
 	const auto& material = asset->physicsMaterials.at(0);
-	REQUIRE(material.staticFriction == 0.5);
-	REQUIRE(material.dynamicFriction == 0.5);
-	REQUIRE(material.restitution == 0);
+	REQUIRE(material.staticFriction == Catch::Approx(0.5));
+	REQUIRE(material.dynamicFriction == Catch::Approx(0.5));
+	REQUIRE(material.restitution == Catch::Approx(0));
 
 	const auto& filter0 = asset->collisionFilters.at(0);
 	REQUIRE(filter0.collisionSystems.size() == 1);
@@ -698,16 +698,16 @@ TEST_CASE("Extension KHR_physics_rigid_bodies complex", "[gltf-loader]") {
 		REQUIRE(limit0.linearAxes.size() == 1);
 		REQUIRE(limit0.linearAxes.at(0) == 0);
 		REQUIRE(limit0.angularAxes.size() == 0);
-		REQUIRE(limit0.min == 0);
-		REQUIRE(limit0.max == 0);
+		REQUIRE(limit0.min == Catch::Approx(0));
+		REQUIRE(limit0.max == Catch::Approx(0));
 		REQUIRE(!limit0.stiffness.has_value());
 
 		const auto limit4 = joint0.limits.at(4);
 		REQUIRE(limit4.linearAxes.size() == 0);
 		REQUIRE(limit4.angularAxes.size() == 1);
 		REQUIRE(limit4.angularAxes.at(0) == 1);
-		REQUIRE(limit4.min == 0);
-		REQUIRE(limit4.max == 0);
+		REQUIRE(limit4.min == Catch::Approx(0));
+		REQUIRE(limit4.max == Catch::Approx(0));
 		REQUIRE(!limit4.stiffness.has_value());
 
 		REQUIRE(joint0.drives.size() == 1);
@@ -716,10 +716,10 @@ TEST_CASE("Extension KHR_physics_rigid_bodies complex", "[gltf-loader]") {
 		REQUIRE(drive0.type == fastgltf::DriveType::Angular);
 		REQUIRE(drive0.mode == fastgltf::DriveMode::Acceleration);
 		REQUIRE(drive0.axis == 0);
-		REQUIRE(drive0.positionTarget == 0);
-        REQUIRE(drive0.velocityTarget == -2);
-		REQUIRE(drive0.stiffness == 0);
-		REQUIRE(drive0.damping == 100);
+		REQUIRE(drive0.positionTarget == Catch::Approx(0));
+        REQUIRE(drive0.velocityTarget == Catch::Approx(-2));
+		REQUIRE(drive0.stiffness == Catch::Approx(0));
+		REQUIRE(drive0.damping == Catch::Approx(100));
 	}
 
 	{
@@ -730,8 +730,8 @@ TEST_CASE("Extension KHR_physics_rigid_bodies complex", "[gltf-loader]") {
 		REQUIRE(limit1.linearAxes.size() == 1);
 		REQUIRE(limit1.linearAxes.at(0) == 2);
 		REQUIRE(limit1.angularAxes.size() == 0);
-		REQUIRE(limit1.min == 0);
-		REQUIRE(limit1.max == 0);
+		REQUIRE(limit1.min == Catch::Approx(0));
+		REQUIRE(limit1.max == Catch::Approx(0));
 		REQUIRE(!limit1.stiffness.has_value());
 
 		REQUIRE(joint9.drives.size() == 0);

--- a/tests/gltf_path.hpp
+++ b/tests/gltf_path.hpp
@@ -5,5 +5,6 @@
 // directory. As Clang does not yet fully support std::source_location, we cannot use that.
 inline auto path = std::filesystem::path { __FILE__ }.parent_path() / "gltf";
 inline auto sampleAssets = std::filesystem::path { __FILE__ }.parent_path() / "gltf" / "glTF-Sample-Assets";
+inline auto physicsSampleAssets = std::filesystem::path{ __FILE__ }.parent_path() / "gltf" / "glTF_Physics";
 inline auto intelSponza = std::filesystem::path { __FILE__ }.parent_path() / "gltf" / "intel_sponza";
 inline auto bistroPath = std::filesystem::path { __FILE__ }.parent_path() / "gltf" / "bistro";


### PR DESCRIPTION
Adds support for the draft [KHR_physics_rigid_bodies](https://github.com/KhronosGroup/glTF/pull/2424) extension, and [KHR_implicit_shapes](https://github.com/KhronosGroup/glTF/pull/2370)

The import code is decently well-tested and used in my game, the export code is a bit rougher