### PR TITLE
Missing <bit> for std::byteswap in util.hpp

### DIFF
--- a/include/fastgltf/util.hpp
+++ b/include/fastgltf/util.hpp
@@ -29,6 +29,7 @@
 
 #if !defined(FASTGLTF_USE_STD_MODULE) || !FASTGLTF_USE_STD_MODULE
 #include <array>
+#include <bit>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>


### PR DESCRIPTION
```
vcpkg_installed/x64-linux/include/fastgltf/util.hpp:392:15: error: missing '#include <bit>'; 'byteswap' must be declared before it is used
  392 |                 return std::byteswap(n);
      |                             ^
/usr/lib/gcc/x86_64-linux-gnu/15/../../../../include/c++/15/bit:112:5: note: declaration here is not visible
  112 |     byteswap(_Tp __value) noexcept
      |     ^
1 error generated.
```

Fix compilation error in GCC-15.