### PR TITLE
fix: redudant moves and unused variables warnings

### DIFF
--- a/include/fastgltf/core.hpp
+++ b/include/fastgltf/core.hpp
@@ -625,7 +625,7 @@ namespace fastgltf {
 			if (buffer.error != fastgltf::Error::None) {
 				return buffer.error;
 			}
-			return std::move(buffer);
+			return buffer;
 		}
 
 		static Expected<GltfDataBuffer> FromBytes(const std::byte* bytes, std::size_t count) noexcept {
@@ -633,7 +633,7 @@ namespace fastgltf {
 			if (buffer.error != fastgltf::Error::None) {
 				return buffer.error;
 			}
-			return std::move(buffer);
+			return buffer;
 		}
 
 #if FASTGLTF_CPP_20
@@ -642,7 +642,7 @@ namespace fastgltf {
 			if (buffer.buffer.get() == nullptr) {
 				return buffer.error;
 			}
-			return std::move(buffer);
+			return buffer;
 		}
 #endif
 
@@ -700,7 +700,7 @@ namespace fastgltf {
 			if (buffer.error != fastgltf::Error::None) {
 				return buffer.error;
 			}
-			return std::move(buffer);
+			return buffer;
 		}
 
 		void read(void* ptr, std::size_t count) override;
@@ -761,7 +761,7 @@ namespace fastgltf {
 			if (buffer.buffer.get() == nullptr) {
 				return buffer.error;
 			}
-			return std::move(buffer);
+			return buffer;
 		}
 	};
 	#endif

--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -1618,7 +1618,7 @@ fg::Expected<fg::Asset> fg::Parser::parse(simdjson::dom::object root, Category c
 		}
 	}
 
-	return std::move(asset);
+	return asset;
 }
 
 fg::Error fg::Parser::parseAccessors(simdjson::dom::array& accessors, Asset& asset) {
@@ -7036,7 +7036,7 @@ fg::Expected<fg::ExportResult<std::string>> fg::Exporter::writeGltfJson(const As
     result.output = std::move(outputString);
     result.bufferPaths = std::move(bufferPaths);
     result.imagePaths = std::move(imagePaths);
-    return std::move(result);
+    return result;
 }
 
 fg::Expected<fg::ExportResult<std::vector<std::byte>>> fg::Exporter::writeGltfBinary(const Asset& asset, ExportOptions _options) {
@@ -7133,7 +7133,7 @@ fg::Expected<fg::ExportResult<std::vector<std::byte>>> fg::Exporter::writeGltfBi
         }
     }
 
