### PR TITLE
Fix: crash in memcpy with invalid GLB header

### DIFF
--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -4844,6 +4844,10 @@ fg::Expected<fg::Asset> fg::Parser::loadGltfBinary(GltfDataGetter& data, fs::pat
 
 		// TODO: Somehow allow skipping the binary part in the future?
 		if (binaryChunk.chunkLength != 0) {
+			if (binaryChunk.chunkLength > data.totalSize() - data.bytesRead()) {
+				return Error::InvalidGLB;
+			}
+
 			if (config.mapCallback != nullptr) {
 				auto info = config.mapCallback(binaryChunk.chunkLength, config.userPointer);
 				if (info.mappedMemory != nullptr) {


### PR DESCRIPTION
Fixes a crash when binary chunk of GLB declares a size larger than the total file size:
```
#0  __memcpy_avx_unaligned_erms () at ../sysdeps/x86_64/multiarch/memmove-vec-unaligned-erms.S:761
#1  0x000055555564ecac in fastgltf::GltfDataBuffer::read (this=0x7fffffffd770, ptr=0x7ffff6a8f010, count=14090888) at /mnt/work/git/fastgltf/src/io.cpp:99
#2  0x00005555555b0915 in fastgltf::Parser::loadGltfBinary (this=this@entry=0x7fffffffd9f0, data=..., _directory=filesystem::path "", _options=_options@entry=fastgltf::Options::LoadExternalBuffers, 
    categories=categories@entry=fastgltf::Category::All) at /mnt/work/git/fastgltf/src/fastgltf.cpp:4858
#3  0x00005555555b0012 in fastgltf::Parser::loadGltf (this=0x7fffffffd9f0, data=..., _directory=..., _options=fastgltf::Options::LoadExternalBuffers, categories=fastgltf::Category::All)
    at /mnt/work/git/fastgltf/src/fastgltf.cpp:4761
```

Usage:
```
    fastgltf::Parser parser{
        fastgltf::Extensions::KHR_materials_emissive_strength};

    auto data{fastgltf::GltfDataBuffer::FromPath(path)};
    if (data.error() != fastgltf::Error::None)
    {
        printf("Faied to create buffer");
        return EXIT_SUCCESS;
    }

    auto const parent_path{path.parent_path()};
    auto asset{parser.loadGltf(data.get(),
        parent_path,
        fastgltf::Options::LoadExternalBuffers)};
    if (asset.error() != fastgltf::Error::None)
    {
        printf("Failed to load");
        return EXIT_SUCCESS;
    }
```