### PR TITLE
Lots of validation fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,10 @@ tests/gltf/bistro
 tests/gltf_loaders/
 tests/gltf/export/
 tests/gltf/export_glb/
+tests/gltf/export_gltf/
+tests/gltf/glTF-new-assets/
+tests/gltf/OMI_*/
+tests/gltf/gltf_validator
 
 # gltf Rust wrapper
 tests/gltf-rs/target

--- a/.gitignore
+++ b/.gitignore
@@ -38,8 +38,6 @@ tests/gltf_loaders/
 tests/gltf/export/
 tests/gltf/export_glb/
 tests/gltf/export_gltf/
-tests/gltf/glTF-new-assets/
-tests/gltf/OMI_*/
 tests/gltf/gltf_validator
 
 # gltf Rust wrapper

--- a/include/fastgltf/types.hpp
+++ b/include/fastgltf/types.hpp
@@ -2238,10 +2238,20 @@ namespace fastgltf {
 #if FASTGLTF_ENABLE_KHR_IMPLICIT_SHAPES
 	FASTGLTF_EXPORT struct SphereShape {
 		num radius = 0.5;
+
+		bool operator==(const SphereShape& other) const {
+			FASTGLTF_REQUIRE(radius == other.radius);
+			return true;
+		}
 	};
 
 	FASTGLTF_EXPORT struct BoxShape {
 		math::fvec3 size = { 1, 1, 1 };
+
+		bool operator==(const BoxShape& other) const {
+			FASTGLTF_REQUIRE(size == other.size);
+			return true;
+		}
 	};
 
 	FASTGLTF_EXPORT struct CapsuleShape {
@@ -2250,6 +2260,13 @@ namespace fastgltf {
 		num radiusBottom = 0.25;
 
 		num radiusTop = 0.25;
+
+		bool operator==(const CapsuleShape& other) const {
+			FASTGLTF_REQUIRE(height == other.height);
+			FASTGLTF_REQUIRE(radiusBottom == other.radiusBottom);
+			FASTGLTF_REQUIRE(radiusTop == other.radiusTop);
+			return true;
+		}
 	};
 
 	FASTGLTF_EXPORT struct CylinderShape {
@@ -2258,6 +2275,13 @@ namespace fastgltf {
 		num radiusBottom = 0.25;
 
 		num radiusTop = 0.25;
+
+		bool operator==(const CylinderShape& other) const {
+			FASTGLTF_REQUIRE(height == other.height);
+			FASTGLTF_REQUIRE(radiusBottom == other.radiusBottom);
+			FASTGLTF_REQUIRE(radiusTop == other.radiusTop);
+			return true;
+		}
 	};
 
 	using Shape = std::variant<SphereShape, BoxShape, CapsuleShape, CylinderShape>;
@@ -2304,6 +2328,18 @@ namespace fastgltf {
          * A multiplier applied to the acceleration due to gravity
          */
         num gravityFactor = 1;
+
+		bool operator==(const Motion& other) const {
+			FASTGLTF_REQUIRE(isKinematic == other.isKinematic);
+			FASTGLTF_REQUIRE(mass == other.mass);
+			FASTGLTF_REQUIRE(centerOfMass == other.centerOfMass);
+			FASTGLTF_REQUIRE(inertialDiagonal == other.inertialDiagonal);
+			FASTGLTF_REQUIRE(inertialOrientation == other.inertialOrientation);
+			FASTGLTF_REQUIRE(linearVelocity == other.linearVelocity);
+			FASTGLTF_REQUIRE(angularVelocity == other.angularVelocity);
+			FASTGLTF_REQUIRE(gravityFactor == other.gravityFactor);
+			return true;
+		}
 	};
 
 	FASTGLTF_EXPORT struct Geometry {
@@ -2321,6 +2357,13 @@ namespace fastgltf {
          * Flag to indicate that the geometry should be a convex hull.
          */
         bool convexHull;
+
+		bool operator==(const Geometry& other) const {
+			FASTGLTF_REQUIRE(shape == other.shape);
+			FASTGLTF_REQUIRE(node == other.node);
+			FASTGLTF_REQUIRE(convexHull == other.convexHull);
+			return true;
+		}
 	};
 
 	FASTGLTF_EXPORT struct PhysicsMaterial {
@@ -2333,6 +2376,15 @@ namespace fastgltf {
 		CombineMode frictionCombine;
 
 		CombineMode restitutionCombine;
+
+		bool operator==(const PhysicsMaterial& other) const {
+			FASTGLTF_REQUIRE(staticFriction == other.staticFriction);
+			FASTGLTF_REQUIRE(dynamicFriction == other.dynamicFriction);
+			FASTGLTF_REQUIRE(restitution == other.restitution);
+			FASTGLTF_REQUIRE(frictionCombine == other.frictionCombine);
+			FASTGLTF_REQUIRE(restitutionCombine == other.restitutionCombine);
+			return true;
+		}
 	};
 
 	FASTGLTF_EXPORT struct CollisionFilter {
@@ -2350,6 +2402,13 @@ namespace fastgltf {
          * An array of strings representing the systems which this node can collide with
          */
         FASTGLTF_FG_PMR_NS::MaybeSmallVector<FASTGLTF_STD_PMR_NS::string> collideWithSystems;
+
+		bool operator==(const CollisionFilter& other) const {
+			FASTGLTF_REQUIRE(collisionSystems == other.collisionSystems);
+			FASTGLTF_REQUIRE(notCollideWithSystems == other.notCollideWithSystems);
+			FASTGLTF_REQUIRE(collideWithSystems == other.collideWithSystems);
+			return true;
+		}
 	};
 
 	FASTGLTF_EXPORT struct Collider {
@@ -2367,6 +2426,13 @@ namespace fastgltf {
          * Indexes into the top-level `collisionFilters` and describes a filter which determines if this collider should perform collision detection against another collider
          */
         Optional<std::size_t> collisionFilter;
+
+		bool operator==(const Collider& other) const {
+			FASTGLTF_REQUIRE(geometry == other.geometry);
+			FASTGLTF_REQUIRE(physicsMaterial == other.physicsMaterial);
+			FASTGLTF_REQUIRE(collisionFilter == other.collisionFilter);
+			return true;
+		}
 	};
 
 	FASTGLTF_EXPORT struct GeometryTrigger {
@@ -2379,6 +2445,12 @@ namespace fastgltf {
 		 * Indexes into the top-level `collisionFilters` and describes a filter which determines if this collider should perform collision detection against another collider
 		 */
 		Optional<std::size_t> collisionFilter;
+
+		bool operator==(const GeometryTrigger& other) const {
+			FASTGLTF_REQUIRE(geometry == other.geometry);
+			FASTGLTF_REQUIRE(collisionFilter == other.collisionFilter);
+			return true;
+		}
 	};
 
 	FASTGLTF_EXPORT struct NodeTrigger {
@@ -2387,6 +2459,11 @@ namespace fastgltf {
 		 * For compound triggers, the set of descendant glTF nodes with a trigger property that make up this compound trigger
 		 */
 		FASTGLTF_FG_PMR_NS::MaybeSmallVector<std::size_t> nodes;
+
+		bool operator==(const NodeTrigger& other) const {
+			FASTGLTF_REQUIRE(nodes == other.nodes);
+			return true;
+		}
 	};
 
 	FASTGLTF_EXPORT struct JointLimit {
@@ -2419,6 +2496,16 @@ namespace fastgltf {
 		 * Optional spring damping applied when beyond the limits
 		 */
 		num damping = 0;
+
+		bool operator==(const JointLimit& other) const {
+			FASTGLTF_REQUIRE(linearAxes == other.linearAxes);
+			FASTGLTF_REQUIRE(angularAxes == other.angularAxes);
+			FASTGLTF_REQUIRE(min == other.min);
+			FASTGLTF_REQUIRE(max == other.max);
+			FASTGLTF_REQUIRE(stiffness == other.stiffness);
+			FASTGLTF_REQUIRE(damping == other.damping);
+			return true;
+		}
 	};
 
 	FASTGLTF_EXPORT struct JointDrive {
@@ -2461,6 +2548,18 @@ namespace fastgltf {
          * The damping factor applied to reach the velocity target
          */
         num damping = 0;
+
+		bool operator==(const JointDrive& other) const {
+			FASTGLTF_REQUIRE(type == other.type);
+			FASTGLTF_REQUIRE(mode == other.mode);
+			FASTGLTF_REQUIRE(axis == other.axis);
+			FASTGLTF_REQUIRE(maxForce == other.maxForce);
+			FASTGLTF_REQUIRE(positionTarget == other.positionTarget);
+			FASTGLTF_REQUIRE(velocityTarget == other.velocityTarget);
+			FASTGLTF_REQUIRE(stiffness == other.stiffness);
+			FASTGLTF_REQUIRE(damping == other.damping);
+			return true;
+		}
 	};
 
 	FASTGLTF_EXPORT struct PhysicsJoint {
@@ -2470,6 +2569,12 @@ namespace fastgltf {
          * Each drive specifies a force to apply along a single axis
          */
         FASTGLTF_FG_PMR_NS::MaybeSmallVector<JointDrive> drives;
+
+		bool operator==(const PhysicsJoint& other) const {
+			FASTGLTF_REQUIRE(limits == other.limits);
+			FASTGLTF_REQUIRE(drives == other.drives);
+			return true;
+		}
 	};
 
 	FASTGLTF_EXPORT struct Joint {
@@ -2478,6 +2583,13 @@ namespace fastgltf {
 		std::size_t joint;
 
 		bool enableCollision = false;
+
+		bool operator==(const Joint& other) const {
+			FASTGLTF_REQUIRE(connectedNode == other.connectedNode);
+			FASTGLTF_REQUIRE(joint == other.joint);
+			FASTGLTF_REQUIRE(enableCollision == other.enableCollision);
+			return true;
+		}
 	};
 
     FASTGLTF_EXPORT struct PhysicsRigidBody {
@@ -2488,6 +2600,14 @@ namespace fastgltf {
 		Optional<std::variant<GeometryTrigger, NodeTrigger>> trigger;
 
 		Optional<Joint> joint;
+
+		bool operator==(const PhysicsRigidBody& other) const {
+			FASTGLTF_REQUIRE(motion == other.motion);
+			FASTGLTF_REQUIRE(collider == other.collider);
+			FASTGLTF_REQUIRE(trigger == other.trigger);
+			FASTGLTF_REQUIRE(joint == other.joint);
+			return true;
+		}
 	};
 #endif
 
@@ -3306,6 +3426,7 @@ namespace fastgltf {
 #endif
 
 		bool nonBufferMembersEqual(const Asset& other) const {
+			FASTGLTF_REQUIRE(assetInfo == other.assetInfo);
 			FASTGLTF_REQUIRE(accessors == other.accessors);
 			FASTGLTF_REQUIRE(animations == other.animations);
 			FASTGLTF_REQUIRE(bufferViews == other.bufferViews);
@@ -3321,6 +3442,14 @@ namespace fastgltf {
 			FASTGLTF_REQUIRE(textures == other.textures);
 			FASTGLTF_REQUIRE(materialVariants == other.materialVariants);
 			FASTGLTF_REQUIRE(availableCategories == other.availableCategories);
+			FASTGLTF_REQUIRE(extensionsUsed == other.extensionsUsed);
+			FASTGLTF_REQUIRE(extensionsRequired == other.extensionsRequired);
+			FASTGLTF_REQUIRE(defaultScene == other.defaultScene);
+		#if FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES
+			FASTGLTF_REQUIRE(physicsMaterials == other.physicsMaterials);
+			FASTGLTF_REQUIRE(physicsJoints == other.physicsJoints);
+			FASTGLTF_REQUIRE(collisionFilters == other.collisionFilters);
+		#endif
 			return true;
 		}
 

--- a/include/fastgltf/types.hpp
+++ b/include/fastgltf/types.hpp
@@ -1421,7 +1421,7 @@ namespace fastgltf {
 
 	FASTGLTF_EXPORT template <typename T, typename U>
 	bool operator==(const OptionalWithFlagValue<T>& lhs, const OptionalWithFlagValue<U>& rhs) {
-		return bool(lhs) == bool(rhs) && !bool(lhs) && *lhs == *rhs;
+		return bool(lhs) == bool(rhs) && (!bool(lhs) || *lhs == *rhs);
 	}
 
 	FASTGLTF_EXPORT template <typename T, typename U>

--- a/include/fastgltf/types.hpp
+++ b/include/fastgltf/types.hpp
@@ -704,14 +704,15 @@ namespace fastgltf {
 
         bool operator==(const StaticVector<value_type>& other) const {
         	FASTGLTF_REQUIRE(other.size() == size());
-        	FASTGLTF_REQUIRE(std::memcmp(data(), other.data(), size_bytes()) == 0);
+        	// FASTGLTF_REQUIRE(std::memcmp(data(), other.data(), size_bytes()) == 0);
+			FASTGLTF_REQUIRE(std::equal(begin(), end(), other.begin()));
         	return true;
         }
 
         // This is mostly just here for compatibility and the tests
         bool operator==(const std::vector<value_type>& other) const {
             FASTGLTF_REQUIRE(other.size() == size());
-            FASTGLTF_REQUIRE(std::memcmp(data(), other.data(), size_bytes()) == 0);
+			FASTGLTF_REQUIRE(std::equal(begin(), end(), other.begin()));
         	return true;
         }
     };
@@ -1066,10 +1067,9 @@ namespace fastgltf {
         }
 
 		bool operator==(const SmallVector& other) const {
-			if (size() != other.size()) {
-				return false;
-			}
-			return std::equal(begin(), end(), other.begin(), other.end());
+			FASTGLTF_REQUIRE(size() == other.size());
+			FASTGLTF_REQUIRE(std::equal(begin(), end(), other.begin(), other.end()));
+			return true;
 		}
     };
 
@@ -1701,13 +1701,9 @@ namespace fastgltf {
 			FASTGLTF_REQUIRE(dataType == other.dataType);
 			FASTGLTF_REQUIRE(len == other.len);
 			if (dataType == BoundsType::int64) {
-				for (std::size_t i = 0; i < len; ++i) {
-					FASTGLTF_REQUIRE(int64_buffer.get()[i] == other.int64_buffer.get()[i]);
-				}
+				FASTGLTF_REQUIRE(std::equal(int64_buffer.get(), int64_buffer.get() + len, other.int64_buffer.get()));
 			} else {
-				for (std::size_t i = 0; i < len; ++i) {
-					FASTGLTF_REQUIRE(float64_buffer.get()[i] == other.float64_buffer.get()[i]);
-				}
+				FASTGLTF_REQUIRE(std::equal(float64_buffer.get(), float64_buffer.get() + len, other.float64_buffer.get()));
 			}
 			return true;
 		}
@@ -1814,13 +1810,6 @@ namespace fastgltf {
 		constexpr span(const span& other) noexcept = default;
 		constexpr span& operator=(const span& other) = default;
 
-		constexpr bool operator==(const span& other) const {
-			if (_size != other._size) {
-				return false;
-			}
-			return std::equal(data(), data() + _size, other.data());
-		}
-
 		[[nodiscard]] constexpr iterator begin() const noexcept {
 			return data();
 		}
@@ -1892,6 +1881,15 @@ namespace fastgltf {
 
     FASTGLTF_EXPORT using CustomBufferId = std::uint64_t;
 
+	template <typename T>
+	constexpr bool span_equals(const span<T>& first, const span<T>& other) {
+		if (first.size() != other.size()) {
+			return false;
+		}
+		return std::equal(first.data(), first.data() + first.size(), other.data());
+	}
+
+
     /**
      * Namespace for structs that describe individual sources of data for images and/or buffers.
      */
@@ -1954,7 +1952,7 @@ namespace fastgltf {
             span<const std::byte> bytes;
             MimeType mimeType = MimeType::None;
 			bool operator==(const ByteView& other) const {
-				FASTGLTF_REQUIRE(bytes == other.bytes);
+				FASTGLTF_REQUIRE(span_equals(bytes, other.bytes));
 				FASTGLTF_REQUIRE(mimeType == other.mimeType);
 				return true;
 			}
@@ -3307,24 +3305,24 @@ namespace fastgltf {
 		std::shared_ptr<std::pmr::monotonic_buffer_resource> memoryResource;
 #endif
 
-	bool nonBufferMembersEqual(const Asset& other) const {
-		FASTGLTF_REQUIRE(accessors == other.accessors);
-		FASTGLTF_REQUIRE(animations == other.animations);
-		FASTGLTF_REQUIRE(bufferViews == other.bufferViews);
-		FASTGLTF_REQUIRE(cameras == other.cameras);
-		FASTGLTF_REQUIRE(images == other.images);
-		FASTGLTF_REQUIRE(lights == other.lights);
-		FASTGLTF_REQUIRE(materials == other.materials);
-		FASTGLTF_REQUIRE(meshes == other.meshes);
-		FASTGLTF_REQUIRE(nodes == other.nodes);
-		FASTGLTF_REQUIRE(samplers == other.samplers);
-		FASTGLTF_REQUIRE(scenes == other.scenes);
-		FASTGLTF_REQUIRE(skins == other.skins);	
-		FASTGLTF_REQUIRE(textures == other.textures);
-		FASTGLTF_REQUIRE(materialVariants == other.materialVariants);
-		FASTGLTF_REQUIRE(availableCategories == other.availableCategories);
-		return true;
-	}
+		bool nonBufferMembersEqual(const Asset& other) const {
+			FASTGLTF_REQUIRE(accessors == other.accessors);
+			FASTGLTF_REQUIRE(animations == other.animations);
+			FASTGLTF_REQUIRE(bufferViews == other.bufferViews);
+			FASTGLTF_REQUIRE(cameras == other.cameras);
+			FASTGLTF_REQUIRE(images == other.images);
+			FASTGLTF_REQUIRE(lights == other.lights);
+			FASTGLTF_REQUIRE(materials == other.materials);
+			FASTGLTF_REQUIRE(meshes == other.meshes);
+			FASTGLTF_REQUIRE(nodes == other.nodes);
+			FASTGLTF_REQUIRE(samplers == other.samplers);
+			FASTGLTF_REQUIRE(scenes == other.scenes);
+			FASTGLTF_REQUIRE(skins == other.skins);	
+			FASTGLTF_REQUIRE(textures == other.textures);
+			FASTGLTF_REQUIRE(materialVariants == other.materialVariants);
+			FASTGLTF_REQUIRE(availableCategories == other.availableCategories);
+			return true;
+		}
 
 	public:
         /**

--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -1012,6 +1012,8 @@ fg::Error fg::validate(const fastgltf::Asset& asset) {
 		if (animation.channels.empty())
 			return Error::InvalidGltf;
 		for (const auto& channel1 : animation.channels) {
+			if (!channel1.nodeIndex.has_value())
+				continue;
 			for (const auto& channel2 : animation.channels) {
 				if (&channel1 == &channel2)
 					continue;

--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -5852,7 +5852,7 @@ void fg::Exporter::writeMaterials(const Asset& asset, std::string& json) {
 
 		if (it->packedOcclusionRoughnessMetallicTextures) {
 			if (json.back() == '}') json += ',';
-			json += R"("MSFT_packing_normalRoughnessMetallic":{)";
+			json += R"("MSFT_packing_occlusionRoughnessMetallic":{)";
 			if (it->packedOcclusionRoughnessMetallicTextures->occlusionRoughnessMetallicTexture.has_value()) {
 				json += R"("occlusionRoughnessMetallicTexture":)";
 				writeTextureInfo(json, &it->packedOcclusionRoughnessMetallicTextures->occlusionRoughnessMetallicTexture.value());

--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -5833,6 +5833,23 @@ void fg::Exporter::writeMeshes(const Asset& asset, std::string& json) {
                     json += R"(,"material":)" + std::to_string(itp->materialIndex.value());
                 }
 
+            	if (!itp->targets.empty())
+            	{
+            		json  += R"(,"targets":[)";
+            		for (auto itt = itp->targets.begin(); itt != itp->targets.end(); ++itt) {
+						json += '{';
+						for (auto ita = itt->begin(); ita != itt->end(); ++ita) {
+							json += '"' + std::string(ita->name) + "\":" + std::to_string(ita->accessorIndex);
+							if (uabs(std::distance(itt->begin(), ita)) + 1 < itt->size())
+								json += ',';
+						}
+						json += '}';
+						if (uabs(std::distance(itp->targets.begin(), itt)) + 1 < itp->targets.size())
+							json += ',';
+					}
+            		json += ']';
+            	}
+
                 if (itp->type != PrimitiveType::Triangles) {
                     json += R"(,"mode":)" + std::to_string(to_underlying(itp->type));
                 }

--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -6754,14 +6754,16 @@ void fg::Exporter::writeExtensions(const fastgltf::Asset& asset, std::string& js
 #endif
 
 #if FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES
-	if (json.back() == ']' || json.back() == '}') {
-		json += ',';
-	}
-	json += R"("KHR_physics_rigid_bodies":{)";
-	writePhysicsMaterials(asset, json);
-	writeCollisionFilters(asset, json);
-    writePhysicsJoints(asset, json);
-	json += '}';
+	if (!asset.physicsMaterials.empty() || !asset.collisionFilters.empty() || !asset.physicsJoints.empty()) {
+		if (json.back() == ']' || json.back() == '}') {
+			json += ',';
+		}
+        json += R"("KHR_physics_rigid_bodies":{)";
+        writePhysicsMaterials(asset, json);
+        writeCollisionFilters(asset, json);
+        writePhysicsJoints(asset, json);
+        json += '}';
+    }
 #endif
 
 	if (!asset.materialVariants.empty()) {

--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -4937,6 +4937,12 @@ namespace fastgltf {
 		auto* end = simdjson::internal::to_chars(std::begin(buffer), std::end(buffer), value);
 		return {std::begin(buffer), end};
 	}
+	
+	std::string to_string_fp_double(const double& value) {
+		char buffer[30] = {};
+		auto* end = simdjson::internal::to_chars(std::begin(buffer), std::end(buffer), value);
+		return {std::begin(buffer), end};
+	}
 
     std::string to_string(const math::fvec2 value) {
 		return to_string_fp(value[0]) + ',' + to_string_fp(value[1]);
@@ -5048,7 +5054,7 @@ void fg::Exporter::writeAccessors(const Asset& asset, std::string& json) {
 
 			for (std::size_t i = 0; i < ref->size(); ++i) {
 				if (ref->isType<double>()) {
-					json += to_string_fp(static_cast<num>(ref->get<double>(i)));
+					json += to_string_fp_double(ref->get<double>(i));
 				} else if (ref->isType<std::int64_t>()) {
 					json += std::to_string(ref->get<std::int64_t>(i));
 				}

--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -5707,6 +5707,42 @@ void fg::Exporter::writeMaterials(const Asset& asset, std::string& json) {
 			}
 			json += '}';
 		}
+#if FASTGLTF_ENABLE_DEPRECATED_EXT
+		if (it->specularGlossiness)
+		{
+			if (json.back() == '}') json += ',';
+			json += R"("KHR_materials_pbrSpecularGlossiness":{)";
+			if (it->specularGlossiness->diffuseFactor != math::nvec4(1)) {
+				json += R"("diffuseFactor":[)" +
+						to_string_fp(it->specularGlossiness->diffuseFactor[0]) + ',' +
+						to_string_fp(it->specularGlossiness->diffuseFactor[1]) + ',' +
+						to_string_fp(it->specularGlossiness->diffuseFactor[2]) + ',' +
+						to_string_fp(it->specularGlossiness->diffuseFactor[3]) + ']';
+			}
+			if (it->specularGlossiness->diffuseTexture.has_value()) {
+				if (json.back() != '{') json += ',';
+				json += "\"diffuseTexture\":";
+				writeTextureInfo(json, &it->specularGlossiness->diffuseTexture.value());
+			}
+			if (it->specularGlossiness->specularFactor != math::nvec3(1)) {
+				if (json.back() != '{') json += ',';
+				json += R"("specularFactor":[)" +
+						to_string_fp(it->specularGlossiness->specularFactor[0]) + ',' +
+						to_string_fp(it->specularGlossiness->specularFactor[1]) + ',' +
+						to_string_fp(it->specularGlossiness->specularFactor[2]) + ']';
+			}
+			if (it->specularGlossiness->glossinessFactor != 1.0) {
+				if (json.back() != '{') json += ',';
+				json += R"("glossinessFactor":)" + to_string_fp(it->specularGlossiness->glossinessFactor);
+			}
+			if (it->specularGlossiness->specularGlossinessTexture.has_value()) {
+				if (json.back() != '{') json += ',';
+				json += "\"specularGlossinessTexture\":";
+				writeTextureInfo(json, &it->specularGlossiness->specularGlossinessTexture.value());
+			}
+			json += '}';
+		}
+#endif
 
 		if (it->transmission) {
 			if (json.back() == '}') json += ',';

--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -665,6 +665,11 @@ bool fg::URI::isLocalPath() const noexcept {
 bool fg::URI::isDataUri() const noexcept {
 	return view.isDataUri();
 }
+
+bool fg::URI::operator==(const URI& other) const {
+	FASTGLTF_REQUIRE(view.string() == other.view.string());
+	return true;
+}
 #pragma endregion
 
 #pragma region glTF parsing

--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -2562,7 +2562,7 @@ fg::Error fg::Parser::parseLights(simdjson::dom::array& lights, Asset& asset) {
         if (lightObject["intensity"].get_double().get(intensity) == SUCCESS) FASTGLTF_LIKELY {
             light.intensity = static_cast<num>(intensity);
         } else {
-            light.intensity = 0.0f;
+            light.intensity = 1.0f;
         }
 
         double range;

--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -24,6 +24,7 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include "fastgltf/types.hpp"
 #if !defined(__cplusplus) || (!defined(_MSVC_LANG) && __cplusplus < 201703L) || (defined(_MSVC_LANG) && _MSVC_LANG < 201703L)
 #error "fastgltf requires C++17"
 #endif
@@ -5050,6 +5051,28 @@ void fg::Exporter::writeAccessors(const Asset& asset, std::string& json) {
 
 		if (it->bufferViewIndex.has_value()) {
 			json += ",\"bufferView\":" + std::to_string(it->bufferViewIndex.value());
+		}
+
+		if (it->sparse.has_value())
+		{
+			json += R"(,"sparse":{)";
+			const auto& sparse = *it->sparse;
+			json += "\"count\":" + std::to_string(sparse.count) + ',';
+			json += "\"indices\":{";
+			json += "\"bufferView\":" + std::to_string(sparse.indicesBufferView) + ',';
+			if (sparse.indicesByteOffset != 0) {
+				json += "\"byteOffset\":" + std::to_string(sparse.indicesByteOffset) + ',';
+			}
+			// only get the lower 13 bits
+			uint16_t componentType = static_cast<uint16_t>(sparse.indexComponentType) & 0x1FFF;
+			json += "\"componentType\":" + std::to_string(componentType);
+			json += "},";
+			json += "\"values\":{";
+			json += "\"bufferView\":" + std::to_string(sparse.valuesBufferView);
+			if (sparse.valuesByteOffset != 0) {
+				json += ",\"byteOffset\":" + std::to_string(sparse.valuesByteOffset);
+			}
+			json += "}}";
 		}
 
 		auto writeMinMax = [&](const std::optional<AccessorBoundsArray>& ref, const std::string_view name) {

--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -5429,7 +5429,7 @@ void fg::Exporter::writeLights(const Asset& asset, std::string& json) {
 		json += '{';
 
 		// [1.0f, 1.0f, 1.0f] is the default.
-		if (it->color[0] != 1.0f && it->color[1] != 1.0f && it->color[2] != 1.0f) {
+		if (!(it->color[0] == 1.0f && it->color[1] == 1.0f && it->color[2] == 1.0f)) {
 			json += R"("color":[)";
 			json += to_string_fp(it->color[0]) + ',' + to_string_fp(it->color[1]) + ',' + to_string_fp(it->color[2]);
 			json += "],";

--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -5890,8 +5890,12 @@ void fg::Exporter::writeMeshes(const Asset& asset, std::string& json) {
                     json += R"(,"mode":)" + std::to_string(to_underlying(itp->type));
                 }
 
+            	const bool has_extensions = !itp->mappings.empty() || itp->dracoCompression;
+            	if (has_extensions) {
+            		json += R"(,"extensions":{)";
+            	}
 				if (!itp->mappings.empty()) {
-					json += R"(,"extensions":{"KHR_materials_variants":{"mappings":[)";
+					json += R"("KHR_materials_variants":{"mappings":[)";
 					// TODO: We should optimise to avoid writing multiple objects for the same material index
 					for (std::size_t i = 0; i < asset.materialVariants.size(); ++i) {
 						if (!itp->mappings[i].has_value())
@@ -5900,8 +5904,28 @@ void fg::Exporter::writeMeshes(const Asset& asset, std::string& json) {
 							json += ',';
 						json += "{\"material\":" + std::to_string(itp->mappings[i].value()) + ",\"variants\":[" + std::to_string(i) + "]}";
 					}
-					json += "]}}";
+					json += "]}";
 				}
+            	if (itp->dracoCompression)
+            	{
+            		if (!itp->mappings.empty())
+						json += ',';
+            		
+            		json += R"("KHR_draco_mesh_compression":{)";
+            		json += R"("bufferView":)" + std::to_string(itp->dracoCompression->bufferView) + ',';
+            		json += R"("attributes":{)";
+            		for (auto ita = itp->dracoCompression->attributes.begin(); ita != itp->dracoCompression->attributes.end(); ++ita) {
+						json += '"' + std::string(ita->name) + "\":" + std::to_string(ita->accessorIndex);
+						if (uabs(std::distance(itp->dracoCompression->attributes.begin(), ita)) + 1 < itp->dracoCompression->attributes.size())
+							json += ',';
+					}
+            		json += "}}";
+            	}
+            	if (has_extensions)
+            	{
+            		json += "}";
+            	}
+
 
                 json += '}';
                 ++itp;

--- a/tests/gltf_path.hpp
+++ b/tests/gltf_path.hpp
@@ -6,5 +6,6 @@
 inline auto path = std::filesystem::path { __FILE__ }.parent_path() / "gltf";
 inline auto sampleAssets = std::filesystem::path { __FILE__ }.parent_path() / "gltf" / "glTF-Sample-Assets";
 inline auto physicsSampleAssets = std::filesystem::path{ __FILE__ }.parent_path() / "gltf" / "glTF_Physics";
+inline auto gltfValidator = std::filesystem::path { __FILE__ }.parent_path() / "gltf" / "gltf_validator" / "gltf_validator";
 inline auto intelSponza = std::filesystem::path { __FILE__ }.parent_path() / "gltf" / "intel_sponza";
 inline auto bistroPath = std::filesystem::path { __FILE__ }.parent_path() / "gltf" / "bistro";

--- a/tests/write_tests.cpp
+++ b/tests/write_tests.cpp
@@ -103,7 +103,7 @@ TEST_CASE("Try writing a glTF with all buffers and images", "[write-tests]") {
 }
 
 static bool run_official_gltf_validator(const std::filesystem::path &model_path) {
-	static constexpr const char * path_to_validator = "/Users/nikita/Downloads/gltf_validator-2.0.0-dev.3.10-macos64/gltf_validator";
+	static constexpr const char * path_to_validator = "/Users/nikita/Downloads/gltf_validator_macos/gltf_validator";
 
 	// run the validator on the model
 	std::string command = std::string(path_to_validator) + " -m " + model_path.string();
@@ -114,39 +114,552 @@ static bool run_official_gltf_validator(const std::filesystem::path &model_path)
 	return true;
 }
 
+// template<typename T>
+bool isABASame(const fastgltf::AccessorBoundsArray& a, const fastgltf::AccessorBoundsArray& b) {
+	// static_assert(std::is_same_v<T, fastgltf::AccessorBoundsArray> || std::is_same_v<T, fastgltf::AccessorBoundsArray>);
+	REQUIRE(a.type() == b.type());
+	for (std::size_t i = 0; i < a.size(); ++i) {
+		if (a.type() == fastgltf::AccessorBoundsArray::BoundsType::float64) {
+			REQUIRE (a.get<double>(i) == b.get<double>(i));
+		} else {
+			REQUIRE (a.get<int64_t>(i) == b.get<int64_t>(i));
+		}
+	}
+	return true;
+}
+
+template<typename T>
+bool isArraySame(const T& a, const T& b, std::size_t minSize = -1) {
+	if (minSize == -1) {
+		REQUIRE(a.size() == b.size());
+		minSize = a.size();
+	} else {
+		REQUIRE(minSize <= a.size());
+		REQUIRE(minSize <= b.size());
+	}
+	for (std::size_t i = 0; i < minSize; ++i) {
+		REQUIRE (a[i] == b[i]);
+	}
+	return true;
+}
+
+bool isDataSourceSame(const fastgltf::DataSource& a, const fastgltf::DataSource& b, size_t minSize = -1) {
+	//    FASTGLTF_EXPORT using DataSource = std::variant<std::monostate, sources::BufferView, sources::URI, sources::Array, sources::Vector, sources::CustomBuffer, sources::ByteView, sources::Fallback>;
+
+	if (std::holds_alternative<std::monostate>(a)) {
+		if (!std::holds_alternative<std::monostate>(b)) {
+			return false;
+		}
+		return true;
+	} else if (std::holds_alternative<fastgltf::sources::BufferView>(a)) {
+		if (!std::holds_alternative<fastgltf::sources::BufferView>(b)) {
+			return false;
+		}
+		auto a_bv = std::get<fastgltf::sources::BufferView>(a);
+		auto b_bv = std::get<fastgltf::sources::BufferView>(b);
+		return a_bv.bufferViewIndex == b_bv.bufferViewIndex && a_bv.mimeType == b_bv.mimeType;
+	} else if (std::holds_alternative<fastgltf::sources::URI>(a)) {
+		if (!std::holds_alternative<fastgltf::sources::URI>(b)) {
+			return false;
+		}
+		auto a_uri = std::get<fastgltf::sources::URI>(a);
+		auto b_uri = std::get<fastgltf::sources::URI>(b);
+		return a_uri.uri.string() == b_uri.uri.string();
+	} else if (std::holds_alternative<fastgltf::sources::Array>(a)) {
+		if (!std::holds_alternative<fastgltf::sources::Array>(b)) {
+			return false;
+		}
+		auto a_array = std::get<fastgltf::sources::Array>(a);
+		auto b_array = std::get<fastgltf::sources::Array>(b);
+		return a_array.mimeType == b_array.mimeType && isArraySame(a_array.bytes, b_array.bytes, minSize);
+	} else if (std::holds_alternative<fastgltf::sources::Vector>(a)) {
+		if (!std::holds_alternative<fastgltf::sources::Vector>(b)) {
+			return false;
+		}
+		auto a_vector = std::get<fastgltf::sources::Vector>(a);
+		auto b_vector = std::get<fastgltf::sources::Vector>(b);
+		return a_vector.mimeType == b_vector.mimeType && isArraySame(a_vector.bytes, b_vector.bytes, minSize);
+	} else if (std::holds_alternative<fastgltf::sources::CustomBuffer>(a)) {
+		if (!std::holds_alternative<fastgltf::sources::CustomBuffer>(b)) {
+			return false;
+		}
+		auto a_custom_buffer = std::get<fastgltf::sources::CustomBuffer>(a);
+		auto b_custom_buffer = std::get<fastgltf::sources::CustomBuffer>(b);
+		return a_custom_buffer.mimeType == b_custom_buffer.mimeType && b_custom_buffer.id == a_custom_buffer.id;
+	} else if (std::holds_alternative<fastgltf::sources::ByteView>(a)) {
+		if (!std::holds_alternative<fastgltf::sources::ByteView>(b)) {
+			return false;
+		}
+		auto a_byte_view = std::get<fastgltf::sources::ByteView>(a);
+		auto b_byte_view = std::get<fastgltf::sources::ByteView>(b);
+		return a_byte_view.mimeType == b_byte_view.mimeType && isArraySame(a_byte_view.bytes, b_byte_view.bytes, minSize);
+	} else if (std::holds_alternative<fastgltf::sources::Fallback>(a)) {
+		if (!std::holds_alternative<fastgltf::sources::Fallback>(b)) {
+			return false;
+		}
+		return true;
+	}
+	return false;
+}
+
+
+static bool compare_TextureInfo(const fastgltf::TextureInfo& a, const fastgltf::TextureInfo& b) {
+	REQUIRE (a.textureIndex == b.textureIndex);
+	REQUIRE (a.texCoordIndex == b.texCoordIndex);
+	if (a.transform) {
+		REQUIRE (a.transform->uvOffset == b.transform->uvOffset);
+		REQUIRE (a.transform->uvScale == b.transform->uvScale);
+		REQUIRE (a.transform->rotation == b.transform->rotation);
+		REQUIRE (a.transform->texCoordIndex == b.transform->texCoordIndex);
+	}
+	return true;
+}
+
+static bool compare_OptionalTextureInfo(const fastgltf::Optional<fastgltf::TextureInfo>& a, const fastgltf::Optional<fastgltf::TextureInfo>& b) {
+	if (a.has_value() != b.has_value()) {
+		return false;
+	}
+	if (!a.has_value()) {
+		return true;
+	}
+	REQUIRE (compare_TextureInfo(a.value(), b.value()));
+	return true;
+}
+
+static bool compare_vector_attributes(const FASTGLTF_STD_PMR_NS::vector<fastgltf::Attribute>& a, const FASTGLTF_STD_PMR_NS::vector<fastgltf::Attribute>& b) {
+	REQUIRE (a.size() == b.size());
+	for (std::size_t i = 0; i < a.size(); ++i) {
+		REQUIRE (a[i].accessorIndex == b[i].accessorIndex);
+		REQUIRE (a[i].name == b[i].name);
+	}
+	return true;
+}
+
+static bool compare_vector_attributes(const fastgltf::SmallVector<fastgltf::Attribute, 4, std::pmr::polymorphic_allocator<fastgltf::Attribute>>& a, const fastgltf::SmallVector<fastgltf::Attribute, 4, std::pmr::polymorphic_allocator<fastgltf::Attribute>>& b) {
+	REQUIRE (a.size() == b.size());
+	for (std::size_t i = 0; i < a.size(); ++i) {
+		REQUIRE (a[i].accessorIndex == b[i].accessorIndex);
+		REQUIRE (a[i].name == b[i].name);
+	}
+	return true;
+}
+
+// change the if... return false to REQUIRE
+static bool isSame(const fastgltf::Asset& asset1, const fastgltf::Asset& asset2) {
+	// assetInfo
+	REQUIRE (asset1.assetInfo->gltfVersion == asset2.assetInfo->gltfVersion);
+	REQUIRE (asset1.assetInfo->generator == asset2.assetInfo->generator);
+	REQUIRE (asset1.assetInfo->copyright == asset2.assetInfo->copyright);
+	// extensionsUsed
+	REQUIRE (asset1.extensionsUsed.size() == asset2.extensionsUsed.size());
+	for (std::size_t j = 0; j < asset1.extensionsUsed.size(); ++j) {
+		REQUIRE (asset1.extensionsUsed[j] == asset2.extensionsUsed[j]);
+	}
+	// extensionsRequired
+	REQUIRE (asset1.extensionsRequired.size() == asset2.extensionsRequired.size())	;
+	for (std::size_t j = 0; j < asset1.extensionsRequired.size(); ++j) {
+		REQUIRE (asset1.extensionsRequired[j] == asset2.extensionsRequired[j]);
+	}
+	// defaultScene
+	REQUIRE (asset1.defaultScene == asset2.defaultScene);
+	// accessors
+	REQUIRE (asset1.accessors.size() == asset2.accessors.size());
+	for (std::size_t j = 0; j < asset1.accessors.size(); ++j) {
+		auto& accessor1 = asset1.accessors[j];
+		auto& accessor2 = asset2.accessors[j];
+		REQUIRE (accessor1.byteOffset == accessor2.byteOffset);
+		REQUIRE (accessor1.count == accessor2.count);
+		REQUIRE (accessor1.type == accessor2.type);
+		REQUIRE (accessor1.componentType == accessor2.componentType);
+		REQUIRE (accessor1.normalized == accessor2.normalized);
+		REQUIRE (accessor1.bufferViewIndex == accessor2.bufferViewIndex);
+		REQUIRE (accessor1.min.has_value() == accessor2.min.has_value());
+		REQUIRE (accessor1.max.has_value() == accessor2.max.has_value());
+		if (accessor1.min.has_value()) {
+			REQUIRE (isABASame(accessor1.min.value(), accessor2.min.value()));
+		}
+		if (accessor1.max.has_value()) {
+			REQUIRE (isABASame(accessor1.max.value(), accessor2.max.value()));
+		}
+		REQUIRE (accessor1.sparse.has_value() == accessor2.sparse.has_value());
+		if (accessor1.sparse.has_value()) {
+			REQUIRE (accessor1.sparse->count == accessor2.sparse->count);
+			REQUIRE (accessor1.sparse->indicesBufferView == accessor2.sparse->indicesBufferView);
+			REQUIRE (accessor1.sparse->indicesByteOffset == accessor2.sparse->indicesByteOffset);
+			REQUIRE (accessor1.sparse->valuesBufferView == accessor2.sparse->valuesBufferView);
+			REQUIRE (accessor1.sparse->valuesByteOffset == accessor2.sparse->valuesByteOffset);
+			REQUIRE (accessor1.sparse->indexComponentType == accessor2.sparse->indexComponentType);
+		}
+		REQUIRE(accessor1.name == accessor2.name);
+	}
+	// animations
+	REQUIRE (asset1.animations.size() == asset2.animations.size());
+	for (std::size_t j = 0; j < asset1.animations.size(); ++j) {
+		auto& animation1 = asset1.animations[j];
+		auto& animation2 = asset2.animations[j];
+		REQUIRE (animation1.name == animation2.name);
+		REQUIRE (animation1.channels.size() == animation2.channels.size());
+		for (std::size_t k = 0; k < animation1.channels.size(); ++k) {
+			auto& channel1 = animation1.channels[k];
+			auto& channel2 = animation2.channels[k];
+			REQUIRE (channel1.samplerIndex == channel2.samplerIndex);
+			REQUIRE (channel1.nodeIndex == channel2.nodeIndex);
+			REQUIRE (channel1.path == channel2.path);
+		}
+		REQUIRE (animation1.samplers.size() == animation2.samplers.size());
+		for (std::size_t k = 0; k < animation1.samplers.size(); ++k) {
+			auto& sampler1 = animation1.samplers[k];
+			auto& sampler2 = animation2.samplers[k];
+			REQUIRE (sampler1.inputAccessor == sampler2.inputAccessor);
+			REQUIRE (sampler1.interpolation == sampler2.interpolation);
+			REQUIRE (sampler1.outputAccessor == sampler2.outputAccessor);
+		}
+	}
+	// buffers
+	REQUIRE (asset1.buffers.size() == asset2.buffers.size());
+	for (std::size_t j = 0; j < asset1.buffers.size(); ++j) {
+		// buffer may be different size because it wasn't aligned properly before
+		REQUIRE (fastgltf::alignUp(asset1.buffers[j].byteLength, 4) == fastgltf::alignUp(asset2.buffers[j].byteLength, 4));
+		REQUIRE (asset1.buffers[j].name == asset2.buffers[j].name);
+		auto minSize = std::min(asset1.buffers[j].byteLength, asset2.buffers[j].byteLength);
+		REQUIRE (isDataSourceSame(asset1.buffers[j].data, asset2.buffers[j].data, minSize));
+	}
+
+	// bufferViews
+	REQUIRE (asset1.bufferViews.size() == asset2.bufferViews.size());
+	for (std::size_t j = 0; j < asset1.bufferViews.size(); ++j) {
+		REQUIRE (asset1.bufferViews[j].bufferIndex == asset2.bufferViews[j].bufferIndex);
+		REQUIRE (asset1.bufferViews[j].byteOffset == asset2.bufferViews[j].byteOffset);
+		REQUIRE (asset1.bufferViews[j].byteLength == asset2.bufferViews[j].byteLength);
+		REQUIRE (asset1.bufferViews[j].byteStride == asset2.bufferViews[j].byteStride);
+		REQUIRE (asset1.bufferViews[j].target == asset2.bufferViews[j].target);
+		REQUIRE (!asset1.bufferViews[j].meshoptCompression == !asset2.bufferViews[j].meshoptCompression);
+		if (asset1.bufferViews[j].meshoptCompression) {
+			REQUIRE (asset1.bufferViews[j].meshoptCompression->bufferIndex == asset2.bufferViews[j].meshoptCompression->bufferIndex);
+			REQUIRE (asset1.bufferViews[j].meshoptCompression->byteOffset == asset2.bufferViews[j].meshoptCompression->byteOffset);
+			REQUIRE (asset1.bufferViews[j].meshoptCompression->byteLength == asset2.bufferViews[j].meshoptCompression->byteLength);
+			REQUIRE (asset1.bufferViews[j].meshoptCompression->count == asset2.bufferViews[j].meshoptCompression->count);
+			REQUIRE (asset1.bufferViews[j].meshoptCompression->mode == asset2.bufferViews[j].meshoptCompression->mode);
+			REQUIRE (asset1.bufferViews[j].meshoptCompression->filter == asset2.bufferViews[j].meshoptCompression->filter);
+			REQUIRE (asset1.bufferViews[j].meshoptCompression->byteStride == asset2.bufferViews[j].meshoptCompression->byteStride);
+		}
+	}
+
+	// cameras
+	REQUIRE (asset1.cameras.size() == asset2.cameras.size());
+	for (std::size_t j = 0; j < asset1.cameras.size(); ++j) {
+		REQUIRE (asset1.cameras[j].name == asset2.cameras[j].name);
+		if (std::holds_alternative<fastgltf::Camera::Perspective>(asset1.cameras[j].camera)) {
+			auto camera1 = std::get_if<fastgltf::Camera::Perspective>(&asset1.cameras[j].camera);
+			auto camera2 = std::get_if<fastgltf::Camera::Perspective>(&asset2.cameras[j].camera);
+			REQUIRE (camera1->aspectRatio == camera2->aspectRatio);
+			REQUIRE (camera1->yfov == camera2->yfov);
+			REQUIRE (camera1->znear == camera2->znear);
+			REQUIRE (camera1->zfar == camera2->zfar);
+		} else if (std::holds_alternative<fastgltf::Camera::Orthographic>(asset1.cameras[j].camera)) {
+			auto camera1 = std::get_if<fastgltf::Camera::Orthographic>(&asset1.cameras[j].camera);
+			auto camera2 = std::get_if<fastgltf::Camera::Orthographic>(&asset2.cameras[j].camera);
+			REQUIRE (camera1->xmag == camera2->xmag);
+			REQUIRE (camera1->ymag == camera2->ymag);
+			REQUIRE (camera1->znear == camera2->znear);
+			REQUIRE (camera1->zfar == camera2->zfar);
+		}
+	}
+
+	// images
+	REQUIRE (asset1.images.size() == asset2.images.size());
+	for (std::size_t j = 0; j < asset1.images.size(); ++j) {
+		REQUIRE (asset1.images[j].name == asset2.images[j].name);
+		REQUIRE (isDataSourceSame(asset1.images[j].data, asset2.images[j].data));
+	}
+
+	// lights
+	REQUIRE (asset1.lights.size() == asset2.lights.size());
+	for (std::size_t j = 0; j < asset1.lights.size(); ++j) {
+		REQUIRE (asset1.lights[j].type == asset2.lights[j].type);
+		REQUIRE (asset1.lights[j].color.x() == asset2.lights[j].color.x());
+		REQUIRE (asset1.lights[j].color.y() == asset2.lights[j].color.y());
+		REQUIRE (asset1.lights[j].color.z() == asset2.lights[j].color.z());
+		REQUIRE (asset1.lights[j].intensity == asset2.lights[j].intensity);
+		REQUIRE (asset1.lights[j].range == asset2.lights[j].range);
+		REQUIRE (asset1.lights[j].innerConeAngle == asset2.lights[j].innerConeAngle);
+		REQUIRE (asset1.lights[j].outerConeAngle == asset2.lights[j].outerConeAngle);
+		REQUIRE (asset1.lights[j].name == asset2.lights[j].name);
+	}
+	// materials
+	REQUIRE (asset1.materials.size() == asset2.materials.size());
+	for (std::size_t j = 0; j < asset1.materials.size(); ++j) {
+		REQUIRE (asset1.materials[j].pbrData.metallicRoughnessTexture.has_value() == asset2.materials[j].pbrData.metallicRoughnessTexture.has_value());
+		if (asset1.materials[j].pbrData.metallicRoughnessTexture.has_value()) {
+			REQUIRE (asset1.materials[j].pbrData.metallicRoughnessTexture.value().textureIndex == asset2.materials[j].pbrData.metallicRoughnessTexture.value().textureIndex);
+			REQUIRE (asset1.materials[j].pbrData.metallicRoughnessTexture.value().texCoordIndex == asset2.materials[j].pbrData.metallicRoughnessTexture.value().texCoordIndex);
+		}
+		REQUIRE (asset1.materials[j].pbrData.metallicFactor == asset2.materials[j].pbrData.metallicFactor);
+		REQUIRE (asset1.materials[j].pbrData.roughnessFactor == asset2.materials[j].pbrData.roughnessFactor);
+		REQUIRE (asset1.materials[j].pbrData.baseColorFactor == asset2.materials[j].pbrData.baseColorFactor);
+		compare_OptionalTextureInfo(asset1.materials[j].pbrData.baseColorTexture, asset2.materials[j].pbrData.baseColorTexture);
+		compare_OptionalTextureInfo(asset1.materials[j].pbrData.metallicRoughnessTexture, asset2.materials[j].pbrData.metallicRoughnessTexture);
+
+		REQUIRE (asset1.materials[j].normalTexture.has_value() == asset2.materials[j].normalTexture.has_value());
+		if (asset1.materials[j].normalTexture.has_value()) {
+			REQUIRE (asset1.materials[j].normalTexture.value().scale == asset2.materials[j].normalTexture.value().scale);
+			compare_TextureInfo(asset1.materials[j].normalTexture.value(), asset2.materials[j].normalTexture.value());
+		}
+		REQUIRE (asset1.materials[j].occlusionTexture.has_value() == asset2.materials[j].occlusionTexture.has_value());
+		if (asset1.materials[j].occlusionTexture.has_value()) {
+			REQUIRE (asset1.materials[j].occlusionTexture.value().strength == asset2.materials[j].occlusionTexture.value().strength);
+			compare_TextureInfo(asset1.materials[j].occlusionTexture.value(), asset2.materials[j].occlusionTexture.value());
+		}
+		compare_OptionalTextureInfo(asset1.materials[j].emissiveTexture, asset2.materials[j].emissiveTexture);
+		//emissiveFactor
+		REQUIRE (asset1.materials[j].emissiveFactor == asset2.materials[j].emissiveFactor);
+		//alphaMode
+		REQUIRE (asset1.materials[j].alphaMode == asset2.materials[j].alphaMode);
+		//doubleSided
+		REQUIRE (asset1.materials[j].doubleSided == asset2.materials[j].doubleSided);
+		//unlit
+		REQUIRE (asset1.materials[j].unlit == asset2.materials[j].unlit);
+		//alphaCutoff
+		REQUIRE (asset1.materials[j].alphaCutoff == asset2.materials[j].alphaCutoff);
+		//emissiveStrength
+		REQUIRE (asset1.materials[j].emissiveStrength == asset2.materials[j].emissiveStrength);
+		//ior
+		REQUIRE (asset1.materials[j].ior == asset2.materials[j].ior);
+		//dispersion
+		REQUIRE (asset1.materials[j].dispersion == asset2.materials[j].dispersion);
+		//anisotropy
+		REQUIRE ((!asset1.materials[j].anisotropy) == (!asset2.materials[j].anisotropy));
+		if (asset1.materials[j].anisotropy) {
+			REQUIRE (asset1.materials[j].anisotropy->anisotropyStrength == asset2.materials[j].anisotropy->anisotropyStrength);
+			REQUIRE (asset1.materials[j].anisotropy->anisotropyRotation == asset2.materials[j].anisotropy->anisotropyRotation);
+			compare_OptionalTextureInfo(asset1.materials[j].anisotropy->anisotropyTexture, asset2.materials[j].anisotropy->anisotropyTexture);
+		}
+		//clearcoat
+		REQUIRE ((!asset1.materials[j].clearcoat) == (!asset2.materials[j].clearcoat));
+		if (asset1.materials[j].clearcoat) {
+			REQUIRE (asset1.materials[j].clearcoat->clearcoatFactor == asset2.materials[j].clearcoat->clearcoatFactor);
+			REQUIRE (asset1.materials[j].clearcoat->clearcoatRoughnessFactor == asset2.materials[j].clearcoat->clearcoatRoughnessFactor);
+			compare_OptionalTextureInfo(asset1.materials[j].clearcoat->clearcoatTexture, asset2.materials[j].clearcoat->clearcoatTexture);
+			compare_OptionalTextureInfo(asset1.materials[j].clearcoat->clearcoatRoughnessTexture, asset2.materials[j].clearcoat->clearcoatRoughnessTexture);
+			REQUIRE (asset1.materials[j].clearcoat->clearcoatNormalTexture.has_value() == asset2.materials[j].clearcoat->clearcoatNormalTexture.has_value());
+			if (asset1.materials[j].clearcoat->clearcoatNormalTexture.has_value()) {
+				REQUIRE (asset1.materials[j].clearcoat->clearcoatNormalTexture.value().scale == asset2.materials[j].clearcoat->clearcoatNormalTexture.value().scale);
+				compare_TextureInfo(asset1.materials[j].clearcoat->clearcoatNormalTexture.value(), asset2.materials[j].clearcoat->clearcoatNormalTexture.value());
+			}
+		}
+		//iridescence
+		REQUIRE ((!asset1.materials[j].iridescence) == (!asset2.materials[j].iridescence));
+		if (asset1.materials[j].iridescence) {
+			REQUIRE (asset1.materials[j].iridescence->iridescenceFactor == asset2.materials[j].iridescence->iridescenceFactor);
+			REQUIRE (asset1.materials[j].iridescence->iridescenceIor == asset2.materials[j].iridescence->iridescenceIor);
+			compare_OptionalTextureInfo(asset1.materials[j].iridescence->iridescenceTexture, asset2.materials[j].iridescence->iridescenceTexture);
+			REQUIRE (asset1.materials[j].iridescence->iridescenceThicknessMinimum == asset2.materials[j].iridescence->iridescenceThicknessMinimum);
+			REQUIRE (asset1.materials[j].iridescence->iridescenceThicknessMaximum == asset2.materials[j].iridescence->iridescenceThicknessMaximum);
+			compare_OptionalTextureInfo(asset1.materials[j].iridescence->iridescenceThicknessTexture, asset2.materials[j].iridescence->iridescenceThicknessTexture);
+		}
+		//sheen
+		REQUIRE ((!asset1.materials[j].sheen) == (!asset2.materials[j].sheen));
+		if (asset1.materials[j].sheen) {
+			REQUIRE (asset1.materials[j].sheen->sheenColorFactor == asset2.materials[j].sheen->sheenColorFactor);
+			compare_OptionalTextureInfo(asset1.materials[j].sheen->sheenColorTexture, asset2.materials[j].sheen->sheenColorTexture);
+			REQUIRE (asset1.materials[j].sheen->sheenRoughnessFactor == asset2.materials[j].sheen->sheenRoughnessFactor);
+			compare_OptionalTextureInfo(asset1.materials[j].sheen->sheenRoughnessTexture, asset2.materials[j].sheen->sheenRoughnessTexture);
+		}
+		//specular
+		REQUIRE ((!asset1.materials[j].specular) == (!asset2.materials[j].specular));
+		if (asset1.materials[j].specular) {
+			REQUIRE (asset1.materials[j].specular->specularFactor == asset2.materials[j].specular->specularFactor);
+			compare_OptionalTextureInfo(asset1.materials[j].specular->specularTexture, asset2.materials[j].specular->specularTexture);
+			REQUIRE(asset1.materials[j].specular->specularColorFactor == asset2.materials[j].specular->specularColorFactor);
+			compare_OptionalTextureInfo(asset1.materials[j].specular->specularColorTexture, asset2.materials[j].specular->specularColorTexture);
+		}
+		//specularGlossiness
+		REQUIRE ((!asset1.materials[j].specularGlossiness) == (!asset2.materials[j].specularGlossiness));
+		if (asset1.materials[j].specularGlossiness) {
+			REQUIRE (asset1.materials[j].specularGlossiness->diffuseFactor == asset2.materials[j].specularGlossiness->diffuseFactor);
+			REQUIRE (asset1.materials[j].specularGlossiness->specularFactor == asset2.materials[j].specularGlossiness->specularFactor);
+			compare_OptionalTextureInfo(asset1.materials[j].specularGlossiness->diffuseTexture, asset2.materials[j].specularGlossiness->diffuseTexture);
+			REQUIRE (asset1.materials[j].specularGlossiness->glossinessFactor == asset2.materials[j].specularGlossiness->glossinessFactor);
+			compare_OptionalTextureInfo(asset1.materials[j].specularGlossiness->specularGlossinessTexture, asset2.materials[j].specularGlossiness->specularGlossinessTexture);
+		}
+		//transmission
+		REQUIRE ((!asset1.materials[j].transmission) == (!asset2.materials[j].transmission));
+		if (asset1.materials[j].transmission) {
+			REQUIRE (asset1.materials[j].transmission->transmissionFactor == asset2.materials[j].transmission->transmissionFactor);
+			compare_OptionalTextureInfo(asset1.materials[j].transmission->transmissionTexture, asset2.materials[j].transmission->transmissionTexture);
+		}
+		//volume
+		REQUIRE ((!asset1.materials[j].volume) == (!asset2.materials[j].volume));
+		if (asset1.materials[j].volume) {
+			REQUIRE(asset1.materials[j].volume->thicknessFactor == asset2.materials[j].volume->thicknessFactor);
+			compare_OptionalTextureInfo(asset1.materials[j].volume->thicknessTexture, asset2.materials[j].volume->thicknessTexture);
+			REQUIRE (asset1.materials[j].volume->attenuationDistance == asset2.materials[j].volume->attenuationDistance);
+			REQUIRE (asset1.materials[j].volume->attenuationColor == asset2.materials[j].volume->attenuationColor);
+		}
+		//packedOcclusionRoughnessMetallicTextures
+		REQUIRE ((!asset1.materials[j].packedOcclusionRoughnessMetallicTextures) == (!asset2.materials[j].packedOcclusionRoughnessMetallicTextures));
+		if (asset1.materials[j].packedOcclusionRoughnessMetallicTextures) {
+			REQUIRE(compare_OptionalTextureInfo(asset1.materials[j].packedOcclusionRoughnessMetallicTextures->occlusionRoughnessMetallicTexture, asset2.materials[j].packedOcclusionRoughnessMetallicTextures->occlusionRoughnessMetallicTexture));
+			REQUIRE(compare_OptionalTextureInfo(asset1.materials[j].packedOcclusionRoughnessMetallicTextures->roughnessMetallicOcclusionTexture, asset2.materials[j].packedOcclusionRoughnessMetallicTextures->roughnessMetallicOcclusionTexture));
+			REQUIRE(compare_OptionalTextureInfo(asset1.materials[j].packedOcclusionRoughnessMetallicTextures->normalTexture, asset2.materials[j].packedOcclusionRoughnessMetallicTextures->normalTexture));
+		}
+		//name
+		REQUIRE (asset1.materials[j].name == asset2.materials[j].name);
+	}
+
+	//meshes
+	REQUIRE (asset1.meshes.size() == asset2.meshes.size());
+	for (std::size_t j = 0; j < asset1.meshes.size(); ++j) {
+		// primitives
+		REQUIRE (asset1.meshes[j].primitives.size() == asset2.meshes[j].primitives.size());
+		for (std::size_t k = 0; k < asset1.meshes[j].primitives.size(); ++k) {
+			REQUIRE (asset1.meshes[j].primitives[k].materialIndex == asset2.meshes[j].primitives[k].materialIndex);
+			REQUIRE(compare_vector_attributes(asset1.meshes[j].primitives[k].attributes, asset2.meshes[j].primitives[k].attributes));
+			REQUIRE(asset1.meshes[j].primitives[k].targets.size() == asset2.meshes[j].primitives[k].targets.size());
+			for (std::size_t l = 0; l < asset1.meshes[j].primitives[k].targets.size(); ++l) {
+				REQUIRE(compare_vector_attributes(asset1.meshes[j].primitives[k].targets[l], asset2.meshes[j].primitives[k].targets[l]));
+			}
+			REQUIRE (asset1.meshes[j].primitives[k].indicesAccessor == asset2.meshes[j].primitives[k].indicesAccessor);
+			REQUIRE (asset1.meshes[j].primitives[k].materialIndex == asset2.meshes[j].primitives[k].materialIndex);
+			REQUIRE (isArraySame(asset1.meshes[j].primitives[k].mappings, asset2.meshes[j].primitives[k].mappings));
+			REQUIRE (asset1.meshes[j].primitives[k].type == asset2.meshes[j].primitives[k].type);
+			REQUIRE ((!asset1.meshes[j].primitives[k].dracoCompression) == (!asset2.meshes[j].primitives[k].dracoCompression));
+			if (asset1.meshes[j].primitives[k].dracoCompression) {
+				REQUIRE (asset1.meshes[j].primitives[k].dracoCompression->bufferView == asset2.meshes[j].primitives[k].dracoCompression->bufferView);
+				REQUIRE(compare_vector_attributes(asset1.meshes[j].primitives[k].dracoCompression->attributes, asset2.meshes[j].primitives[k].dracoCompression->attributes));
+			}
+		}
+		REQUIRE (asset1.meshes[j].name == asset2.meshes[j].name);
+		REQUIRE (isArraySame(asset1.meshes[j].weights, asset2.meshes[j].weights));
+	}
+
+	// nodes
+	REQUIRE (asset1.nodes.size() == asset2.nodes.size());
+	for (std::size_t j = 0; j < asset1.nodes.size(); ++j) {
+		REQUIRE (asset1.nodes[j].meshIndex == asset2.nodes[j].meshIndex);
+		REQUIRE (asset1.nodes[j].skinIndex == asset2.nodes[j].skinIndex);
+		REQUIRE (asset1.nodes[j].cameraIndex == asset2.nodes[j].cameraIndex);
+		REQUIRE (asset1.nodes[j].lightIndex == asset2.nodes[j].lightIndex);
+		REQUIRE (isArraySame(asset1.nodes[j].children, asset2.nodes[j].children));
+		REQUIRE (isArraySame(asset1.nodes[j].weights, asset2.nodes[j].weights));
+		// REQUIRE (asset1.nodes[j].transform == asset2.nodes[j].transform);
+		//        std::variant<TRS, math::fmat4x4> transform;
+
+		REQUIRE(std::holds_alternative<fastgltf::TRS>(asset1.nodes[j].transform) == std::holds_alternative<fastgltf::TRS>(asset2.nodes[j].transform));
+		if (std::holds_alternative<fastgltf::TRS>(asset1.nodes[j].transform)) {
+			auto &a = std::get<fastgltf::TRS>(asset1.nodes[j].transform);
+			auto &b = std::get<fastgltf::TRS>(asset2.nodes[j].transform);
+			REQUIRE (a.translation == b.translation);
+			REQUIRE (a.rotation == b.rotation);
+			REQUIRE (a.scale == b.scale);
+		} else {
+			auto &a = std::get<fastgltf::math::fmat4x4>(asset1.nodes[j].transform);
+			auto &b = std::get<fastgltf::math::fmat4x4>(asset2.nodes[j].transform);
+			REQUIRE (a == b);
+		}
+		REQUIRE(asset1.nodes[j].instancingAttributes.size() == asset2.nodes[j].instancingAttributes.size());
+		for (std::size_t k = 0; k < asset1.nodes[j].instancingAttributes.size(); ++k) {
+			REQUIRE(asset1.nodes[j].instancingAttributes[k].name == asset2.nodes[j].instancingAttributes[k].name);
+			REQUIRE(asset1.nodes[j].instancingAttributes[k].accessorIndex == asset2.nodes[j].instancingAttributes[k].accessorIndex);
+		}
+		compare_vector_attributes(asset1.nodes[j].instancingAttributes, asset2.nodes[j].instancingAttributes);
+		REQUIRE (asset1.nodes[j].name == asset2.nodes[j].name);
+
+	}
+	// samplers
+	REQUIRE (asset1.samplers.size() == asset2.samplers.size());
+	for (std::size_t j = 0; j < asset1.samplers.size(); ++j) {
+		REQUIRE (asset1.samplers[j].magFilter == asset2.samplers[j].magFilter);
+		REQUIRE (asset1.samplers[j].minFilter == asset2.samplers[j].minFilter);
+		REQUIRE (asset1.samplers[j].wrapS == asset2.samplers[j].wrapS);
+		REQUIRE (asset1.samplers[j].wrapT == asset2.samplers[j].wrapT);
+		REQUIRE (asset1.samplers[j].name == asset2.samplers[j].name);
+	}
+        // std::vector<Scene> scenes;
+        // std::vector<Skin> skins;
+        // std::vector<Texture> textures;
+
+		// std::vector<std::string> materialVariants;
+
+	// scenes
+	REQUIRE (asset1.scenes.size() == asset2.scenes.size());
+	for (std::size_t j = 0; j < asset1.scenes.size(); ++j) {
+		REQUIRE (asset1.scenes[j].name == asset2.scenes[j].name);
+		REQUIRE (isArraySame(asset1.scenes[j].nodeIndices, asset2.scenes[j].nodeIndices));
+	}
+	
+	// skins
+	REQUIRE (asset1.skins.size() == asset2.skins.size());
+	for (std::size_t j = 0; j < asset1.skins.size(); ++j) {
+		REQUIRE (asset1.skins[j].name == asset2.skins[j].name);
+		REQUIRE (isArraySame(asset1.skins[j].joints, asset2.skins[j].joints));
+		REQUIRE (asset1.skins[j].skeleton == asset2.skins[j].skeleton);
+		REQUIRE (asset1.skins[j].inverseBindMatrices == asset2.skins[j].inverseBindMatrices);
+	}
+	
+	// textures
+	REQUIRE (asset1.textures.size() == asset2.textures.size());
+	for (std::size_t j = 0; j < asset1.textures.size(); ++j) {
+		REQUIRE (asset1.textures[j].samplerIndex == asset2.textures[j].samplerIndex);
+		REQUIRE (asset1.textures[j].imageIndex == asset2.textures[j].imageIndex);
+		REQUIRE (asset1.textures[j].basisuImageIndex == asset2.textures[j].basisuImageIndex);
+		REQUIRE (asset1.textures[j].ddsImageIndex == asset2.textures[j].ddsImageIndex);
+		REQUIRE (asset1.textures[j].webpImageIndex == asset2.textures[j].webpImageIndex);
+		REQUIRE (asset1.textures[j].name == asset2.textures[j].name);
+	}
+	
+	// material variants
+	REQUIRE (isArraySame(asset1.materialVariants, asset2.materialVariants));
+
+	return true;
+}
+
+
 static void inline test_glb_rewrite(const std::filesystem::path &model_parent_dir, const std::filesystem::path &model_file) {
-	if (!run_official_gltf_validator(sampleModels / model_parent_dir / model_file)) {
+	if (!run_official_gltf_validator(sampleAssets / model_parent_dir / model_file)) {
 		auto report = std::string( "Failed to validate the model: " + (model_parent_dir / model_file).string());
 		SKIP(report.c_str());
 		return;
 	}
 	
-	auto cubePath = sampleModels / model_parent_dir;
-	fastgltf::GltfFileStream cubeJson(cubePath / model_file);
-	REQUIRE(cubeJson.isOpen());
+	auto sampleDir = sampleAssets / model_parent_dir;
+	auto samplePath = sampleDir / model_file;
+	fastgltf::GltfFileStream sampleFileStream(samplePath);
+	REQUIRE(sampleFileStream.isOpen());
 	static constexpr auto requiredExtensions = fastgltf::Extensions::KHR_texture_transform |
-				fastgltf::Extensions::KHR_texture_basisu |
-				fastgltf::Extensions::MSFT_texture_dds |
-				fastgltf::Extensions::KHR_mesh_quantization |
-				fastgltf::Extensions::EXT_meshopt_compression |
-				fastgltf::Extensions::KHR_lights_punctual |
-				fastgltf::Extensions::EXT_texture_webp |
-				fastgltf::Extensions::KHR_materials_specular |
-				fastgltf::Extensions::KHR_materials_ior |
-				fastgltf::Extensions::KHR_materials_iridescence |
-				fastgltf::Extensions::KHR_materials_volume |
-				fastgltf::Extensions::KHR_materials_transmission |
-				fastgltf::Extensions::KHR_materials_clearcoat |
-				fastgltf::Extensions::KHR_materials_emissive_strength |
-				fastgltf::Extensions::KHR_materials_sheen |
-				fastgltf::Extensions::KHR_materials_unlit |
-				fastgltf::Extensions::KHR_materials_anisotropy;
-		fastgltf::Parser parser(requiredExtensions);
-		auto options = fastgltf::Options::LoadExternalBuffers | fastgltf::Options::LoadExternalImages ;
-		fastgltf::Expected<fastgltf::Asset> asset = model_file.extension() == ".gltf" ?
-			parser.loadGltfJson(cubeJson, cubePath, options) :
-			parser.loadGltfBinary(cubeJson, cubePath, options);
-		REQUIRE(asset.error() == fastgltf::Error::None);
+			fastgltf::Extensions::KHR_texture_basisu |
+			fastgltf::Extensions::MSFT_texture_dds |
+			fastgltf::Extensions::KHR_mesh_quantization |
+			fastgltf::Extensions::EXT_meshopt_compression |
+			fastgltf::Extensions::KHR_lights_punctual |
+			fastgltf::Extensions::EXT_texture_webp |
+			fastgltf::Extensions::KHR_materials_specular |
+			fastgltf::Extensions::KHR_materials_ior |
+			fastgltf::Extensions::KHR_materials_iridescence |
+			fastgltf::Extensions::KHR_materials_volume |
+			fastgltf::Extensions::KHR_materials_transmission |
+			fastgltf::Extensions::KHR_materials_clearcoat |
+			fastgltf::Extensions::KHR_materials_emissive_strength |
+			fastgltf::Extensions::KHR_materials_sheen |
+			fastgltf::Extensions::KHR_materials_unlit |
+			fastgltf::Extensions::KHR_materials_anisotropy |
+			fastgltf::Extensions::EXT_mesh_gpu_instancing |
+			#if FASTGLTF_ENABLE_DEPRECATED_EXT
+			fastgltf::Extensions::KHR_materials_pbrSpecularGlossiness |
+			#endif
+			fastgltf::Extensions::MSFT_packing_normalRoughnessMetallic |
+			fastgltf::Extensions::MSFT_packing_occlusionRoughnessMetallic |
+			fastgltf::Extensions::KHR_materials_dispersion |		
+			fastgltf::Extensions::KHR_materials_variants |
+			fastgltf::Extensions::KHR_accessor_float64 |
+			fastgltf::Extensions::KHR_draco_mesh_compression;
+	fastgltf::Parser parser(requiredExtensions);
+	auto options = fastgltf::Options::LoadExternalBuffers | fastgltf::Options::LoadExternalImages ;
+	fastgltf::Expected<fastgltf::Asset> asset = model_file.extension() == ".gltf" ?
+		parser.loadGltfJson(sampleFileStream, sampleDir, options) :
+		parser.loadGltfBinary(sampleFileStream, sampleDir, options);
+	REQUIRE(getErrorName(asset.error()) == "None");
+	REQUIRE(getErrorName(fastgltf::validate(asset.get())) == "None");
 
 	// Destroy the directory to make sure that the FileExporter correctly creates directories.
 	auto exportedFolder = path / "export_glb";
@@ -163,7 +676,16 @@ static void inline test_glb_rewrite(const std::filesystem::path &model_parent_di
 	// error = exporter.writeGltfJson(asset.get(), exportedGLTFPath, fastgltf::ExportOptions::PrettyPrintJson);
 
 
-	
+	std::uint32_t oldJsonChunkLength = 0;
+	{
+		std::ifstream glb_old(samplePath, std::ios::binary);
+		REQUIRE(glb_old.is_open());
+
+		// Skip over the header
+		glb_old.seekg(sizeof(std::uint32_t) * 3, std::ifstream::beg);
+		// Read the chunk length
+		glb_old.read(reinterpret_cast<char*>(&oldJsonChunkLength), sizeof oldJsonChunkLength);
+	}
 
 	// Make sure the GLB buffer is written
 	std::ifstream glb(exportedGLBPath, std::ios::binary);
@@ -173,15 +695,17 @@ static void inline test_glb_rewrite(const std::filesystem::path &model_parent_di
 	glb.seekg(sizeof(std::uint32_t) * 3, std::ifstream::beg);
 
 	// Read the chunk length
-	std::uint32_t chunkLength = 0;
-	glb.read(reinterpret_cast<char*>(&chunkLength), sizeof chunkLength);
-
+	std::uint32_t jsonChunkLength = 0;
+	glb.read(reinterpret_cast<char*>(&jsonChunkLength), sizeof jsonChunkLength);
+	// REQUIRE(jsonChunkLength == fastgltf::alignUp(oldJsonChunkLength, 4));
+	
 	// Skip over the chunk type + chunk
-	glb.seekg(sizeof(std::uint32_t) + fastgltf::alignUp(chunkLength, 4), std::ifstream::cur);
+	glb.seekg(sizeof(std::uint32_t) + fastgltf::alignUp(jsonChunkLength, 4), std::ifstream::cur);
 
 	// Read binary chunk length
-	glb.read(reinterpret_cast<char*>(&chunkLength), sizeof chunkLength);
-	REQUIRE(chunkLength == asset->buffers.front().byteLength);
+	std::uint32_t binChunkLength = 0;
+	glb.read(reinterpret_cast<char*>(&binChunkLength), sizeof binChunkLength);
+	REQUIRE(binChunkLength == fastgltf::alignUp(asset->buffers.front().byteLength, 4));
 
 	// Read & verify BIN chunk type id
 	std::array<std::uint8_t, 4> binType {};
@@ -195,21 +719,21 @@ static void inline test_glb_rewrite(const std::filesystem::path &model_parent_di
 	// Re-read the GLB
 	auto result = run_official_gltf_validator(exportedGLBPath);
 	REQUIRE(result);
-
+	fastgltf::Parser new_parser(requiredExtensions);
 	fastgltf::GltfFileStream rewrittenGlb(exportedGLBPath);
 	REQUIRE(rewrittenGlb.isOpen());
-
-	auto rerwittenAsset = parser.loadGltfBinary(cubeJson, cubePath, options);
-	REQUIRE(rerwittenAsset.error() == fastgltf::Error::None);
-	REQUIRE(fastgltf::validate(rerwittenAsset.get()) == fastgltf::Error::None);
+	fastgltf::Expected<fastgltf::Asset> rewrittenAsset = new_parser.loadGltfBinary(rewrittenGlb, exportedGLBPath.parent_path(), options);
+	REQUIRE(rewrittenAsset.error() == fastgltf::Error::None);
+	REQUIRE(getErrorName(fastgltf::validate(rewrittenAsset.get())) == "None");
+	REQUIRE(isSame(asset.get(), rewrittenAsset.get()));
 }
 
-std::vector<std::filesystem::path> getSampleModels(const std::filesystem::path& dir, bool include_text = false, bool include_binary = false) {
+std::vector<std::filesystem::path> getSampleAssets(const std::filesystem::path& dir, bool include_text = false, bool include_binary = false) {
   std::vector<std::filesystem::path> models;
 	try {
 		for (const auto& entry : std::filesystem::directory_iterator(dir)) {
 			if (entry.is_directory()) {
-				auto subModels = getSampleModels(entry.path(), include_text, include_binary);
+				auto subModels = getSampleAssets(entry.path(), include_text, include_binary);
 				models.insert(models.end(), subModels.begin(), subModels.end());
 			} else if (entry.is_regular_file()) {
 				auto ext = entry.path().extension();
@@ -226,7 +750,7 @@ std::vector<std::filesystem::path> getSampleModels(const std::filesystem::path& 
 }
 
 TEST_CASE("Try writing a GLB with all buffers and images (ALL IN MODEL)", "[write-tests]") {
-	auto models = getSampleModels(sampleModels / "2.0", false, true);
+	auto models = getSampleAssets(sampleAssets / "Models", false, true);
 	// Destroy the directory to make sure that the FileExporter correctly creates directories.
 	// auto exportedFolder = path / "export_glb";
 	// if (std::filesystem::exists(exportedFolder)) {
@@ -236,16 +760,18 @@ TEST_CASE("Try writing a GLB with all buffers and images (ALL IN MODEL)", "[writ
 	// }
 
 	for (const auto& model : models) {
-		SECTION(model.string()) {
-			// we want to get the relative directory to sampleModels
-			auto model_parent_path = std::filesystem::relative(model.parent_path(), sampleModels);
+		// get the directory relative to sampleAssets
+		auto rel_dir = std::filesystem::relative(model, sampleAssets);
+		SECTION(rel_dir.string()) {
+			// we want to get the relative directory to sampleAssets
+			auto model_parent_path = std::filesystem::relative(model.parent_path(), sampleAssets);
 			test_glb_rewrite(model_parent_path, model.filename());
 		}
 	}
 }
 
 TEST_CASE("Try writing a GLB with all buffers and images (DUCK)", "[write-tests]") {
-	test_glb_rewrite(std::filesystem::path("2.0") / "Duck" / "glTF-Binary", "Duck.glb");
+	test_glb_rewrite(std::filesystem::path("Models") / "Duck" / "glTF-Binary", "Duck.glb");
 }
 
 TEST_CASE("Try writing a GLB with all buffers and images", "[write-tests]") {

--- a/tests/write_tests.cpp
+++ b/tests/write_tests.cpp
@@ -2,12 +2,13 @@
 #include <cinttypes>
 #include <cstdint>
 #include <fstream>
-
 #include <catch2/catch_test_macros.hpp>
 
 #include <simdjson.h>
+#include <unordered_set>
 
 #include <fastgltf/core.hpp>
+#include <fastgltf/types.hpp>
 #include "gltf_path.hpp"
 
 TEST_CASE("Test simple glTF composition", "[write-tests]") {
@@ -103,10 +104,11 @@ TEST_CASE("Try writing a glTF with all buffers and images", "[write-tests]") {
 }
 
 static bool run_official_gltf_validator(const std::filesystem::path &model_path) {
-	static constexpr const char * path_to_validator = "/Users/nikita/Downloads/gltf_validator_macos/gltf_validator";
-
+	if (!std::filesystem::exists(gltfValidator)) {
+		return false;
+	}
 	// run the validator on the model
-	std::string command = std::string(path_to_validator) + " -m " + model_path.string();
+	std::string command = std::string(gltfValidator) + " -m " + model_path.string();
 	auto result = std::system(command.c_str());
 	if (result != 0) {
 		return false;
@@ -114,509 +116,13 @@ static bool run_official_gltf_validator(const std::filesystem::path &model_path)
 	return true;
 }
 
-// template<typename T>
-bool isABASame(const fastgltf::AccessorBoundsArray& a, const fastgltf::AccessorBoundsArray& b) {
-	// static_assert(std::is_same_v<T, fastgltf::AccessorBoundsArray> || std::is_same_v<T, fastgltf::AccessorBoundsArray>);
-	REQUIRE(a.type() == b.type());
-	for (std::size_t i = 0; i < a.size(); ++i) {
-		if (a.type() == fastgltf::AccessorBoundsArray::BoundsType::float64) {
-			REQUIRE (a.get<double>(i) == b.get<double>(i));
-		} else {
-			REQUIRE (a.get<int64_t>(i) == b.get<int64_t>(i));
-		}
-	}
-	return true;
-}
-
-template<typename T>
-bool isArraySame(const T& a, const T& b, std::size_t minSize = -1) {
-	if (minSize == -1) {
-		REQUIRE(a.size() == b.size());
-		minSize = a.size();
-	} else {
-		REQUIRE(minSize <= a.size());
-		REQUIRE(minSize <= b.size());
-	}
-	for (std::size_t i = 0; i < minSize; ++i) {
-		REQUIRE (a[i] == b[i]);
-	}
-	return true;
-}
-
-bool isDataSourceSame(const fastgltf::DataSource& a, const fastgltf::DataSource& b, size_t minSize = -1) {
-	//    FASTGLTF_EXPORT using DataSource = std::variant<std::monostate, sources::BufferView, sources::URI, sources::Array, sources::Vector, sources::CustomBuffer, sources::ByteView, sources::Fallback>;
-
-	if (std::holds_alternative<std::monostate>(a)) {
-		if (!std::holds_alternative<std::monostate>(b)) {
-			return false;
-		}
-		return true;
-	} else if (std::holds_alternative<fastgltf::sources::BufferView>(a)) {
-		if (!std::holds_alternative<fastgltf::sources::BufferView>(b)) {
-			return false;
-		}
-		auto a_bv = std::get<fastgltf::sources::BufferView>(a);
-		auto b_bv = std::get<fastgltf::sources::BufferView>(b);
-		return a_bv.bufferViewIndex == b_bv.bufferViewIndex && a_bv.mimeType == b_bv.mimeType;
-	} else if (std::holds_alternative<fastgltf::sources::URI>(a)) {
-		if (!std::holds_alternative<fastgltf::sources::URI>(b)) {
-			return false;
-		}
-		auto a_uri = std::get<fastgltf::sources::URI>(a);
-		auto b_uri = std::get<fastgltf::sources::URI>(b);
-		return a_uri.uri.string() == b_uri.uri.string();
-	} else if (std::holds_alternative<fastgltf::sources::Array>(a)) {
-		if (!std::holds_alternative<fastgltf::sources::Array>(b)) {
-			return false;
-		}
-		auto a_array = std::get<fastgltf::sources::Array>(a);
-		auto b_array = std::get<fastgltf::sources::Array>(b);
-		return a_array.mimeType == b_array.mimeType && isArraySame(a_array.bytes, b_array.bytes, minSize);
-	} else if (std::holds_alternative<fastgltf::sources::Vector>(a)) {
-		if (!std::holds_alternative<fastgltf::sources::Vector>(b)) {
-			return false;
-		}
-		auto a_vector = std::get<fastgltf::sources::Vector>(a);
-		auto b_vector = std::get<fastgltf::sources::Vector>(b);
-		return a_vector.mimeType == b_vector.mimeType && isArraySame(a_vector.bytes, b_vector.bytes, minSize);
-	} else if (std::holds_alternative<fastgltf::sources::CustomBuffer>(a)) {
-		if (!std::holds_alternative<fastgltf::sources::CustomBuffer>(b)) {
-			return false;
-		}
-		auto a_custom_buffer = std::get<fastgltf::sources::CustomBuffer>(a);
-		auto b_custom_buffer = std::get<fastgltf::sources::CustomBuffer>(b);
-		return a_custom_buffer.mimeType == b_custom_buffer.mimeType && b_custom_buffer.id == a_custom_buffer.id;
-	} else if (std::holds_alternative<fastgltf::sources::ByteView>(a)) {
-		if (!std::holds_alternative<fastgltf::sources::ByteView>(b)) {
-			return false;
-		}
-		auto a_byte_view = std::get<fastgltf::sources::ByteView>(a);
-		auto b_byte_view = std::get<fastgltf::sources::ByteView>(b);
-		return a_byte_view.mimeType == b_byte_view.mimeType && isArraySame(a_byte_view.bytes, b_byte_view.bytes, minSize);
-	} else if (std::holds_alternative<fastgltf::sources::Fallback>(a)) {
-		if (!std::holds_alternative<fastgltf::sources::Fallback>(b)) {
-			return false;
-		}
-		return true;
-	}
-	return false;
-}
-
-
-static bool compare_TextureInfo(const fastgltf::TextureInfo& a, const fastgltf::TextureInfo& b) {
-	REQUIRE (a.textureIndex == b.textureIndex);
-	REQUIRE (a.texCoordIndex == b.texCoordIndex);
-	if (a.transform) {
-		REQUIRE (a.transform->uvOffset == b.transform->uvOffset);
-		REQUIRE (a.transform->uvScale == b.transform->uvScale);
-		REQUIRE (a.transform->rotation == b.transform->rotation);
-		REQUIRE (a.transform->texCoordIndex == b.transform->texCoordIndex);
-	}
-	return true;
-}
-
-static bool compare_OptionalTextureInfo(const fastgltf::Optional<fastgltf::TextureInfo>& a, const fastgltf::Optional<fastgltf::TextureInfo>& b) {
-	if (a.has_value() != b.has_value()) {
-		return false;
-	}
-	if (!a.has_value()) {
-		return true;
-	}
-	REQUIRE (compare_TextureInfo(a.value(), b.value()));
-	return true;
-}
-
-static bool compare_vector_attributes(const FASTGLTF_STD_PMR_NS::vector<fastgltf::Attribute>& a, const FASTGLTF_STD_PMR_NS::vector<fastgltf::Attribute>& b) {
-	REQUIRE (a.size() == b.size());
-	for (std::size_t i = 0; i < a.size(); ++i) {
-		REQUIRE (a[i].accessorIndex == b[i].accessorIndex);
-		REQUIRE (a[i].name == b[i].name);
-	}
-	return true;
-}
-
-static bool compare_vector_attributes(const fastgltf::SmallVector<fastgltf::Attribute, 4, std::pmr::polymorphic_allocator<fastgltf::Attribute>>& a, const fastgltf::SmallVector<fastgltf::Attribute, 4, std::pmr::polymorphic_allocator<fastgltf::Attribute>>& b) {
-	REQUIRE (a.size() == b.size());
-	for (std::size_t i = 0; i < a.size(); ++i) {
-		REQUIRE (a[i].accessorIndex == b[i].accessorIndex);
-		REQUIRE (a[i].name == b[i].name);
-	}
-	return true;
-}
-
-// change the if... return false to REQUIRE
-static bool isSame(const fastgltf::Asset& asset1, const fastgltf::Asset& asset2) {
-	// assetInfo
-	REQUIRE (asset1.assetInfo->gltfVersion == asset2.assetInfo->gltfVersion);
-	REQUIRE (asset1.assetInfo->generator == asset2.assetInfo->generator);
-	REQUIRE (asset1.assetInfo->copyright == asset2.assetInfo->copyright);
-	// extensionsUsed
-	REQUIRE (asset1.extensionsUsed.size() == asset2.extensionsUsed.size());
-	for (std::size_t j = 0; j < asset1.extensionsUsed.size(); ++j) {
-		REQUIRE (asset1.extensionsUsed[j] == asset2.extensionsUsed[j]);
-	}
-	// extensionsRequired
-	REQUIRE (asset1.extensionsRequired.size() == asset2.extensionsRequired.size())	;
-	for (std::size_t j = 0; j < asset1.extensionsRequired.size(); ++j) {
-		REQUIRE (asset1.extensionsRequired[j] == asset2.extensionsRequired[j]);
-	}
-	// defaultScene
-	REQUIRE (asset1.defaultScene == asset2.defaultScene);
-	// accessors
-	REQUIRE (asset1.accessors.size() == asset2.accessors.size());
-	for (std::size_t j = 0; j < asset1.accessors.size(); ++j) {
-		auto& accessor1 = asset1.accessors[j];
-		auto& accessor2 = asset2.accessors[j];
-		REQUIRE (accessor1.byteOffset == accessor2.byteOffset);
-		REQUIRE (accessor1.count == accessor2.count);
-		REQUIRE (accessor1.type == accessor2.type);
-		REQUIRE (accessor1.componentType == accessor2.componentType);
-		REQUIRE (accessor1.normalized == accessor2.normalized);
-		REQUIRE (accessor1.bufferViewIndex == accessor2.bufferViewIndex);
-		REQUIRE (accessor1.min.has_value() == accessor2.min.has_value());
-		REQUIRE (accessor1.max.has_value() == accessor2.max.has_value());
-		if (accessor1.min.has_value()) {
-			REQUIRE (isABASame(accessor1.min.value(), accessor2.min.value()));
-		}
-		if (accessor1.max.has_value()) {
-			REQUIRE (isABASame(accessor1.max.value(), accessor2.max.value()));
-		}
-		REQUIRE (accessor1.sparse.has_value() == accessor2.sparse.has_value());
-		if (accessor1.sparse.has_value()) {
-			REQUIRE (accessor1.sparse->count == accessor2.sparse->count);
-			REQUIRE (accessor1.sparse->indicesBufferView == accessor2.sparse->indicesBufferView);
-			REQUIRE (accessor1.sparse->indicesByteOffset == accessor2.sparse->indicesByteOffset);
-			REQUIRE (accessor1.sparse->valuesBufferView == accessor2.sparse->valuesBufferView);
-			REQUIRE (accessor1.sparse->valuesByteOffset == accessor2.sparse->valuesByteOffset);
-			REQUIRE (accessor1.sparse->indexComponentType == accessor2.sparse->indexComponentType);
-		}
-		REQUIRE(accessor1.name == accessor2.name);
-	}
-	// animations
-	REQUIRE (asset1.animations.size() == asset2.animations.size());
-	for (std::size_t j = 0; j < asset1.animations.size(); ++j) {
-		auto& animation1 = asset1.animations[j];
-		auto& animation2 = asset2.animations[j];
-		REQUIRE (animation1.name == animation2.name);
-		REQUIRE (animation1.channels.size() == animation2.channels.size());
-		for (std::size_t k = 0; k < animation1.channels.size(); ++k) {
-			auto& channel1 = animation1.channels[k];
-			auto& channel2 = animation2.channels[k];
-			REQUIRE (channel1.samplerIndex == channel2.samplerIndex);
-			REQUIRE (channel1.nodeIndex == channel2.nodeIndex);
-			REQUIRE (channel1.path == channel2.path);
-		}
-		REQUIRE (animation1.samplers.size() == animation2.samplers.size());
-		for (std::size_t k = 0; k < animation1.samplers.size(); ++k) {
-			auto& sampler1 = animation1.samplers[k];
-			auto& sampler2 = animation2.samplers[k];
-			REQUIRE (sampler1.inputAccessor == sampler2.inputAccessor);
-			REQUIRE (sampler1.interpolation == sampler2.interpolation);
-			REQUIRE (sampler1.outputAccessor == sampler2.outputAccessor);
-		}
-	}
-	// buffers
-	REQUIRE (asset1.buffers.size() == asset2.buffers.size());
-	for (std::size_t j = 0; j < asset1.buffers.size(); ++j) {
-		// buffer may be different size because it wasn't aligned properly before
-		REQUIRE (fastgltf::alignUp(asset1.buffers[j].byteLength, 4) == fastgltf::alignUp(asset2.buffers[j].byteLength, 4));
-		REQUIRE (asset1.buffers[j].name == asset2.buffers[j].name);
-		auto minSize = std::min(asset1.buffers[j].byteLength, asset2.buffers[j].byteLength);
-		REQUIRE (isDataSourceSame(asset1.buffers[j].data, asset2.buffers[j].data, minSize));
+static void inline test_glb_rewrite(const std::filesystem::path &model_parent_dir, const std::filesystem::path &model_file, bool skip_official_validator = false) {
+	if (!skip_official_validator && !std::filesystem::exists(gltfValidator)) {
+		SKIP("Failed to find the official glTF validator (download and unzip to tests/gltf/gltf_validator)");
+		return;
 	}
 
-	// bufferViews
-	REQUIRE (asset1.bufferViews.size() == asset2.bufferViews.size());
-	for (std::size_t j = 0; j < asset1.bufferViews.size(); ++j) {
-		REQUIRE (asset1.bufferViews[j].bufferIndex == asset2.bufferViews[j].bufferIndex);
-		REQUIRE (asset1.bufferViews[j].byteOffset == asset2.bufferViews[j].byteOffset);
-		REQUIRE (asset1.bufferViews[j].byteLength == asset2.bufferViews[j].byteLength);
-		REQUIRE (asset1.bufferViews[j].byteStride == asset2.bufferViews[j].byteStride);
-		REQUIRE (asset1.bufferViews[j].target == asset2.bufferViews[j].target);
-		REQUIRE (!asset1.bufferViews[j].meshoptCompression == !asset2.bufferViews[j].meshoptCompression);
-		if (asset1.bufferViews[j].meshoptCompression) {
-			REQUIRE (asset1.bufferViews[j].meshoptCompression->bufferIndex == asset2.bufferViews[j].meshoptCompression->bufferIndex);
-			REQUIRE (asset1.bufferViews[j].meshoptCompression->byteOffset == asset2.bufferViews[j].meshoptCompression->byteOffset);
-			REQUIRE (asset1.bufferViews[j].meshoptCompression->byteLength == asset2.bufferViews[j].meshoptCompression->byteLength);
-			REQUIRE (asset1.bufferViews[j].meshoptCompression->count == asset2.bufferViews[j].meshoptCompression->count);
-			REQUIRE (asset1.bufferViews[j].meshoptCompression->mode == asset2.bufferViews[j].meshoptCompression->mode);
-			REQUIRE (asset1.bufferViews[j].meshoptCompression->filter == asset2.bufferViews[j].meshoptCompression->filter);
-			REQUIRE (asset1.bufferViews[j].meshoptCompression->byteStride == asset2.bufferViews[j].meshoptCompression->byteStride);
-		}
-	}
-
-	// cameras
-	REQUIRE (asset1.cameras.size() == asset2.cameras.size());
-	for (std::size_t j = 0; j < asset1.cameras.size(); ++j) {
-		REQUIRE (asset1.cameras[j].name == asset2.cameras[j].name);
-		if (std::holds_alternative<fastgltf::Camera::Perspective>(asset1.cameras[j].camera)) {
-			auto camera1 = std::get_if<fastgltf::Camera::Perspective>(&asset1.cameras[j].camera);
-			auto camera2 = std::get_if<fastgltf::Camera::Perspective>(&asset2.cameras[j].camera);
-			REQUIRE (camera1->aspectRatio == camera2->aspectRatio);
-			REQUIRE (camera1->yfov == camera2->yfov);
-			REQUIRE (camera1->znear == camera2->znear);
-			REQUIRE (camera1->zfar == camera2->zfar);
-		} else if (std::holds_alternative<fastgltf::Camera::Orthographic>(asset1.cameras[j].camera)) {
-			auto camera1 = std::get_if<fastgltf::Camera::Orthographic>(&asset1.cameras[j].camera);
-			auto camera2 = std::get_if<fastgltf::Camera::Orthographic>(&asset2.cameras[j].camera);
-			REQUIRE (camera1->xmag == camera2->xmag);
-			REQUIRE (camera1->ymag == camera2->ymag);
-			REQUIRE (camera1->znear == camera2->znear);
-			REQUIRE (camera1->zfar == camera2->zfar);
-		}
-	}
-
-	// images
-	REQUIRE (asset1.images.size() == asset2.images.size());
-	for (std::size_t j = 0; j < asset1.images.size(); ++j) {
-		REQUIRE (asset1.images[j].name == asset2.images[j].name);
-		REQUIRE (isDataSourceSame(asset1.images[j].data, asset2.images[j].data));
-	}
-
-	// lights
-	REQUIRE (asset1.lights.size() == asset2.lights.size());
-	for (std::size_t j = 0; j < asset1.lights.size(); ++j) {
-		REQUIRE (asset1.lights[j].type == asset2.lights[j].type);
-		REQUIRE (asset1.lights[j].color.x() == asset2.lights[j].color.x());
-		REQUIRE (asset1.lights[j].color.y() == asset2.lights[j].color.y());
-		REQUIRE (asset1.lights[j].color.z() == asset2.lights[j].color.z());
-		REQUIRE (asset1.lights[j].intensity == asset2.lights[j].intensity);
-		REQUIRE (asset1.lights[j].range == asset2.lights[j].range);
-		REQUIRE (asset1.lights[j].innerConeAngle == asset2.lights[j].innerConeAngle);
-		REQUIRE (asset1.lights[j].outerConeAngle == asset2.lights[j].outerConeAngle);
-		REQUIRE (asset1.lights[j].name == asset2.lights[j].name);
-	}
-	// materials
-	REQUIRE (asset1.materials.size() == asset2.materials.size());
-	for (std::size_t j = 0; j < asset1.materials.size(); ++j) {
-		REQUIRE (asset1.materials[j].pbrData.metallicRoughnessTexture.has_value() == asset2.materials[j].pbrData.metallicRoughnessTexture.has_value());
-		if (asset1.materials[j].pbrData.metallicRoughnessTexture.has_value()) {
-			REQUIRE (asset1.materials[j].pbrData.metallicRoughnessTexture.value().textureIndex == asset2.materials[j].pbrData.metallicRoughnessTexture.value().textureIndex);
-			REQUIRE (asset1.materials[j].pbrData.metallicRoughnessTexture.value().texCoordIndex == asset2.materials[j].pbrData.metallicRoughnessTexture.value().texCoordIndex);
-		}
-		REQUIRE (asset1.materials[j].pbrData.metallicFactor == asset2.materials[j].pbrData.metallicFactor);
-		REQUIRE (asset1.materials[j].pbrData.roughnessFactor == asset2.materials[j].pbrData.roughnessFactor);
-		REQUIRE (asset1.materials[j].pbrData.baseColorFactor == asset2.materials[j].pbrData.baseColorFactor);
-		compare_OptionalTextureInfo(asset1.materials[j].pbrData.baseColorTexture, asset2.materials[j].pbrData.baseColorTexture);
-		compare_OptionalTextureInfo(asset1.materials[j].pbrData.metallicRoughnessTexture, asset2.materials[j].pbrData.metallicRoughnessTexture);
-
-		REQUIRE (asset1.materials[j].normalTexture.has_value() == asset2.materials[j].normalTexture.has_value());
-		if (asset1.materials[j].normalTexture.has_value()) {
-			REQUIRE (asset1.materials[j].normalTexture.value().scale == asset2.materials[j].normalTexture.value().scale);
-			compare_TextureInfo(asset1.materials[j].normalTexture.value(), asset2.materials[j].normalTexture.value());
-		}
-		REQUIRE (asset1.materials[j].occlusionTexture.has_value() == asset2.materials[j].occlusionTexture.has_value());
-		if (asset1.materials[j].occlusionTexture.has_value()) {
-			REQUIRE (asset1.materials[j].occlusionTexture.value().strength == asset2.materials[j].occlusionTexture.value().strength);
-			compare_TextureInfo(asset1.materials[j].occlusionTexture.value(), asset2.materials[j].occlusionTexture.value());
-		}
-		compare_OptionalTextureInfo(asset1.materials[j].emissiveTexture, asset2.materials[j].emissiveTexture);
-		//emissiveFactor
-		REQUIRE (asset1.materials[j].emissiveFactor == asset2.materials[j].emissiveFactor);
-		//alphaMode
-		REQUIRE (asset1.materials[j].alphaMode == asset2.materials[j].alphaMode);
-		//doubleSided
-		REQUIRE (asset1.materials[j].doubleSided == asset2.materials[j].doubleSided);
-		//unlit
-		REQUIRE (asset1.materials[j].unlit == asset2.materials[j].unlit);
-		//alphaCutoff
-		REQUIRE (asset1.materials[j].alphaCutoff == asset2.materials[j].alphaCutoff);
-		//emissiveStrength
-		REQUIRE (asset1.materials[j].emissiveStrength == asset2.materials[j].emissiveStrength);
-		//ior
-		REQUIRE (asset1.materials[j].ior == asset2.materials[j].ior);
-		//dispersion
-		REQUIRE (asset1.materials[j].dispersion == asset2.materials[j].dispersion);
-		//anisotropy
-		REQUIRE ((!asset1.materials[j].anisotropy) == (!asset2.materials[j].anisotropy));
-		if (asset1.materials[j].anisotropy) {
-			REQUIRE (asset1.materials[j].anisotropy->anisotropyStrength == asset2.materials[j].anisotropy->anisotropyStrength);
-			REQUIRE (asset1.materials[j].anisotropy->anisotropyRotation == asset2.materials[j].anisotropy->anisotropyRotation);
-			compare_OptionalTextureInfo(asset1.materials[j].anisotropy->anisotropyTexture, asset2.materials[j].anisotropy->anisotropyTexture);
-		}
-		//clearcoat
-		REQUIRE ((!asset1.materials[j].clearcoat) == (!asset2.materials[j].clearcoat));
-		if (asset1.materials[j].clearcoat) {
-			REQUIRE (asset1.materials[j].clearcoat->clearcoatFactor == asset2.materials[j].clearcoat->clearcoatFactor);
-			REQUIRE (asset1.materials[j].clearcoat->clearcoatRoughnessFactor == asset2.materials[j].clearcoat->clearcoatRoughnessFactor);
-			compare_OptionalTextureInfo(asset1.materials[j].clearcoat->clearcoatTexture, asset2.materials[j].clearcoat->clearcoatTexture);
-			compare_OptionalTextureInfo(asset1.materials[j].clearcoat->clearcoatRoughnessTexture, asset2.materials[j].clearcoat->clearcoatRoughnessTexture);
-			REQUIRE (asset1.materials[j].clearcoat->clearcoatNormalTexture.has_value() == asset2.materials[j].clearcoat->clearcoatNormalTexture.has_value());
-			if (asset1.materials[j].clearcoat->clearcoatNormalTexture.has_value()) {
-				REQUIRE (asset1.materials[j].clearcoat->clearcoatNormalTexture.value().scale == asset2.materials[j].clearcoat->clearcoatNormalTexture.value().scale);
-				compare_TextureInfo(asset1.materials[j].clearcoat->clearcoatNormalTexture.value(), asset2.materials[j].clearcoat->clearcoatNormalTexture.value());
-			}
-		}
-		//iridescence
-		REQUIRE ((!asset1.materials[j].iridescence) == (!asset2.materials[j].iridescence));
-		if (asset1.materials[j].iridescence) {
-			REQUIRE (asset1.materials[j].iridescence->iridescenceFactor == asset2.materials[j].iridescence->iridescenceFactor);
-			REQUIRE (asset1.materials[j].iridescence->iridescenceIor == asset2.materials[j].iridescence->iridescenceIor);
-			compare_OptionalTextureInfo(asset1.materials[j].iridescence->iridescenceTexture, asset2.materials[j].iridescence->iridescenceTexture);
-			REQUIRE (asset1.materials[j].iridescence->iridescenceThicknessMinimum == asset2.materials[j].iridescence->iridescenceThicknessMinimum);
-			REQUIRE (asset1.materials[j].iridescence->iridescenceThicknessMaximum == asset2.materials[j].iridescence->iridescenceThicknessMaximum);
-			compare_OptionalTextureInfo(asset1.materials[j].iridescence->iridescenceThicknessTexture, asset2.materials[j].iridescence->iridescenceThicknessTexture);
-		}
-		//sheen
-		REQUIRE ((!asset1.materials[j].sheen) == (!asset2.materials[j].sheen));
-		if (asset1.materials[j].sheen) {
-			REQUIRE (asset1.materials[j].sheen->sheenColorFactor == asset2.materials[j].sheen->sheenColorFactor);
-			compare_OptionalTextureInfo(asset1.materials[j].sheen->sheenColorTexture, asset2.materials[j].sheen->sheenColorTexture);
-			REQUIRE (asset1.materials[j].sheen->sheenRoughnessFactor == asset2.materials[j].sheen->sheenRoughnessFactor);
-			compare_OptionalTextureInfo(asset1.materials[j].sheen->sheenRoughnessTexture, asset2.materials[j].sheen->sheenRoughnessTexture);
-		}
-		//specular
-		REQUIRE ((!asset1.materials[j].specular) == (!asset2.materials[j].specular));
-		if (asset1.materials[j].specular) {
-			REQUIRE (asset1.materials[j].specular->specularFactor == asset2.materials[j].specular->specularFactor);
-			compare_OptionalTextureInfo(asset1.materials[j].specular->specularTexture, asset2.materials[j].specular->specularTexture);
-			REQUIRE(asset1.materials[j].specular->specularColorFactor == asset2.materials[j].specular->specularColorFactor);
-			compare_OptionalTextureInfo(asset1.materials[j].specular->specularColorTexture, asset2.materials[j].specular->specularColorTexture);
-		}
-		//specularGlossiness
-		REQUIRE ((!asset1.materials[j].specularGlossiness) == (!asset2.materials[j].specularGlossiness));
-		if (asset1.materials[j].specularGlossiness) {
-			REQUIRE (asset1.materials[j].specularGlossiness->diffuseFactor == asset2.materials[j].specularGlossiness->diffuseFactor);
-			REQUIRE (asset1.materials[j].specularGlossiness->specularFactor == asset2.materials[j].specularGlossiness->specularFactor);
-			compare_OptionalTextureInfo(asset1.materials[j].specularGlossiness->diffuseTexture, asset2.materials[j].specularGlossiness->diffuseTexture);
-			REQUIRE (asset1.materials[j].specularGlossiness->glossinessFactor == asset2.materials[j].specularGlossiness->glossinessFactor);
-			compare_OptionalTextureInfo(asset1.materials[j].specularGlossiness->specularGlossinessTexture, asset2.materials[j].specularGlossiness->specularGlossinessTexture);
-		}
-		//transmission
-		REQUIRE ((!asset1.materials[j].transmission) == (!asset2.materials[j].transmission));
-		if (asset1.materials[j].transmission) {
-			REQUIRE (asset1.materials[j].transmission->transmissionFactor == asset2.materials[j].transmission->transmissionFactor);
-			compare_OptionalTextureInfo(asset1.materials[j].transmission->transmissionTexture, asset2.materials[j].transmission->transmissionTexture);
-		}
-		//volume
-		REQUIRE ((!asset1.materials[j].volume) == (!asset2.materials[j].volume));
-		if (asset1.materials[j].volume) {
-			REQUIRE(asset1.materials[j].volume->thicknessFactor == asset2.materials[j].volume->thicknessFactor);
-			compare_OptionalTextureInfo(asset1.materials[j].volume->thicknessTexture, asset2.materials[j].volume->thicknessTexture);
-			REQUIRE (asset1.materials[j].volume->attenuationDistance == asset2.materials[j].volume->attenuationDistance);
-			REQUIRE (asset1.materials[j].volume->attenuationColor == asset2.materials[j].volume->attenuationColor);
-		}
-		//packedOcclusionRoughnessMetallicTextures
-		REQUIRE ((!asset1.materials[j].packedOcclusionRoughnessMetallicTextures) == (!asset2.materials[j].packedOcclusionRoughnessMetallicTextures));
-		if (asset1.materials[j].packedOcclusionRoughnessMetallicTextures) {
-			REQUIRE(compare_OptionalTextureInfo(asset1.materials[j].packedOcclusionRoughnessMetallicTextures->occlusionRoughnessMetallicTexture, asset2.materials[j].packedOcclusionRoughnessMetallicTextures->occlusionRoughnessMetallicTexture));
-			REQUIRE(compare_OptionalTextureInfo(asset1.materials[j].packedOcclusionRoughnessMetallicTextures->roughnessMetallicOcclusionTexture, asset2.materials[j].packedOcclusionRoughnessMetallicTextures->roughnessMetallicOcclusionTexture));
-			REQUIRE(compare_OptionalTextureInfo(asset1.materials[j].packedOcclusionRoughnessMetallicTextures->normalTexture, asset2.materials[j].packedOcclusionRoughnessMetallicTextures->normalTexture));
-		}
-		//name
-		REQUIRE (asset1.materials[j].name == asset2.materials[j].name);
-	}
-
-	//meshes
-	REQUIRE (asset1.meshes.size() == asset2.meshes.size());
-	for (std::size_t j = 0; j < asset1.meshes.size(); ++j) {
-		// primitives
-		REQUIRE (asset1.meshes[j].primitives.size() == asset2.meshes[j].primitives.size());
-		for (std::size_t k = 0; k < asset1.meshes[j].primitives.size(); ++k) {
-			REQUIRE (asset1.meshes[j].primitives[k].materialIndex == asset2.meshes[j].primitives[k].materialIndex);
-			REQUIRE(compare_vector_attributes(asset1.meshes[j].primitives[k].attributes, asset2.meshes[j].primitives[k].attributes));
-			REQUIRE(asset1.meshes[j].primitives[k].targets.size() == asset2.meshes[j].primitives[k].targets.size());
-			for (std::size_t l = 0; l < asset1.meshes[j].primitives[k].targets.size(); ++l) {
-				REQUIRE(compare_vector_attributes(asset1.meshes[j].primitives[k].targets[l], asset2.meshes[j].primitives[k].targets[l]));
-			}
-			REQUIRE (asset1.meshes[j].primitives[k].indicesAccessor == asset2.meshes[j].primitives[k].indicesAccessor);
-			REQUIRE (asset1.meshes[j].primitives[k].materialIndex == asset2.meshes[j].primitives[k].materialIndex);
-			REQUIRE (isArraySame(asset1.meshes[j].primitives[k].mappings, asset2.meshes[j].primitives[k].mappings));
-			REQUIRE (asset1.meshes[j].primitives[k].type == asset2.meshes[j].primitives[k].type);
-			REQUIRE ((!asset1.meshes[j].primitives[k].dracoCompression) == (!asset2.meshes[j].primitives[k].dracoCompression));
-			if (asset1.meshes[j].primitives[k].dracoCompression) {
-				REQUIRE (asset1.meshes[j].primitives[k].dracoCompression->bufferView == asset2.meshes[j].primitives[k].dracoCompression->bufferView);
-				REQUIRE(compare_vector_attributes(asset1.meshes[j].primitives[k].dracoCompression->attributes, asset2.meshes[j].primitives[k].dracoCompression->attributes));
-			}
-		}
-		REQUIRE (asset1.meshes[j].name == asset2.meshes[j].name);
-		REQUIRE (isArraySame(asset1.meshes[j].weights, asset2.meshes[j].weights));
-	}
-
-	// nodes
-	REQUIRE (asset1.nodes.size() == asset2.nodes.size());
-	for (std::size_t j = 0; j < asset1.nodes.size(); ++j) {
-		REQUIRE (asset1.nodes[j].meshIndex == asset2.nodes[j].meshIndex);
-		REQUIRE (asset1.nodes[j].skinIndex == asset2.nodes[j].skinIndex);
-		REQUIRE (asset1.nodes[j].cameraIndex == asset2.nodes[j].cameraIndex);
-		REQUIRE (asset1.nodes[j].lightIndex == asset2.nodes[j].lightIndex);
-		REQUIRE (isArraySame(asset1.nodes[j].children, asset2.nodes[j].children));
-		REQUIRE (isArraySame(asset1.nodes[j].weights, asset2.nodes[j].weights));
-		// REQUIRE (asset1.nodes[j].transform == asset2.nodes[j].transform);
-		//        std::variant<TRS, math::fmat4x4> transform;
-
-		REQUIRE(std::holds_alternative<fastgltf::TRS>(asset1.nodes[j].transform) == std::holds_alternative<fastgltf::TRS>(asset2.nodes[j].transform));
-		if (std::holds_alternative<fastgltf::TRS>(asset1.nodes[j].transform)) {
-			auto &a = std::get<fastgltf::TRS>(asset1.nodes[j].transform);
-			auto &b = std::get<fastgltf::TRS>(asset2.nodes[j].transform);
-			REQUIRE (a.translation == b.translation);
-			REQUIRE (a.rotation == b.rotation);
-			REQUIRE (a.scale == b.scale);
-		} else {
-			auto &a = std::get<fastgltf::math::fmat4x4>(asset1.nodes[j].transform);
-			auto &b = std::get<fastgltf::math::fmat4x4>(asset2.nodes[j].transform);
-			REQUIRE (a == b);
-		}
-		REQUIRE(asset1.nodes[j].instancingAttributes.size() == asset2.nodes[j].instancingAttributes.size());
-		for (std::size_t k = 0; k < asset1.nodes[j].instancingAttributes.size(); ++k) {
-			REQUIRE(asset1.nodes[j].instancingAttributes[k].name == asset2.nodes[j].instancingAttributes[k].name);
-			REQUIRE(asset1.nodes[j].instancingAttributes[k].accessorIndex == asset2.nodes[j].instancingAttributes[k].accessorIndex);
-		}
-		compare_vector_attributes(asset1.nodes[j].instancingAttributes, asset2.nodes[j].instancingAttributes);
-		REQUIRE (asset1.nodes[j].name == asset2.nodes[j].name);
-
-	}
-	// samplers
-	REQUIRE (asset1.samplers.size() == asset2.samplers.size());
-	for (std::size_t j = 0; j < asset1.samplers.size(); ++j) {
-		REQUIRE (asset1.samplers[j].magFilter == asset2.samplers[j].magFilter);
-		REQUIRE (asset1.samplers[j].minFilter == asset2.samplers[j].minFilter);
-		REQUIRE (asset1.samplers[j].wrapS == asset2.samplers[j].wrapS);
-		REQUIRE (asset1.samplers[j].wrapT == asset2.samplers[j].wrapT);
-		REQUIRE (asset1.samplers[j].name == asset2.samplers[j].name);
-	}
-        // std::vector<Scene> scenes;
-        // std::vector<Skin> skins;
-        // std::vector<Texture> textures;
-
-		// std::vector<std::string> materialVariants;
-
-	// scenes
-	REQUIRE (asset1.scenes.size() == asset2.scenes.size());
-	for (std::size_t j = 0; j < asset1.scenes.size(); ++j) {
-		REQUIRE (asset1.scenes[j].name == asset2.scenes[j].name);
-		REQUIRE (isArraySame(asset1.scenes[j].nodeIndices, asset2.scenes[j].nodeIndices));
-	}
-	
-	// skins
-	REQUIRE (asset1.skins.size() == asset2.skins.size());
-	for (std::size_t j = 0; j < asset1.skins.size(); ++j) {
-		REQUIRE (asset1.skins[j].name == asset2.skins[j].name);
-		REQUIRE (isArraySame(asset1.skins[j].joints, asset2.skins[j].joints));
-		REQUIRE (asset1.skins[j].skeleton == asset2.skins[j].skeleton);
-		REQUIRE (asset1.skins[j].inverseBindMatrices == asset2.skins[j].inverseBindMatrices);
-	}
-	
-	// textures
-	REQUIRE (asset1.textures.size() == asset2.textures.size());
-	for (std::size_t j = 0; j < asset1.textures.size(); ++j) {
-		REQUIRE (asset1.textures[j].samplerIndex == asset2.textures[j].samplerIndex);
-		REQUIRE (asset1.textures[j].imageIndex == asset2.textures[j].imageIndex);
-		REQUIRE (asset1.textures[j].basisuImageIndex == asset2.textures[j].basisuImageIndex);
-		REQUIRE (asset1.textures[j].ddsImageIndex == asset2.textures[j].ddsImageIndex);
-		REQUIRE (asset1.textures[j].webpImageIndex == asset2.textures[j].webpImageIndex);
-		REQUIRE (asset1.textures[j].name == asset2.textures[j].name);
-	}
-	
-	// material variants
-	REQUIRE (isArraySame(asset1.materialVariants, asset2.materialVariants));
-
-	return true;
-}
-
-
-static void inline test_glb_rewrite(const std::filesystem::path &model_parent_dir, const std::filesystem::path &model_file) {
-	if (!run_official_gltf_validator(sampleAssets / model_parent_dir / model_file)) {
+	if (!skip_official_validator && !run_official_gltf_validator(sampleAssets / model_parent_dir / model_file)) {
 		auto report = std::string( "Failed to validate the model: " + (model_parent_dir / model_file).string());
 		SKIP(report.c_str());
 		return;
@@ -626,33 +132,15 @@ static void inline test_glb_rewrite(const std::filesystem::path &model_parent_di
 	auto samplePath = sampleDir / model_file;
 	fastgltf::GltfFileStream sampleFileStream(samplePath);
 	REQUIRE(sampleFileStream.isOpen());
-	static constexpr auto requiredExtensions = fastgltf::Extensions::KHR_texture_transform |
-			fastgltf::Extensions::KHR_texture_basisu |
-			fastgltf::Extensions::MSFT_texture_dds |
-			fastgltf::Extensions::KHR_mesh_quantization |
-			fastgltf::Extensions::EXT_meshopt_compression |
-			fastgltf::Extensions::KHR_lights_punctual |
-			fastgltf::Extensions::EXT_texture_webp |
-			fastgltf::Extensions::KHR_materials_specular |
-			fastgltf::Extensions::KHR_materials_ior |
-			fastgltf::Extensions::KHR_materials_iridescence |
-			fastgltf::Extensions::KHR_materials_volume |
-			fastgltf::Extensions::KHR_materials_transmission |
-			fastgltf::Extensions::KHR_materials_clearcoat |
-			fastgltf::Extensions::KHR_materials_emissive_strength |
-			fastgltf::Extensions::KHR_materials_sheen |
-			fastgltf::Extensions::KHR_materials_unlit |
-			fastgltf::Extensions::KHR_materials_anisotropy |
-			fastgltf::Extensions::EXT_mesh_gpu_instancing |
-			#if FASTGLTF_ENABLE_DEPRECATED_EXT
-			fastgltf::Extensions::KHR_materials_pbrSpecularGlossiness |
-			#endif
-			fastgltf::Extensions::MSFT_packing_normalRoughnessMetallic |
-			fastgltf::Extensions::MSFT_packing_occlusionRoughnessMetallic |
-			fastgltf::Extensions::KHR_materials_dispersion |		
-			fastgltf::Extensions::KHR_materials_variants |
-			fastgltf::Extensions::KHR_accessor_float64 |
-			fastgltf::Extensions::KHR_draco_mesh_compression;
+	static constexpr auto requiredExtensions = static_cast<fastgltf::Extensions>(~0U);
+
+
+	//std hashset
+	std::unordered_set<std::string_view> requiredExtensionsSet;
+	for (const auto& [name, value] : fastgltf::extensionStrings) {
+		requiredExtensionsSet.insert(name);
+		REQUIRE((requiredExtensions & value) == value);
+	}
 	fastgltf::Parser parser(requiredExtensions);
 	auto options = fastgltf::Options::LoadExternalBuffers | fastgltf::Options::LoadExternalImages ;
 	fastgltf::Expected<fastgltf::Asset> asset = model_file.extension() == ".gltf" ?
@@ -666,26 +154,21 @@ static void inline test_glb_rewrite(const std::filesystem::path &model_parent_di
 
 	fastgltf::FileExporter exporter;
 	auto model_base_name = model_file.stem();
-	auto exportedGLTFPath = exportedFolder / "rewritten_gltf" / model_parent_dir / model_base_name += ".gltf";
-	auto exportedGLBPath = exportedFolder / "rewritten_glb" / model_parent_dir / model_base_name += ".glb";
+	auto exportedGLTFDir = exportedFolder / "rewritten_gltf" / model_parent_dir;
+	auto exportedGLBDir = exportedFolder / "rewritten_glb" / model_parent_dir;
+	auto exportedGLTFPath = exportedGLTFDir / model_base_name += ".gltf";
+	auto exportedGLBPath = exportedGLBDir / model_base_name += ".glb";
+	if (std::filesystem::exists(exportedGLBPath.parent_path())) {
+		// rimraf
+		std::error_code ec;
+		std::filesystem::remove_all(exportedGLBDir, ec);
+		REQUIRE(!ec);
+	}
 	// ensure dir
 	std::filesystem::create_directories(exportedGLBPath.parent_path());
 	auto error = exporter.writeGltfBinary(asset.get(), exportedGLBPath, fastgltf::ExportOptions::ValidateAsset);
 	REQUIRE(error == fastgltf::Error::None);
 	REQUIRE(std::filesystem::exists(exportedGLBPath));
-	// error = exporter.writeGltfJson(asset.get(), exportedGLTFPath, fastgltf::ExportOptions::PrettyPrintJson);
-
-
-	std::uint32_t oldJsonChunkLength = 0;
-	{
-		std::ifstream glb_old(samplePath, std::ios::binary);
-		REQUIRE(glb_old.is_open());
-
-		// Skip over the header
-		glb_old.seekg(sizeof(std::uint32_t) * 3, std::ifstream::beg);
-		// Read the chunk length
-		glb_old.read(reinterpret_cast<char*>(&oldJsonChunkLength), sizeof oldJsonChunkLength);
-	}
 
 	// Make sure the GLB buffer is written
 	std::ifstream glb(exportedGLBPath, std::ios::binary);
@@ -697,7 +180,6 @@ static void inline test_glb_rewrite(const std::filesystem::path &model_parent_di
 	// Read the chunk length
 	std::uint32_t jsonChunkLength = 0;
 	glb.read(reinterpret_cast<char*>(&jsonChunkLength), sizeof jsonChunkLength);
-	// REQUIRE(jsonChunkLength == fastgltf::alignUp(oldJsonChunkLength, 4));
 	
 	// Skip over the chunk type + chunk
 	glb.seekg(sizeof(std::uint32_t) + fastgltf::alignUp(jsonChunkLength, 4), std::ifstream::cur);
@@ -717,15 +199,18 @@ static void inline test_glb_rewrite(const std::filesystem::path &model_parent_di
 
 	glb.close();
 	// Re-read the GLB
-	auto result = run_official_gltf_validator(exportedGLBPath);
-	REQUIRE(result);
+	if (!skip_official_validator) {
+		auto result = run_official_gltf_validator(exportedGLBPath);
+		REQUIRE(result);
+	}
 	fastgltf::Parser new_parser(requiredExtensions);
 	fastgltf::GltfFileStream rewrittenGlb(exportedGLBPath);
 	REQUIRE(rewrittenGlb.isOpen());
 	fastgltf::Expected<fastgltf::Asset> rewrittenAsset = new_parser.loadGltfBinary(rewrittenGlb, exportedGLBPath.parent_path(), options);
 	REQUIRE(rewrittenAsset.error() == fastgltf::Error::None);
 	REQUIRE(getErrorName(fastgltf::validate(rewrittenAsset.get())) == "None");
-	REQUIRE(isSame(asset.get(), rewrittenAsset.get()));
+	// Test that the rewritten asset is equivalent to the original asset
+	REQUIRE(asset.get().equivalent(rewrittenAsset.get()));
 }
 
 std::vector<std::filesystem::path> getSampleAssets(const std::filesystem::path& dir, bool include_text = false, bool include_binary = false) {
@@ -749,7 +234,7 @@ std::vector<std::filesystem::path> getSampleAssets(const std::filesystem::path& 
     return models;
 }
 
-TEST_CASE("Try writing a GLB with all buffers and images (ALL IN MODEL)", "[write-tests]") {
+TEST_CASE("Try writing a GLB with all buffers and images (ALL MODELS)", "[write-tests]") {
 	auto models = getSampleAssets(sampleAssets / "Models", false, true);
 	// Destroy the directory to make sure that the FileExporter correctly creates directories.
 	// auto exportedFolder = path / "export_glb";
@@ -765,14 +250,21 @@ TEST_CASE("Try writing a GLB with all buffers and images (ALL IN MODEL)", "[writ
 		SECTION(rel_dir.string()) {
 			// we want to get the relative directory to sampleAssets
 			auto model_parent_path = std::filesystem::relative(model.parent_path(), sampleAssets);
-			test_glb_rewrite(model_parent_path, model.filename());
+			test_glb_rewrite(model_parent_path, model.filename(), true);
 		}
 	}
 }
 
 TEST_CASE("Try writing a GLB with all buffers and images (DUCK)", "[write-tests]") {
-	test_glb_rewrite(std::filesystem::path("Models") / "Duck" / "glTF-Binary", "Duck.glb");
+	test_glb_rewrite(std::filesystem::path("Models") / "Duck" / "glTF-Binary", "Duck.glb", true);
 }
+
+TEST_CASE("Try writing a GLB with all buffers and images with official validator (DUCK)", "[write-tests]")
+{
+	test_glb_rewrite(std::filesystem::path("Models") / "Duck" / "glTF-Binary", "Duck.glb", false);
+
+}
+
 
 TEST_CASE("Try writing a GLB with all buffers and images", "[write-tests]") {
     auto cubePath = sampleAssets / "Models" / "Cube" / "glTF";
@@ -842,13 +334,18 @@ TEST_CASE("Test pretty-print", "[write-tests]") {
 TEST_CASE("Test all local models and re-export them", "[write-tests]") {
 	// Enable all extensions
 	static constexpr auto requiredExtensions = static_cast<fastgltf::Extensions>(~0U);
+	const auto options = fastgltf::Options::LoadExternalBuffers | fastgltf::Options::LoadExternalImages
+	#if FASTGLTF_PARSE_EXTRAS_AND_ADDITIONAL_EXTENSIONS
+		| fastgltf::Options::ParseAdditionalExtensionsAndExtras
+	#endif
+	;
 	fastgltf::Parser parser(requiredExtensions);
 
-	static std::filesystem::path folderPath = "";
+	static std::filesystem::path folderPath = sampleAssets / "Models";
 	if (folderPath.empty()) {
 		SKIP();
 	}
-
+	auto exportedFolder = path / "export_gltf";
 	std::uint64_t testedAssets = 0;
 	for (const auto& entry : std::filesystem::recursive_directory_iterator(folderPath)) {
 		if (!entry.is_regular_file())
@@ -858,35 +355,51 @@ TEST_CASE("Test all local models and re-export them", "[write-tests]") {
 			continue;
 		if (epath.extension() != ".gltf" && epath.extension() != ".glb")
 			continue;
+		const auto rel = std::filesystem::relative(epath, folderPath);
+		SECTION(rel.string())
+		{
+			auto model_parent_dir = rel.parent_path();
+			auto model_base_name = rel.filename().stem();
+			auto exportedGLTFPath = exportedFolder / "rewritten_gltf" / model_parent_dir / model_base_name += ".gltf";
+			auto exportedDir = exportedGLTFPath.parent_path();
+			if (std::filesystem::exists(exportedDir)) {
+				std::error_code ec;
+				std::filesystem::remove_all(exportedDir, ec);
+				REQUIRE(!ec);
+			}
+			if (!std::filesystem::exists(exportedDir)) {
+				std::filesystem::create_directories(exportedDir);
+			}
+			
+			// Parse the glTF
+			fastgltf::GltfFileStream gltfData(epath);
+			auto model = parser.loadGltf(gltfData, epath.parent_path(), options);
+			if (model.error() == fastgltf::Error::UnsupportedVersion || model.error() == fastgltf::Error::UnknownRequiredExtension || model.error() == fastgltf::Error::InvalidOrMissingAssetField)
+				continue; // Skip any glTF 1.0 or 0.x files or glTFs with unsupported extensions.
 
-		// Parse the glTF
-		fastgltf::GltfFileStream gltfData(epath);
-		auto model = parser.loadGltf(gltfData, epath.parent_path());
-		if (model.error() == fastgltf::Error::UnsupportedVersion || model.error() == fastgltf::Error::UnknownRequiredExtension || model.error() == fastgltf::Error::InvalidOrMissingAssetField)
-			continue; // Skip any glTF 1.0 or 0.x files or glTFs with unsupported extensions.
+			REQUIRE(model.error() == fastgltf::Error::None);
+			REQUIRE(fastgltf::validate(model.get()) == fastgltf::Error::None);
 
-		REQUIRE(model.error() == fastgltf::Error::None);
-		REQUIRE(fastgltf::validate(model.get()) == fastgltf::Error::None);
+			fastgltf::ExportOptions export_options = fastgltf::ExportOptions::None;
+			// Don't pretty print the performance tests, it takes forever
+			if (model_base_name.string().find("Performance") == std::string::npos) {
+				export_options |= fastgltf::ExportOptions::PrettyPrintJson;
+			}
+			fastgltf::FileExporter exporter;
+			auto error = exporter.writeGltfJson(model.get(), exportedGLTFPath, export_options);
+			REQUIRE(error == fastgltf::Error::None);
+			REQUIRE(std::filesystem::exists(exportedGLTFPath));
 
-		// Re-export the glTF as an in-memory JSON
-		fastgltf::Exporter exporter;
-		auto exported = exporter.writeGltfJson(model.get());
-		REQUIRE(exported.error() == fastgltf::Error::None);
-
-		// UTF-8 validation on the exported JSON string
-		auto& exportedJson = exported.get().output;
-		REQUIRE(simdjson::validate_utf8(exportedJson));
-
-		// Parse the re-generated glTF and validate
-		auto regeneratedJson = fastgltf::GltfDataBuffer::FromBytes(
-				reinterpret_cast<const std::byte*>(exportedJson.data()), exportedJson.size());
-		REQUIRE(regeneratedJson.error() == fastgltf::Error::None);
-		auto regeneratedModel = parser.loadGltf(regeneratedJson.get(), epath.parent_path());
-		REQUIRE(regeneratedModel.error() == fastgltf::Error::None);
-
-		REQUIRE(fastgltf::validate(regeneratedModel.get()) == fastgltf::Error::None);
-
-		++testedAssets;
+			// load it
+			fastgltf::GltfFileStream regeneratedData(exportedGLTFPath);
+			REQUIRE(regeneratedData.isOpen());
+			auto regeneratedModel = parser.loadGltfJson(regeneratedData, exportedGLTFPath.parent_path(), options);
+			REQUIRE(regeneratedModel.error() == fastgltf::Error::None);
+			REQUIRE(fastgltf::validate(regeneratedModel.get()) == fastgltf::Error::None);
+			// Test that the rewritten asset is equivalent to the original asset
+			REQUIRE(model.get().equivalent(regeneratedModel.get()));
+			++testedAssets;
+		}
 	}
 	printf("Successfully tested fastgltf exporter on %" PRIu64 " assets.", testedAssets);
 }


### PR DESCRIPTION
Hi,

I wanted to use this library for verifying and manipulating GLB assets, but I ran into a bunch of errors when attempting to validate the rewrite output. Basically, there were a bunch of bugs/missing features in serializing assets, so I have fixed these.

You'll be happy to know that we currently are able to rewrite all of the models contained in the entire gltf-sample-assets repo, and the rewritten outputs are equal to the source models.

In order to implement equality tests for the rewrite tests, I had to implement `operator==` for the GLTF objects. In addition, I made it such that it calls the `REQUIRE` catch2 macro on all the equality sub_tests if the catch2 macros are present; this is to make tracking down test failures easier. 

<img width="699" alt="image" src="https://github.com/user-attachments/assets/853279de-f8ed-4dae-9c1b-f9dc3e4acd2f" />