-    return std::move(result);
+    return result;
 }
 
 namespace fastgltf {

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -100,7 +100,7 @@ void fg::GltfDataBuffer::read(void *ptr, std::size_t count) {
 	idx += count;
 }
 
-fg::span<std::byte> fg::GltfDataBuffer::read(std::size_t count, std::size_t padding) {
+fg::span<std::byte> fg::GltfDataBuffer::read(std::size_t count, [[maybe_unused]] std::size_t padding) {
 	span<std::byte> sub(buffer.get() + idx, count);
 	idx += count;
 	return sub;
@@ -294,7 +294,7 @@ void fg::MappedGltfFile::read(void *ptr, std::size_t count) {
 	idx += count;
 }
 
-fg::span<std::byte> fg::MappedGltfFile::read(std::size_t count, std::size_t padding) {
+fg::span<std::byte> fg::MappedGltfFile::read(std::size_t count, [[maybe_unused]] std::size_t padding) {
 	span<std::byte> sub(static_cast<std::byte*>(mappedFile) + idx, count);
 	idx += count;
 	return sub;


### PR DESCRIPTION
Hi fantastic project you have here

While integrating it into a project with `-Wall -Wextra -Wpedantic` I got a bunch of warnings that I figured would resolve and contribute upstream

Let me know what you think

To reproduce the warnings:

```bash
❯ cmake -B build -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wpedantic"
-- The C compiler identification is GNU 14.3.1
-- The CXX compiler identification is GNU 14.3.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Could NOT find simdjson (missing: simdjson_DIR)
-- fastgltf: Found simdjson (Version 3.12.3)
-- Configuring done (0.4s)
-- Generating done (0.0s)
-- Build files have been written to: /home/andre/dev/lvgl/fastgltf/build
❯ cmake --build build -j$(nproc)
[ 40%] Building CXX object CMakeFiles/fastgltf.dir/src/fastgltf.cpp.o
[ 40%] Building CXX object CMakeFiles/fastgltf.dir/deps/simdjson/simdjson.cpp.o
[ 80%] Building CXX object CMakeFiles/fastgltf.dir/src/base64.cpp.o
[ 80%] Building CXX object CMakeFiles/fastgltf.dir/src/io.cpp.o
In file included from /home/andre/dev/lvgl/fastgltf/src/fastgltf.cpp:51:
/home/andre/dev/lvgl/fastgltf/include/fastgltf/core.hpp: In static member function ‘static fastgltf::Expected<fastgltf::GltfDataBuffer> fastgltf::GltfDataBuffer::FromPath(const std::filesystem::__cxx11::path&)’:
/home/andre/dev/lvgl/fastgltf/include/fastgltf/core.hpp:628:41: warning: redundant move in return statement [-Wredundant-move]
  628 |                         return std::move(buffer);
      |                                ~~~~~~~~~^~~~~~~~
/home/andre/dev/lvgl/fastgltf/include/fastgltf/core.hpp:628:41: note: remove ‘std::move’ call
/home/andre/dev/lvgl/fastgltf/include/fastgltf/core.hpp: In static member function ‘static fastgltf::Expected<fastgltf::GltfDataBuffer> fastgltf::GltfDataBuffer::FromBytes(const std::byte*, std::size_t)’:
/home/andre/dev/lvgl/fastgltf/include/fastgltf/core.hpp:636:41: warning: redundant move in return statement [-Wredundant-move]
  636 |                         return std::move(buffer);
      |                                ~~~~~~~~~^~~~~~~~
/home/andre/dev/lvgl/fastgltf/include/fastgltf/core.hpp:636:41: note: remove ‘std::move’ call
/home/andre/dev/lvgl/fastgltf/include/fastgltf/core.hpp: In static member function ‘static fastgltf::Expected<fastgltf::MappedGltfFile> fastgltf::MappedGltfFile::FromPath(const std::filesystem::__cxx11::path&)’:
/home/andre/dev/lvgl/fastgltf/include/fastgltf/core.hpp:703:41: warning: redundant move in return statement [-Wredundant-move]
  703 |                         return std::move(buffer);
      |                                ~~~~~~~~~^~~~~~~~
/home/andre/dev/lvgl/fastgltf/include/fastgltf/core.hpp:703:41: note: remove ‘std::move’ call
In file included from /home/andre/dev/lvgl/fastgltf/src/io.cpp:29:
/home/andre/dev/lvgl/fastgltf/include/fastgltf/core.hpp: In static member function ‘static fastgltf::Expected<fastgltf::GltfDataBuffer> fastgltf::GltfDataBuffer::FromPath(const std::filesystem::__cxx11::path&)’:
/home/andre/dev/lvgl/fastgltf/include/fastgltf/core.hpp:628:41: warning: redundant move in return statement [-Wredundant-move]
  628 |                         return std::move(buffer);
      |                                ~~~~~~~~~^~~~~~~~
/home/andre/dev/lvgl/fastgltf/include/fastgltf/core.hpp:628:41: note: remove ‘std::move’ call
/home/andre/dev/lvgl/fastgltf/include/fastgltf/core.hpp: In static member function ‘static fastgltf::Expected<fastgltf::GltfDataBuffer> fastgltf::GltfDataBuffer::FromBytes(const std::byte*, std::size_t)’:
/home/andre/dev/lvgl/fastgltf/include/fastgltf/core.hpp:636:41: warning: redundant move in return statement [-Wredundant-move]
  636 |                         return std::move(buffer);
      |                                ~~~~~~~~~^~~~~~~~
/home/andre/dev/lvgl/fastgltf/include/fastgltf/core.hpp:636:41: note: remove ‘std::move’ call
/home/andre/dev/lvgl/fastgltf/include/fastgltf/core.hpp: In static member function ‘static fastgltf::Expected<fastgltf::MappedGltfFile> fastgltf::MappedGltfFile::FromPath(const std::filesystem::__cxx11::path&)’:
/home/andre/dev/lvgl/fastgltf/include/fastgltf/core.hpp:703:41: warning: redundant move in return statement [-Wredundant-move]
  703 |                         return std::move(buffer);
      |                                ~~~~~~~~~^~~~~~~~
/home/andre/dev/lvgl/fastgltf/include/fastgltf/core.hpp:703:41: note: remove ‘std::move’ call
/home/andre/dev/lvgl/fastgltf/src/io.cpp: In member function ‘virtual fastgltf::span<std::byte> fastgltf::GltfDataBuffer::read(std::size_t, std::size_t)’:
/home/andre/dev/lvgl/fastgltf/src/io.cpp:103:77: warning: unused parameter ‘padding’ [-Wunused-parameter]
  103 | fg::span<std::byte> fg::GltfDataBuffer::read(std::size_t count, std::size_t padding) {
      |                                                                 ~~~~~~~~~~~~^~~~~~~
/home/andre/dev/lvgl/fastgltf/src/io.cpp: In member function ‘virtual fastgltf::span<std::byte> fastgltf::MappedGltfFile::read(std::size_t, std::size_t)’:
/home/andre/dev/lvgl/fastgltf/src/io.cpp:297:77: warning: unused parameter ‘padding’ [-Wunused-parameter]
  297 | fg::span<std::byte> fg::MappedGltfFile::read(std::size_t count, std::size_t padding) {
      |                                                                 ~~~~~~~~~~~~^~~~~~~
/home/andre/dev/lvgl/fastgltf/src/fastgltf.cpp: In member function ‘fastgltf::Expected<fastgltf::Asset> fastgltf::Parser::parse(simdjson::dom::object, fastgltf::Category)’:
/home/andre/dev/lvgl/fastgltf/src/fastgltf.cpp:1621:25: warning: redundant move in return statement [-Wredundant-move]
 1621 |         return std::move(asset);
      |                ~~~~~~~~~^~~~~~~
/home/andre/dev/lvgl/fastgltf/src/fastgltf.cpp:1621:25: note: remove ‘std::move’ call
/home/andre/dev/lvgl/fastgltf/src/fastgltf.cpp: In member function ‘fastgltf::Expected<fastgltf::ExportResult<std::__cxx11::basic_string<char> > > fastgltf::Exporter::writeGltfJson(const fastgltf::Asset&, fastgltf::ExportOptions)’:
/home/andre/dev/lvgl/fastgltf/src/fastgltf.cpp:7039:21: warning: redundant move in return statement [-Wredundant-move]
 7039 |     return std::move(result);
      |            ~~~~~~~~~^~~~~~~~
/home/andre/dev/lvgl/fastgltf/src/fastgltf.cpp:7039:21: note: remove ‘std::move’ call
/home/andre/dev/lvgl/fastgltf/src/fastgltf.cpp: In member function ‘fastgltf::Expected<fastgltf::ExportResult<std::vector<std::byte, std::allocator<std::byte> > > > fastgltf::Exporter::writeGltfBinary(const fastgltf::Asset&, fastgltf::ExportOptions)’:
/home/andre/dev/lvgl/fastgltf/src/fastgltf.cpp:7136:21: warning: redundant move in return statement [-Wredundant-move]
 7136 |     return std::move(result);
      |            ~~~~~~~~~^~~~~~~~
/home/andre/dev/lvgl/fastgltf/src/fastgltf.cpp:7136:21: note: remove ‘std::move’ call
[100%] Linking CXX static library libfastgltf.a
[100%] Built target fastgltf