### PR TITLE
Fix: stack buffer overflow with invalid node transformation properties

### DIFF
--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -3597,12 +3597,15 @@ fg::Error fg::Parser::parseNodes(simdjson::dom::array& nodes, Asset& asset) {
 
         auto error = nodeObject["matrix"].get_array().get(array);
         if (error == SUCCESS) FASTGLTF_LIKELY {
+            if (array.size() != 16) FASTGLTF_UNLIKELY {
+                return Error::InvalidGltf;
+            }
             math::fmat4x4 transformMatrix;
             std::size_t i = 0, j = 0;
 			for (auto num : array) {
                 double val;
                 if (num.get_double().get(val) != SUCCESS) FASTGLTF_UNLIKELY {
-                    break;
+                    return Error::InvalidGltf;
                 }
 				transformMatrix.col(i)[j++] = static_cast<fastgltf::num>(val);
 				if (j == 4) {
@@ -3623,6 +3626,9 @@ fg::Error fg::Parser::parseNodes(simdjson::dom::array& nodes, Asset& asset) {
 
             // There's no matrix, let's see if there's scale, rotation, or rotation fields.
             if (auto scaleError = nodeObject["scale"].get_array().get(array); scaleError == SUCCESS) FASTGLTF_LIKELY {
+                if (array.size() != 3) FASTGLTF_UNLIKELY {
+                    return Error::InvalidGltf;
+                }
                 auto i = 0U;
                 for (auto num : array) {
                     double val;
@@ -3637,6 +3643,9 @@ fg::Error fg::Parser::parseNodes(simdjson::dom::array& nodes, Asset& asset) {
             }
 
             if (auto translationError = nodeObject["translation"].get_array().get(array); translationError == SUCCESS) FASTGLTF_LIKELY {
+                if (array.size() != 3) FASTGLTF_UNLIKELY {
+                    return Error::InvalidGltf;
+                }
                 auto i = 0U;
                 for (auto num : array) {
                     double val;
@@ -3651,6 +3660,9 @@ fg::Error fg::Parser::parseNodes(simdjson::dom::array& nodes, Asset& asset) {
             }
 
             if (auto rotationError = nodeObject["rotation"].get_array().get(array); rotationError == SUCCESS) FASTGLTF_LIKELY {
+                if (array.size() != 4) FASTGLTF_UNLIKELY {
+                    return Error::InvalidGltf;
+                }
                 auto i = 0U;
                 for (auto num : array) {
                     double val;


### PR DESCRIPTION
If the transformation node has more values than allowed i.e `"matrix":[1,0,0.0,0.0,0.0,0.0,0.0,-1.0,0.0,0.0,1.0,0.0,0.0,0.0,0.0,0.0,1.0]`, there is a stack overflow:
```
/mnt/work/git/fastgltf/src/fastgltf.cpp:3607:33: runtime error: store to address 0x7ffff4e05710 with insufficient space for an object of type 'float'
0x7ffff4e05710: note: pointer points here
 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00
              ^ 
=================================================================
==27313==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7ffff4e05710 at pc 0x555555e53c4a bp 0x7fffffffa080 sp 0x7fffffffa070
WRITE of size 4 at 0x7ffff4e05710 thread T0
    #0 0x555555e53c49 in fastgltf::Parser::parseNodes(simdjson::dom::array&, fastgltf::Asset&) /mnt/work/git/fastgltf/src/fastgltf.cpp:3607
    #1 0x555555e59c33 in fastgltf::Parser::parse(simdjson::dom::object, fastgltf::Category) /mnt/work/git/fastgltf/src/fastgltf.cpp:1565
    #2 0x555555e5f599 in fastgltf::Parser::loadGltfBinary(fastgltf::GltfDataGetter&, std::filesystem::__cxx11::path, fastgltf::Options, fastgltf::Category) /mnt/work/git/fastgltf/src/fastgltf.cpp:4873
    #3 0x555555e634db in fastgltf::Parser::loadGltf(fastgltf::GltfDataGetter&, std::filesystem::__cxx11::path, fastgltf::Options, fastgltf::Category) /mnt/work/git/fastgltf/src/fastgltf.cpp:4761
```

PS: I've also noticed an inconsistency here: https://github.com/spnda/fastgltf/blob/49f70e240d8fe3697944b7ff8c88c9278c545d2b/src/fastgltf.cpp#L3604-L3606 all other branches return `Error::InvalidGltf` in similar cases, while this one does a `break`, let me know if I should change it to return `Error::InvalidGltf` as well.