### PR TITLE
Fix: crash in simdjson with invalid GLB header

### DIFF
--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -4818,7 +4818,7 @@ fg::Expected<fg::Asset> fg::Parser::loadGltfBinary(GltfDataGetter& data, fs::pat
     //  1. JSON chunk
     //  2. BIN chunk (optional)
     auto jsonChunk = readBinaryChunk(data);
-    if (jsonChunk.chunkType != binaryGltfJsonChunkMagic) {
+    if (jsonChunk.chunkType != binaryGltfJsonChunkMagic || jsonChunk.chunkLength > data.totalSize() - sizeof(BinaryGltfHeader)) {
 	    return Error::InvalidGLB;
     }
 


### PR DESCRIPTION
Fixes a crash when JSON chunk of GLB declares a size larger than the total file size:
```
#0  simdjson::haswell::(anonymous namespace)::simd::simd8x64<unsigned char>::simd8x64 (ptr=0x5555558f6fc4 "", this=<optimized out>)
    at /mnt/work/git/fastgltf/deps/simdjson/simdjson.cpp:14814
#1  simdjson::haswell::(anonymous namespace)::stage1::json_structural_indexer::step<128ul> (block=0x5555558f6f84 "", this=<optimized out>, reader=...)
    at /mnt/work/git/fastgltf/deps/simdjson/simdjson.cpp:18892
#2  simdjson::haswell::(anonymous namespace)::stage1::json_structural_indexer::index<128ul> (
    buf=0x5555558ea684 "{\"asset\":{\"generator\":\"COLLADA2GLTF\",\"version\":\"2.0\"},\"scene\":0,\"scenes\":[{\"nodes\":[0]}],\"nodes\":[{\"children\":[1],\"matrix\":[1.0,0.0,0.0,0.0,0.0,0.0,-1.0,0.0,0.0,1.0,0.0,0.0,0.0,0.0,0.0,1.0]},{\"mesh\":0"..., len=15336380, parser=..., partial=<optimized out>)
    at /mnt/work/git/fastgltf/deps/simdjson/simdjson.cpp:18879
#3  simdjson::haswell::dom_parser_implementation::stage1 (this=this@entry=0x5555558e87e0, 
    _buf=0x5555558ea684 "{\"asset\":{\"generator\":\"COLLADA2GLTF\",\"version\":\"2.0\"},\"scene\":0,\"scenes\":[{\"nodes\":[0]}],\"nodes\":[{\"children\":[1],\"matrix\":[1.0,0.0,0.0,0.0,0.0,0.0,-1.0,0.0,0.0,1.0,0.0,0.0,0.0,0.0,0.0,1.0]},{\"mesh\":0"..., _len=<optimized out>, 
    streaming=streaming@entry=simdjson::stage1_mode::regular) at /mnt/work/git/fastgltf/deps/simdjson/simdjson.cpp:20398
#4  0x00005555556649d3 in simdjson::haswell::dom_parser_implementation::parse (this=0x5555558e87e0, _buf=0x5555556d5310 <__afl_area_initial> "", 
    _len=93824995993220, _doc=...) at /mnt/work/git/fastgltf/deps/simdjson/simdjson.cpp:20423
#5  0x000055555564741f in simdjson::dom::parser::parse_into_document(simdjson::dom::document&, unsigned char const*, unsigned long, bool) & (
    this=0x5555558e8430, provided_doc=..., buf=0x5555556d5310 <__afl_area_initial> "", len=len@entry=15336380, realloc_if_needed=false)
    at /mnt/work/git/fastgltf/deps/simdjson/simdjson.h:8121
#6  0x00005555555b0763 in simdjson::dom::parser::parse(unsigned char const*, unsigned long, bool) & (this=0x5555556d5310 <__afl_area_initial>, 
    this@entry=0xea03bc, buf=0x1 <error: Cannot access memory at address 0x1>, len=15336380, realloc_if_needed=false)
    at /mnt/work/git/fastgltf/deps/simdjson/simdjson.h:8140
#7  simdjson::dom::parser::parse(char const*, unsigned long, bool) & (this=0x5555556d5310 <__afl_area_initial>, this@entry=0xea03bc, 
    buf=0x1 <error: Cannot access memory at address 0x1>, len=15336380, realloc_if_needed=false) at /mnt/work/git/fastgltf/deps/simdjson/simdjson.h:8144
#8  simdjson::dom::parser::parse(simdjson::padded_string_view const&) & (this=0x5555556d5310 <__afl_area_initial>, this@entry=0xea03bc, v=...)
    at /mnt/work/git/fastgltf/deps/simdjson/simdjson.h:8153
#9  fastgltf::Parser::loadGltfBinary (this=this@entry=0x7fffffffda10, data=..., _directory=filesystem::path "", 
    _options=_options@entry=fastgltf::Options::LoadExternalBuffers, categories=categories@entry=fastgltf::Category::All)
    at /mnt/work/git/fastgltf/src/fastgltf.cpp:4833
#10 0x00005555555b0012 in fastgltf::Parser::loadGltf (this=0x7fffffffda10, data=..., _directory=..., _options=fastgltf::Options::LoadExternalBuffers, 
    categories=fastgltf::Category::All) at /mnt/work/git/fastgltf/src/fastgltf.cpp:4761
```

Same example program as here: https://github.com/spnda/fastgltf/pull/104
