### PR TITLE
add mat4x4 invert function

### DIFF
--- a/include/fastgltf/math.hpp
+++ b/include/fastgltf/math.hpp
@@ -825,6 +825,65 @@ namespace fastgltf::math {
 			vec<T, 4>(l.x(), l.y(), l.z(), 1.f));
 	}
 
+	/** Inverts a 4x4 matrix, if possible. Returns true if success, false if failure.  A pointer to the input can also safely be used as the output */
+	FASTGLTF_EXPORT template <typename T>
+	bool invert(const mat<T, 4, 4>& m, mat<T, 4, 4>* output) noexcept {
+		T a00 = m[0][0];
+		T a01 = m[0][1];
+		T a02 = m[0][2];
+		T a03 = m[0][3];
+		T a10 = m[1][0];
+		T a11 = m[1][1];
+		T a12 = m[1][2];
+		T a13 = m[1][3];
+		T a20 = m[2][0];
+		T a21 = m[2][1];
+		T a22 = m[2][2];
+		T a23 = m[2][3];
+		T a30 = m[3][0];
+		T a31 = m[3][1];
+		T a32 = m[3][2];
+		T a33 = m[3][3];
+
+		T b00 = a00 * a11 - a01 * a10;
+		T b01 = a00 * a12 - a02 * a10;
+		T b02 = a00 * a13 - a03 * a10;
+		T b03 = a01 * a12 - a02 * a11;
+		T b04 = a01 * a13 - a03 * a11;
+		T b05 = a02 * a13 - a03 * a12;
+		T b06 = a20 * a31 - a21 * a30;
+		T b07 = a20 * a32 - a22 * a30;
+		T b08 = a20 * a33 - a23 * a30;
+		T b09 = a21 * a32 - a22 * a31;
+		T b10 = a21 * a33 - a23 * a31;
+		T b11 = a22 * a33 - a23 * a32;
+
+		// Calculate the determinant
+		T det = b00 * b11 - b01 * b10 + b02 * b09 + b03 * b08 - b04 * b07 + b05 * b06;
+		if (det == T(0)) {
+			// Can not invert this matrix
+			return false;
+		}
+		det = T(1) / det;
+		(*output)[0][0] = (a11 * b11 - a12 * b10 + a13 * b09) * det;
+		(*output)[0][1] = (a02 * b10 - a01 * b11 - a03 * b09) * det;
+		(*output)[0][2] = (a31 * b05 - a32 * b04 + a33 * b03) * det;
+		(*output)[0][3] = (a22 * b04 - a21 * b05 - a23 * b03) * det;
+		(*output)[1][0] = (a12 * b08 - a10 * b11 - a13 * b07) * det;
+		(*output)[1][1] = (a00 * b11 - a02 * b08 + a03 * b07) * det;
+		(*output)[1][2] = (a32 * b02 - a30 * b05 - a33 * b01) * det;
+		(*output)[1][3] = (a20 * b05 - a22 * b02 + a23 * b01) * det;
+		(*output)[2][0] = (a10 * b10 - a11 * b08 + a13 * b06) * det;
+		(*output)[2][1] = (a01 * b08 - a00 * b10 - a03 * b06) * det;
+		(*output)[2][2] = (a30 * b04 - a31 * b02 + a33 * b00) * det;
+		(*output)[2][3] = (a21 * b02 - a20 * b04 - a23 * b00) * det;
+		(*output)[3][0] = (a11 * b07 - a10 * b09 - a12 * b06) * det;
+		(*output)[3][1] = (a00 * b09 - a01 * b07 + a02 * b06) * det;
+		(*output)[3][2] = (a31 * b01 - a30 * b03 - a32 * b00) * det;
+		(*output)[3][3] = (a20 * b03 - a21 * b01 + a22 * b00) * det;
+		return true;
+	}
+
 	/** Translates a given transform matrix by the world space translation vector */
 	FASTGLTF_EXPORT template <typename T>
 	[[nodiscard]] auto translate(const mat<T, 4, 4>& m, const vec<T, 3>& translation) noexcept {


### PR DESCRIPTION
I was having problems using the affineInverse function to correctly invert animated cameras to their correct orientation.  It seems like there is a way to do it with affineInverse, but I have not figured out how yet.  Instead I used this function, which calculates the inverted matrix (if that's possible).  That produced the correct matrix for me for my animated cameras.

If there's a way to avoid using this function, please let me know.  I feel like I'm missing something with the affineInverse that's already in fastgltf::math... But in case it helps someone else out, here's the function that's working for me.

Credit: mat4.js from glMatrix (I just converted the code a bit)