### PR TITLE
Bump base C++ requirement to C++20

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,24 @@
+Language: Cpp
+Standard: c++20
+BasedOnStyle: Google
+ColumnLimit: 100
+UseTab: ForContinuationAndIndentation
+IndentWidth: 4
+TabWidth: 4
+IndentCaseLabels: true
+LambdaBodyIndentation: OuterScope
+IndentPPDirectives: AfterHash
+AlwaysBreakTemplateDeclarations: Yes
+
+IndentRequiresClause: false
+RequiresClausePosition: OwnLine
+RequiresExpressionIndentation: OuterScope
+
+DerivePointerAlignment: false
+AllowShortCaseLabelsOnASingleLine: true
+QualifierAlignment: Left
+AlignConsecutiveShortCaseStatements:
+  Enabled: true
+  AcrossEmptyLines: true
+  AcrossComments: true
+  AlignCaseColons: false

--- a/.github/workflows/ci_x64.yml
+++ b/.github/workflows/ci_x64.yml
@@ -18,9 +18,6 @@ env:
 
 jobs:
   build_windows:
-    strategy:
-      matrix:
-        cpp20: [NO, YES]
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
@@ -37,7 +34,7 @@ jobs:
         run: git clone https://github.com/KhronosGroup/glTF-Sample-Assets ${{ github.workspace }}/${{ env.SAMPLE_ASSETS_LOCATION }}
 
       - name: Configure CMake
-        run: cmake -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DFASTGLTF_ENABLE_TESTS=ON -DFASTGLTF_COMPILE_AS_CPP20=${{ matrix.cpp20 }}
+        run: cmake -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DFASTGLTF_ENABLE_TESTS=ON
 
       - name: Build (Windows)
         run: cmake --build ${{ github.workspace }}/build --config ${{ env.BUILD_TYPE }} --target tests/fastgltf_tests --verbose
@@ -86,7 +83,6 @@ jobs:
       matrix:
         c_compiler: [gcc-12, gcc-13, gcc-14, clang-16, clang-17, clang-18]
         os: [ubuntu-24.04]
-        cpp20: [NO, YES]
         include:
           - cxx_compiler: g++-12
             c_compiler: gcc-12
@@ -120,7 +116,7 @@ jobs:
         run: git clone https://github.com/KhronosGroup/glTF-Sample-Assets ${{ github.workspace }}/${{ env.SAMPLE_ASSETS_LOCATION }}
 
       - name: Configure CMake
-        run: cmake -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DFASTGLTF_ENABLE_TESTS=ON -DFASTGLTF_COMPILE_AS_CPP20=${{ matrix.cpp20 }}
+        run: cmake -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DFASTGLTF_ENABLE_TESTS=ON
 
       - name: Build
         run: cmake --build ${{ github.workspace }}/build --config ${{ env.BUILD_TYPE }} --target fastgltf_tests --verbose

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,17 +15,12 @@ option(FASTGLTF_ENABLE_ASSIMP "Enables the benchmark usage of assimp" OFF)
 option(FASTGLTF_ENABLE_DEPRECATED_EXT "Enables support for deprecated extensions" OFF)
 option(FASTGLTF_DISABLE_CUSTOM_MEMORY_POOL "Disables the memory allocation algorithm based on polymorphic resources" OFF)
 option(FASTGLTF_USE_64BIT_FLOAT "Default to 64-bit double precision floats for everything" OFF)
-option(FASTGLTF_COMPILE_AS_CPP20 "Have the library compile as C++20" OFF)
 option(FASTGLTF_ENABLE_CPP_MODULES "Enables the fastgltf::module target, which uses C++20 modules" OFF)
 option(FASTGLTF_USE_STD_MODULE "Use the std module when compiling using C++ modules" OFF)
 option(FASTGLTF_ENABLE_KHR_IMPLICIT_SHAPES "Enable support for the experimental KHR_implicit_shapes extension" OFF)
 option(FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES "Enable support for the experimental KHR_physics_rigid_bodies extension" OFF)
 
-if (FASTGLTF_COMPILE_AS_CPP20)
-    set(FASTGLTF_COMPILE_TARGET cxx_std_20)
-else ()
-    set(FASTGLTF_COMPILE_TARGET cxx_std_17)
-endif ()
+set(FASTGLTF_COMPILE_TARGET cxx_std_20)
 
 # physics rigid bodies depends on implicit shapes
 if (FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES)

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 [![Documentation Status](https://readthedocs.org/projects/fastgltf/badge/?version=latest)](https://fastgltf.readthedocs.io/latest/?badge=latest)
 
 
-**fastgltf** is a speed and usability focused glTF 2.0 library written in modern C++17 with minimal dependencies.
+**fastgltf** is a speed and usability focused glTF 2.0 library written in modern C++20 with minimal dependencies.
 It uses SIMD in various areas to decrease the time the application spends parsing and loading glTF data.
-By taking advantage of modern C++17 (and optionally C++20) it also provides easy and safe access to the properties and data.
+By taking advantage of modern C++20 it also provides easy and safe access to the properties and data.
 It is also available as a C++20 [named module](https://en.cppreference.com/w/cpp/language/modules).
 
 The library supports the entirety of glTF 2.0 specification, including many extensions.
@@ -18,6 +18,9 @@ However, it brings many additional features to ease working with the data,
 including accessor tools, the ability to directly write to mapped GPU buffers, and decomposing transform matrices.
 
 To learn more about fastgltf, its features, performance and API you can read [the docs](https://fastgltf.readthedocs.io/).
+
+> [!NOTE]  
+> For C++17 compatibility, please use v0.9.x. Later versions require C++20.
 
 ## Examples and real-world usage
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,15 +1,18 @@
 fastgltf
 ========
 
-**fastgltf** is a speed and usability focused glTF 2.0 library written in modern C++17 with minimal dependencies.
+**fastgltf** is a speed and usability focused glTF 2.0 library written in modern C++20 with minimal dependencies.
 It uses SIMD in various areas to decrease the time the application spends parsing and loading glTF data.
-By taking advantage of modern C++17 (and optionally C++20) it also provides easy and safe access to the properties and data.
+By taking advantage of modern C++20 it also provides easy and safe access to the properties and data.
+It is also available as a C++20 `named module <https://en.cppreference.com/w/cpp/language/modules>`_.
 
 The library supports the entirety of glTF 2.0 specification, including many extensions.
 By default, fastgltf will only do the absolute minimum to work with a glTF model.
 However, it brings many additional features to ease working with the data,
 including accessor tools, the ability to directly write to mapped GPU buffers, and decomposing transform matrices.
 
+.. note::
+   For C++17 compatibility, please use v0.9.x. Later versions require C++20.
 
 Indices and tables
 ------------------

--- a/docs/options.rst
+++ b/docs/options.rst
@@ -40,13 +40,6 @@ This allocator allocates fixed-size blocks of memory as needed and divides them 
 All of this functionality can be disabled using this flag.
 All types will then be normal ``std`` containers and use standard heap allocation with new and malloc.
 
-``FASTGLTF_COMPILE_AS_CPP20``
------------------------------
-
-This ``BOOL`` option controls the C++ standard the library is compiled as. When ``NO`` fastgltf is always compiled as C++17.
-When ``YES`` fastgltf is compiled as C++20, including the tests. This might allow the compiler to perform certain optimisations,
-since fastgltf then uses some specialized stdlib functions instead.
-
 ``FASTGLTF_ENABLE_CPP_MODULES``
 -------------------------------
 

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -4,9 +4,9 @@ Overview
 
 .. contents:: Table of Contents
 
-**fastgltf** is a speed and usability focused glTF 2.0 library written in modern C++17 with minimal dependencies.
+**fastgltf** is a speed and usability focused glTF 2.0 library written in modern C++20 with minimal dependencies.
 It uses SIMD in various areas to decrease the time the application spends parsing and loading glTF data.
-By taking advantage of modern C++17 (and optionally C++20) it also provides easy and safe access to the properties and data.
+By taking advantage of modern C++20 it also provides easy and safe access to the properties and data.
 It is also available as a C++20 `named module <https://en.cppreference.com/w/cpp/language/modules>`_.
 
 The library supports the entirety of glTF 2.0 specification, including many extensions.
@@ -14,6 +14,8 @@ By default, **fastgltf** will only do the absolute minimum to work with a glTF m
 However, it brings many additional features to ease working with the data,
 including accessor tools, the ability to directly write to mapped GPU buffers, and decomposing transform matrices.
 
+.. note::
+   For C++17 compatibility, please use v0.9.x. Later versions require C++20.
 
 .. _why:
 
@@ -110,7 +112,7 @@ Usage
 .. _vcpkg: https://github.com/microsoft/vcpkg
 .. _conan: https://conan.io/
 
-**fastgltf** is a pure C++17 library and only depends on simdjson.
+**fastgltf** is a C++20 library and only depends on simdjson.
 By using the included CMake 3.11 script, simdjson is automatically downloaded while configuring by default.
 The library is tested on GCC 9, GCC 10, Clang 13, and MSVC 14 (Visual Studio 2022) using CI.
 **fastgltf** is also available from vcpkg_ and conan_.

--- a/examples/gl_viewer/gl_viewer.cpp
+++ b/examples/gl_viewer/gl_viewer.cpp
@@ -24,54 +24,54 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <GLFW/glfw3.h>
+#include <backends/imgui_impl_glfw.h>
+#include <backends/imgui_impl_opengl3.h>
+#include <glad/gl.h>
+#include <imgui.h>
+
 #include <chrono>
 #include <iostream>
 
-#include <glad/gl.h>
-#include <GLFW/glfw3.h>
-
-#include <imgui.h>
-#include <backends/imgui_impl_glfw.h>
-#include <backends/imgui_impl_opengl3.h>
-
 #define STB_IMAGE_IMPLEMENTATION
-#include "stb_image.h"
-
 #include <fastgltf/core.hpp>
-#include <fastgltf/types.hpp>
 #include <fastgltf/tools.hpp>
+#include <fastgltf/types.hpp>
+
+#include "stb_image.h"
 
 // It's simpler here to just declare the functions as part of the fastgltf::math namespace.
 namespace fastgltf::math {
-	/** Creates a right-handed view matrix */
-	[[nodiscard]] auto lookAtRH(const fvec3& eye, const fvec3& center, const fvec3& up) noexcept {
-		auto dir = normalize(center - eye);
-		auto lft = normalize(cross(dir, up));
-		auto rup = cross(lft, dir);
+/** Creates a right-handed view matrix */
+[[nodiscard]] auto lookAtRH(const fvec3& eye, const fvec3& center, const fvec3& up) noexcept {
+	auto dir = normalize(center - eye);
+	auto lft = normalize(cross(dir, up));
+	auto rup = cross(lft, dir);
 
-		mat<float, 4, 4> ret(1.f);
-		ret.col(0) = { lft.x(), rup.x(), -dir.x(), 0.f };
-		ret.col(1) = { lft.y(), rup.y(), -dir.y(), 0.f };
-		ret.col(2) = { lft.z(), rup.z(), -dir.z(), 0.f };
-		ret.col(3) = { -dot(lft, eye), -dot(rup, eye), dot(dir, eye), 1.f };
-		return ret;
-	}
+	mat<float, 4, 4> ret(1.f);
+	ret.col(0) = {lft.x(), rup.x(), -dir.x(), 0.f};
+	ret.col(1) = {lft.y(), rup.y(), -dir.y(), 0.f};
+	ret.col(2) = {lft.z(), rup.z(), -dir.z(), 0.f};
+	ret.col(3) = {-dot(lft, eye), -dot(rup, eye), dot(dir, eye), 1.f};
+	return ret;
+}
 
-	/**
-	 * Creates a right-handed perspective matrix, with the near and far clips at -1 and +1, respectively.
-	 * @param fov The FOV in radians
-	 */
-	[[nodiscard]] auto perspectiveRH(float fov, float ratio, float zNear, float zFar) noexcept {
-		mat<float, 4, 4> ret(0.f);
-		auto tanHalfFov = std::tanf(fov / 2.f);
-		ret.col(0).x() = 1.f / (ratio * tanHalfFov);
-		ret.col(1).y() = 1.f / tanHalfFov;
-		ret.col(2).z() = -(zFar + zNear) / (zFar - zNear);
-		ret.col(2).w() = -1.f;
-		ret.col(3).z() = -(2.f * zFar * zNear) / (zFar - zNear);
-		return ret;
-	}
-} // namespace fastgltf::math
+/**
+ * Creates a right-handed perspective matrix, with the near and far clips at -1 and +1,
+ * respectively.
+ * @param fov The FOV in radians
+ */
+[[nodiscard]] auto perspectiveRH(float fov, float ratio, float zNear, float zFar) noexcept {
+	mat<float, 4, 4> ret(0.f);
+	auto tanHalfFov = std::tanf(fov / 2.f);
+	ret.col(0).x() = 1.f / (ratio * tanHalfFov);
+	ret.col(1).y() = 1.f / tanHalfFov;
+	ret.col(2).z() = -(zFar + zNear) / (zFar - zNear);
+	ret.col(2).w() = -1.f;
+	ret.col(3).z() = -(2.f * zFar * zNear) / (zFar - zNear);
+	return ret;
+}
+}  // namespace fastgltf::math
 
 constexpr std::string_view vertexShaderSource = R"(
     #version 460 core
@@ -132,42 +132,43 @@ constexpr std::string_view fragmentShaderSource = R"(
     }
 )";
 
-void glMessageCallback(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam) {
-    if (severity == GL_DEBUG_SEVERITY_HIGH) {
-        std::cerr << message << '\n';
-    } else {
-        std::cout << message << '\n';
-    }
+void glMessageCallback(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length,
+					   const GLchar* message, const void* userParam) {
+	if (severity == GL_DEBUG_SEVERITY_HIGH) {
+		std::cerr << message << '\n';
+	} else {
+		std::cout << message << '\n';
+	}
 }
 
 bool checkGlCompileErrors(GLuint shader) {
-    GLint success;
-    constexpr int length = 1024;
-    std::string log;
-    log.resize(length);
-    glGetShaderiv(shader, GL_COMPILE_STATUS, &success);
-    if (success != GL_TRUE) {
-        glGetShaderInfoLog(shader, length, nullptr, log.data());
-        std::cout << "Shader compilation error: " << "\n"
-                  << log << "\n -- --------------------------------------------------- -- " << '\n';
-        return false;
-    }
-    return true;
+	GLint success;
+	constexpr int length = 1024;
+	std::string log;
+	log.resize(length);
+	glGetShaderiv(shader, GL_COMPILE_STATUS, &success);
+	if (success != GL_TRUE) {
+		glGetShaderInfoLog(shader, length, nullptr, log.data());
+		std::cout << "Shader compilation error: " << "\n"
+				  << log << "\n -- --------------------------------------------------- -- " << '\n';
+		return false;
+	}
+	return true;
 }
 
 bool checkGlLinkErrors(GLuint target) {
-    GLint success;
-    constexpr int length = 1024;
-    std::string log;
-    log.resize(length);
-    glGetProgramiv(target, GL_LINK_STATUS, &success);
-    if (success != GL_TRUE) {
-        glGetShaderInfoLog(target, length, nullptr, log.data());
-        std::cout << "Shader program linking error: " << "\n"
-                  << log << "\n -- --------------------------------------------------- -- " << '\n';
-        return false;
-    }
-    return true;
+	GLint success;
+	constexpr int length = 1024;
+	std::string log;
+	log.resize(length);
+	glGetProgramiv(target, GL_LINK_STATUS, &success);
+	if (success != GL_TRUE) {
+		glGetShaderInfoLog(target, length, nullptr, log.data());
+		std::cout << "Shader program linking error: " << "\n"
+				  << log << "\n -- --------------------------------------------------- -- " << '\n';
+		return false;
+	}
+	return true;
 }
 
 struct IndirectDrawCommand {
@@ -184,72 +185,72 @@ struct Vertex {
 };
 
 struct Primitive {
-    IndirectDrawCommand draw;
-    GLenum primitiveType;
-    GLenum indexType;
-    GLuint vertexArray;
+	IndirectDrawCommand draw;
+	GLenum primitiveType;
+	GLenum indexType;
+	GLuint vertexArray;
 
 	GLuint vertexBuffer;
 	GLuint indexBuffer;
 
-    std::size_t materialUniformsIndex;
-    GLuint albedoTexture;
+	std::size_t materialUniformsIndex;
+	GLuint albedoTexture;
 };
 
 struct Mesh {
-    GLuint drawsBuffer;
-    std::vector<Primitive> primitives;
+	GLuint drawsBuffer;
+	std::vector<Primitive> primitives;
 };
 
 struct Texture {
-    GLuint texture;
+	GLuint texture;
 };
 
 enum MaterialUniformFlags : std::uint32_t {
-    None = 0 << 0,
-    HasBaseColorTexture = 1 << 0,
+	None = 0 << 0,
+	HasBaseColorTexture = 1 << 0,
 };
 
 struct MaterialUniforms {
-    fastgltf::math::fvec4 baseColorFactor;
-    float alphaCutoff = 0.f;
+	fastgltf::math::fvec4 baseColorFactor;
+	float alphaCutoff = 0.f;
 	std::uint32_t flags = 0;
 
 	fastgltf::math::fvec2 padding;
 };
 
 struct Viewer {
-    fastgltf::Asset asset;
+	fastgltf::Asset asset;
 
-    std::vector<GLuint> bufferAllocations;
-    std::vector<Mesh> meshes;
-    std::vector<Texture> textures;
+	std::vector<GLuint> bufferAllocations;
+	std::vector<Mesh> meshes;
+	std::vector<Texture> textures;
 	std::vector<fastgltf::math::fmat4x4> cameras;
 
-    std::vector<MaterialUniforms> materials;
-    std::vector<GLuint> materialBuffers;
+	std::vector<MaterialUniforms> materials;
+	std::vector<GLuint> materialBuffers;
 
 	GLint uvOffsetUniform = GL_NONE;
 	GLint uvScaleUniform = GL_NONE;
 	GLint uvRotationUniform = GL_NONE;
 
 	fastgltf::math::ivec2 windowDimensions = fastgltf::math::ivec2(0);
-    fastgltf::math::fmat4x4 viewMatrix = fastgltf::math::fmat4x4(1.0f);
-    fastgltf::math::fmat4x4 projectionMatrix = fastgltf::math::fmat4x4(1.0f);
-    GLint viewProjectionMatrixUniform = GL_NONE;
-    GLint modelMatrixUniform = GL_NONE;
+	fastgltf::math::fmat4x4 viewMatrix = fastgltf::math::fmat4x4(1.0f);
+	fastgltf::math::fmat4x4 projectionMatrix = fastgltf::math::fmat4x4(1.0f);
+	GLint viewProjectionMatrixUniform = GL_NONE;
+	GLint modelMatrixUniform = GL_NONE;
 
-    float lastFrame = 0.0f;
-    float deltaTime = 0.0f;
-    fastgltf::math::fvec3 accelerationVector = fastgltf::math::fvec3(0.0f);
-    fastgltf::math::fvec3 velocity = fastgltf::math::fvec3(0.0f);
-    fastgltf::math::fvec3 position = fastgltf::math::fvec3(0.0f, 0.0f, 0.0f);
+	float lastFrame = 0.0f;
+	float deltaTime = 0.0f;
+	fastgltf::math::fvec3 accelerationVector = fastgltf::math::fvec3(0.0f);
+	fastgltf::math::fvec3 velocity = fastgltf::math::fvec3(0.0f);
+	fastgltf::math::fvec3 position = fastgltf::math::fvec3(0.0f, 0.0f, 0.0f);
 
-    fastgltf::math::dvec2 lastCursorPosition = fastgltf::math::dvec2(0.0f);
-    fastgltf::math::fvec3 direction = fastgltf::math::fvec3(0.0f, 0.0f, -1.0f);
-    float yaw = -90.0f;
-    float pitch = 0.0f;
-    bool firstMouse = true;
+	fastgltf::math::dvec2 lastCursorPosition = fastgltf::math::dvec2(0.0f);
+	fastgltf::math::fvec3 direction = fastgltf::math::fvec3(0.0f, 0.0f, -1.0f);
+	float yaw = -90.0f;
+	float pitch = 0.0f;
+	bool firstMouse = true;
 
 	std::size_t sceneIndex = 0;
 	std::size_t materialVariant = 0;
@@ -257,71 +258,71 @@ struct Viewer {
 };
 
 void updateCameraMatrix(Viewer* viewer) {
-    auto viewProjection = viewer->projectionMatrix * viewer->viewMatrix;
-    glUniformMatrix4fv(viewer->viewProjectionMatrixUniform, 1, GL_FALSE, viewProjection.data());
+	auto viewProjection = viewer->projectionMatrix * viewer->viewMatrix;
+	glUniformMatrix4fv(viewer->viewProjectionMatrixUniform, 1, GL_FALSE, viewProjection.data());
 }
 
 void windowSizeCallback(GLFWwindow* window, int width, int height) {
-    void* ptr = glfwGetWindowUserPointer(window);
-    auto* viewer = static_cast<Viewer*>(ptr);
+	void* ptr = glfwGetWindowUserPointer(window);
+	auto* viewer = static_cast<Viewer*>(ptr);
 
-	viewer->windowDimensions = { width, height };
+	viewer->windowDimensions = {width, height};
 
-    glViewport(0, 0, width, height);
+	glViewport(0, 0, width, height);
 }
 
 void cursorCallback(GLFWwindow* window, double xpos, double ypos) {
-    void* ptr = glfwGetWindowUserPointer(window);
-    auto* viewer = static_cast<Viewer*>(ptr);
+	void* ptr = glfwGetWindowUserPointer(window);
+	auto* viewer = static_cast<Viewer*>(ptr);
 
 	int state = glfwGetMouseButton(window, GLFW_MOUSE_BUTTON_MIDDLE);
 	if (state != GLFW_PRESS) {
-		viewer->lastCursorPosition = { xpos, ypos };
+		viewer->lastCursorPosition = {xpos, ypos};
 		return;
 	}
 
-    if (viewer->firstMouse) {
-        viewer->lastCursorPosition = { xpos, ypos };
-        viewer->firstMouse = false;
-    }
+	if (viewer->firstMouse) {
+		viewer->lastCursorPosition = {xpos, ypos};
+		viewer->firstMouse = false;
+	}
 
-    auto offset = fastgltf::math::fvec2(xpos - viewer->lastCursorPosition.x(), viewer->lastCursorPosition.y() - ypos);
-    viewer->lastCursorPosition = { xpos, ypos };
-    offset *= 0.1f;
+	auto offset = fastgltf::math::fvec2(xpos - viewer->lastCursorPosition.x(),
+										viewer->lastCursorPosition.y() - ypos);
+	viewer->lastCursorPosition = {xpos, ypos};
+	offset *= 0.1f;
 
-    viewer->yaw   += offset.x();
-    viewer->pitch += offset.y();
-    viewer->pitch = fastgltf::math::clamp(viewer->pitch, -89.0f, 89.0f);
+	viewer->yaw += offset.x();
+	viewer->pitch += offset.y();
+	viewer->pitch = fastgltf::math::clamp(viewer->pitch, -89.0f, 89.0f);
 
-    auto& direction = viewer->direction;
-    direction.x() = cos(fastgltf::math::radians(viewer->yaw)) * cos(fastgltf::math::radians(viewer->pitch));
-    direction.y() = sin(fastgltf::math::radians(viewer->pitch));
-    direction.z() = sin(fastgltf::math::radians(viewer->yaw)) * cos(fastgltf::math::radians(viewer->pitch));
-    direction = fastgltf::math::normalize(direction);
+	auto& direction = viewer->direction;
+	direction.x() =
+		cos(fastgltf::math::radians(viewer->yaw)) * cos(fastgltf::math::radians(viewer->pitch));
+	direction.y() = sin(fastgltf::math::radians(viewer->pitch));
+	direction.z() =
+		sin(fastgltf::math::radians(viewer->yaw)) * cos(fastgltf::math::radians(viewer->pitch));
+	direction = fastgltf::math::normalize(direction);
 }
 
 void keyCallback(GLFWwindow* window, int key, int scancode, int action, int mods) {
-    void* ptr = glfwGetWindowUserPointer(window);
-    auto* viewer = static_cast<Viewer*>(ptr);
-    static constexpr auto cameraUp = fastgltf::math::fvec3(0.0f, 1.0f, 0.0f);
+	void* ptr = glfwGetWindowUserPointer(window);
+	auto* viewer = static_cast<Viewer*>(ptr);
+	static constexpr auto cameraUp = fastgltf::math::fvec3(0.0f, 1.0f, 0.0f);
 
-    auto& acceleration = viewer->accelerationVector;
-    switch (key) {
-        case GLFW_KEY_W:
-            acceleration += viewer->direction;
-            break;
-        case GLFW_KEY_S:
-            acceleration -= viewer->direction;
-            break;
-        case GLFW_KEY_D:
-            acceleration += fastgltf::math::normalize(fastgltf::math::cross(viewer->direction, cameraUp));
-            break;
-        case GLFW_KEY_A:
-            acceleration -= fastgltf::math::normalize(fastgltf::math::cross(viewer->direction, cameraUp));
-            break;
-        default:
-            break;
-    }
+	auto& acceleration = viewer->accelerationVector;
+	switch (key) {
+		case GLFW_KEY_W: acceleration += viewer->direction; break;
+		case GLFW_KEY_S: acceleration -= viewer->direction; break;
+		case GLFW_KEY_D:
+			acceleration +=
+				fastgltf::math::normalize(fastgltf::math::cross(viewer->direction, cameraUp));
+			break;
+		case GLFW_KEY_A:
+			acceleration -=
+				fastgltf::math::normalize(fastgltf::math::cross(viewer->direction, cameraUp));
+			break;
+		default: break;
+	}
 }
 
 bool loadGltf(Viewer* viewer, std::filesystem::path path) {
@@ -336,303 +337,321 @@ bool loadGltf(Viewer* viewer, std::filesystem::path path) {
 		std::cout << "Loading " << path << '\n';
 	}
 
-    // Parse the glTF file and get the constructed asset
-    {
-		static constexpr auto supportedExtensions =
-			fastgltf::Extensions::KHR_mesh_quantization |
-			fastgltf::Extensions::KHR_texture_transform |
-			fastgltf::Extensions::KHR_materials_variants;
+	// Parse the glTF file and get the constructed asset
+	{
+		static constexpr auto supportedExtensions = fastgltf::Extensions::KHR_mesh_quantization |
+													fastgltf::Extensions::KHR_texture_transform |
+													fastgltf::Extensions::KHR_materials_variants;
 
-        fastgltf::Parser parser(supportedExtensions);
+		fastgltf::Parser parser(supportedExtensions);
 
-        constexpr auto gltfOptions =
-            fastgltf::Options::DontRequireValidAssetMember |
-            fastgltf::Options::AllowDouble |
-            fastgltf::Options::LoadExternalBuffers |
-            fastgltf::Options::LoadExternalImages |
+		constexpr auto gltfOptions =
+			fastgltf::Options::DontRequireValidAssetMember | fastgltf::Options::AllowDouble |
+			fastgltf::Options::LoadExternalBuffers | fastgltf::Options::LoadExternalImages |
 			fastgltf::Options::GenerateMeshIndices;
 
 		auto gltfFile = fastgltf::MappedGltfFile::FromPath(path);
 		if (!bool(gltfFile)) {
-			std::cerr << "Failed to open glTF file: " << fastgltf::getErrorMessage(gltfFile.error()) << '\n';
+			std::cerr << "Failed to open glTF file: " << fastgltf::getErrorMessage(gltfFile.error())
+					  << '\n';
 			return false;
 		}
 
-        auto asset = parser.loadGltf(gltfFile.get(), path.parent_path(), gltfOptions);
-        if (asset.error() != fastgltf::Error::None) {
-            std::cerr << "Failed to load glTF: " << fastgltf::getErrorMessage(asset.error()) << '\n';
-            return false;
-        }
+		auto asset = parser.loadGltf(gltfFile.get(), path.parent_path(), gltfOptions);
+		if (asset.error() != fastgltf::Error::None) {
+			std::cerr << "Failed to load glTF: " << fastgltf::getErrorMessage(asset.error())
+					  << '\n';
+			return false;
+		}
 
-        viewer->asset = std::move(asset.get());
-    }
+		viewer->asset = std::move(asset.get());
+	}
 
-    return true;
+	return true;
 }
 
 bool loadMesh(Viewer* viewer, fastgltf::Mesh& mesh) {
-    auto& asset = viewer->asset;
-    Mesh outMesh = {};
-    outMesh.primitives.resize(mesh.primitives.size());
+	auto& asset = viewer->asset;
+	Mesh outMesh = {};
+	outMesh.primitives.resize(mesh.primitives.size());
 
-    for (auto it = mesh.primitives.begin(); it != mesh.primitives.end(); ++it) {
+	for (auto it = mesh.primitives.begin(); it != mesh.primitives.end(); ++it) {
 		auto* positionIt = it->findAttribute("POSITION");
-		assert(positionIt != it->attributes.end()); // A mesh primitive is required to hold the POSITION attribute.
-		assert(it->indicesAccessor.has_value()); // We specify GenerateMeshIndices, so we should always have indices
+		assert(
+			positionIt !=
+			it->attributes.end());  // A mesh primitive is required to hold the POSITION attribute.
+		assert(
+			it->indicesAccessor
+				.has_value());  // We specify GenerateMeshIndices, so we should always have indices
 
-        // Generate the VAO
-        GLuint vao = GL_NONE;
-        glCreateVertexArrays(1, &vao);
+		// Generate the VAO
+		GLuint vao = GL_NONE;
+		glCreateVertexArrays(1, &vao);
 
 		std::size_t baseColorTexcoordIndex = 0;
 
-        // Get the output primitive
-        auto index = std::distance(mesh.primitives.begin(), it);
-        auto& primitive = outMesh.primitives[index];
-        primitive.primitiveType = fastgltf::to_underlying(it->type);
-        primitive.vertexArray = vao;
-        if (it->materialIndex.has_value()) {
-            primitive.materialUniformsIndex = it->materialIndex.value() + 1; // Adjust for default material
-            auto& material = viewer->asset.materials[it->materialIndex.value()];
+		// Get the output primitive
+		auto index = std::distance(mesh.primitives.begin(), it);
+		auto& primitive = outMesh.primitives[index];
+		primitive.primitiveType = fastgltf::to_underlying(it->type);
+		primitive.vertexArray = vao;
+		if (it->materialIndex.has_value()) {
+			primitive.materialUniformsIndex =
+				it->materialIndex.value() + 1;  // Adjust for default material
+			auto& material = viewer->asset.materials[it->materialIndex.value()];
 
 			auto& baseColorTexture = material.pbrData.baseColorTexture;
-            if (baseColorTexture.has_value()) {
-                auto& texture = viewer->asset.textures[baseColorTexture->textureIndex];
-				if (!texture.imageIndex.has_value())
-					return false;
-                primitive.albedoTexture = viewer->textures[texture.imageIndex.value()].texture;
+			if (baseColorTexture.has_value()) {
+				auto& texture = viewer->asset.textures[baseColorTexture->textureIndex];
+				if (!texture.imageIndex.has_value()) return false;
+				primitive.albedoTexture = viewer->textures[texture.imageIndex.value()].texture;
 
-				if (baseColorTexture->transform && baseColorTexture->transform->texCoordIndex.has_value()) {
+				if (baseColorTexture->transform &&
+					baseColorTexture->transform->texCoordIndex.has_value()) {
 					baseColorTexcoordIndex = baseColorTexture->transform->texCoordIndex.value();
 				} else {
 					baseColorTexcoordIndex = material.pbrData.baseColorTexture->texCoordIndex;
 				}
-            }
-        } else {
+			}
+		} else {
 			primitive.materialUniformsIndex = 0;
 		}
 
-        {
-            // Position
-            auto& positionAccessor = asset.accessors[positionIt->accessorIndex];
-            if (!positionAccessor.bufferViewIndex.has_value())
-                continue;
+		{
+			// Position
+			auto& positionAccessor = asset.accessors[positionIt->accessorIndex];
+			if (!positionAccessor.bufferViewIndex.has_value()) continue;
 
-			// Create the vertex buffer for this primitive, and use the accessor tools to copy directly into the mapped buffer.
+			// Create the vertex buffer for this primitive, and use the accessor tools to copy
+			// directly into the mapped buffer.
 			glCreateBuffers(1, &primitive.vertexBuffer);
-			glNamedBufferData(primitive.vertexBuffer, positionAccessor.count * sizeof(Vertex), nullptr, GL_STATIC_DRAW);
-			auto* vertices = static_cast<Vertex*>(glMapNamedBuffer(primitive.vertexBuffer, GL_WRITE_ONLY));
-			fastgltf::iterateAccessorWithIndex<fastgltf::math::fvec3>(asset, positionAccessor, [&](fastgltf::math::fvec3 pos, std::size_t idx) {
+			glNamedBufferData(primitive.vertexBuffer, positionAccessor.count * sizeof(Vertex),
+							  nullptr, GL_STATIC_DRAW);
+			auto* vertices =
+				static_cast<Vertex*>(glMapNamedBuffer(primitive.vertexBuffer, GL_WRITE_ONLY));
+			fastgltf::iterateAccessorWithIndex<fastgltf::math::fvec3>(
+				asset, positionAccessor, [&](fastgltf::math::fvec3 pos, std::size_t idx) {
 				vertices[idx].position = fastgltf::math::fvec3(pos.x(), pos.y(), pos.z());
 				vertices[idx].uv = fastgltf::math::fvec2();
 			});
 			glUnmapNamedBuffer(primitive.vertexBuffer);
 
-            glEnableVertexArrayAttrib(vao, 0);
-            glVertexArrayAttribFormat(vao, 0,
-                                      3, GL_FLOAT,
-                                      GL_FALSE, 0);
-            glVertexArrayAttribBinding(vao, 0, 0);
+			glEnableVertexArrayAttrib(vao, 0);
+			glVertexArrayAttribFormat(vao, 0, 3, GL_FLOAT, GL_FALSE, 0);
+			glVertexArrayAttribBinding(vao, 0, 0);
 
-			glVertexArrayVertexBuffer(vao, 0, primitive.vertexBuffer,
-									  0, sizeof(Vertex));
-        }
+			glVertexArrayVertexBuffer(vao, 0, primitive.vertexBuffer, 0, sizeof(Vertex));
+		}
 
 		auto texcoordAttribute = std::string("TEXCOORD_") + std::to_string(baseColorTexcoordIndex);
-        if (const auto* texcoord = it->findAttribute(texcoordAttribute); texcoord != it->attributes.end()) {
-            // Tex coord
+		if (const auto* texcoord = it->findAttribute(texcoordAttribute);
+			texcoord != it->attributes.end()) {
+			// Tex coord
 			auto& texCoordAccessor = asset.accessors[texcoord->accessorIndex];
-            if (!texCoordAccessor.bufferViewIndex.has_value())
-                continue;
+			if (!texCoordAccessor.bufferViewIndex.has_value()) continue;
 
-			auto* vertices = static_cast<Vertex*>(glMapNamedBuffer(primitive.vertexBuffer, GL_WRITE_ONLY));
-			fastgltf::iterateAccessorWithIndex<fastgltf::math::fvec2>(asset, texCoordAccessor, [&](fastgltf::math::fvec2 uv, std::size_t idx) {
+			auto* vertices =
+				static_cast<Vertex*>(glMapNamedBuffer(primitive.vertexBuffer, GL_WRITE_ONLY));
+			fastgltf::iterateAccessorWithIndex<fastgltf::math::fvec2>(
+				asset, texCoordAccessor, [&](fastgltf::math::fvec2 uv, std::size_t idx) {
 				vertices[idx].uv = fastgltf::math::fvec2(uv.x(), uv.y());
 			});
 			glUnmapNamedBuffer(primitive.vertexBuffer);
 
 			glEnableVertexArrayAttrib(vao, 1);
-            glVertexArrayAttribFormat(vao, 1,
-									  2, GL_FLOAT,
-                                      GL_FALSE, 0);
-            glVertexArrayAttribBinding(vao, 1, 1);
+			glVertexArrayAttribFormat(vao, 1, 2, GL_FLOAT, GL_FALSE, 0);
+			glVertexArrayAttribBinding(vao, 1, 1);
 
-			glVertexArrayVertexBuffer(vao, 1, primitive.vertexBuffer,
-									  offsetof(Vertex, uv), sizeof(Vertex));
-        }
+			glVertexArrayVertexBuffer(vao, 1, primitive.vertexBuffer, offsetof(Vertex, uv),
+									  sizeof(Vertex));
+		}
 
-        // Generate the indirect draw command
-        auto& draw = primitive.draw;
-        draw.instanceCount = 1;
-        draw.baseInstance = 0;
-        draw.baseVertex = 0;
+		// Generate the indirect draw command
+		auto& draw = primitive.draw;
+		draw.instanceCount = 1;
+		draw.baseInstance = 0;
+		draw.baseVertex = 0;
 		draw.firstIndex = 0;
 
-        auto& indexAccessor = asset.accessors[it->indicesAccessor.value()];
-        if (!indexAccessor.bufferViewIndex.has_value())
-            return false;
-        draw.count = static_cast<std::uint32_t>(indexAccessor.count);
+		auto& indexAccessor = asset.accessors[it->indicesAccessor.value()];
+		if (!indexAccessor.bufferViewIndex.has_value()) return false;
+		draw.count = static_cast<std::uint32_t>(indexAccessor.count);
 
 		// Create the index buffer and copy the indices into it.
 		glCreateBuffers(1, &primitive.indexBuffer);
-		if (indexAccessor.componentType == fastgltf::ComponentType::UnsignedByte || indexAccessor.componentType == fastgltf::ComponentType::UnsignedShort) {
-        	primitive.indexType = GL_UNSIGNED_SHORT;
+		if (indexAccessor.componentType == fastgltf::ComponentType::UnsignedByte ||
+			indexAccessor.componentType == fastgltf::ComponentType::UnsignedShort) {
+			primitive.indexType = GL_UNSIGNED_SHORT;
 			glNamedBufferData(primitive.indexBuffer,
-							  static_cast<GLsizeiptr>(indexAccessor.count * sizeof(std::uint16_t)), nullptr,
-							  GL_STATIC_DRAW);
-			auto* indices = static_cast<std::uint16_t*>(glMapNamedBuffer(primitive.indexBuffer, GL_WRITE_ONLY));
+							  static_cast<GLsizeiptr>(indexAccessor.count * sizeof(std::uint16_t)),
+							  nullptr, GL_STATIC_DRAW);
+			auto* indices =
+				static_cast<std::uint16_t*>(glMapNamedBuffer(primitive.indexBuffer, GL_WRITE_ONLY));
 			fastgltf::copyFromAccessor<std::uint16_t>(asset, indexAccessor, indices);
 			glUnmapNamedBuffer(primitive.indexBuffer);
 		} else {
-        	primitive.indexType = GL_UNSIGNED_INT;
+			primitive.indexType = GL_UNSIGNED_INT;
 			glNamedBufferData(primitive.indexBuffer,
-							  static_cast<GLsizeiptr>(indexAccessor.count * sizeof(std::uint32_t)), nullptr,
-							  GL_STATIC_DRAW);
-			auto* indices = static_cast<std::uint32_t*>(glMapNamedBuffer(primitive.indexBuffer, GL_WRITE_ONLY));
+							  static_cast<GLsizeiptr>(indexAccessor.count * sizeof(std::uint32_t)),
+							  nullptr, GL_STATIC_DRAW);
+			auto* indices =
+				static_cast<std::uint32_t*>(glMapNamedBuffer(primitive.indexBuffer, GL_WRITE_ONLY));
 			fastgltf::copyFromAccessor<std::uint32_t>(asset, indexAccessor, indices);
 			glUnmapNamedBuffer(primitive.indexBuffer);
 		}
 
-        glVertexArrayElementBuffer(vao, primitive.indexBuffer);
-    }
+		glVertexArrayElementBuffer(vao, primitive.indexBuffer);
+	}
 
-    // Create the buffer holding all of our primitive structs.
-    glCreateBuffers(1, &outMesh.drawsBuffer);
-    glNamedBufferData(outMesh.drawsBuffer, static_cast<GLsizeiptr>(outMesh.primitives.size() * sizeof(Primitive)),
-                      outMesh.primitives.data(), GL_STATIC_DRAW);
+	// Create the buffer holding all of our primitive structs.
+	glCreateBuffers(1, &outMesh.drawsBuffer);
+	glNamedBufferData(outMesh.drawsBuffer,
+					  static_cast<GLsizeiptr>(outMesh.primitives.size() * sizeof(Primitive)),
+					  outMesh.primitives.data(), GL_STATIC_DRAW);
 
-    viewer->meshes.emplace_back(outMesh);
+	viewer->meshes.emplace_back(outMesh);
 
-    return true;
+	return true;
 }
 
 bool loadImage(Viewer* viewer, fastgltf::Image& image) {
-    auto getLevelCount = [](int width, int height) -> GLsizei {
-        return static_cast<GLsizei>(1 + floor(log2(width > height ? width : height)));
-    };
+	auto getLevelCount = [](int width, int height) -> GLsizei {
+		return static_cast<GLsizei>(1 + floor(log2(width > height ? width : height)));
+	};
 
-    GLuint texture;
-    glCreateTextures(GL_TEXTURE_2D, 1, &texture);
-    std::visit(fastgltf::visitor {
-        [](auto& arg) {},
-        [&](fastgltf::sources::URI& filePath) {
-            assert(filePath.fileByteOffset == 0); // We don't support offsets with stbi.
-            assert(filePath.uri.isLocalPath()); // We're only capable of loading local files.
-            int width, height, nrChannels;
+	GLuint texture;
+	glCreateTextures(GL_TEXTURE_2D, 1, &texture);
+	std::visit(fastgltf::visitor{
+				   [](auto& arg) {},
+				   [&](fastgltf::sources::URI& filePath) {
+		assert(filePath.fileByteOffset == 0);  // We don't support offsets with stbi.
+		assert(filePath.uri.isLocalPath());    // We're only capable of loading local files.
+		int width, height, nrChannels;
 
-            const std::string path(filePath.uri.path().begin(), filePath.uri.path().end()); // Thanks C++.
-            unsigned char *data = stbi_load(path.c_str(), &width, &height, &nrChannels, 4);
-            glTextureStorage2D(texture, getLevelCount(width, height), GL_RGBA8, width, height);
-            glTextureSubImage2D(texture, 0, 0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, data);
-            stbi_image_free(data);
-        },
-        [&](fastgltf::sources::Array& vector) {
-            int width, height, nrChannels;
-            unsigned char *data = stbi_load_from_memory(reinterpret_cast<const stbi_uc*>(vector.bytes.data()), static_cast<int>(vector.bytes.size()), &width, &height, &nrChannels, 4);
-            glTextureStorage2D(texture, getLevelCount(width, height), GL_RGBA8, width, height);
-            glTextureSubImage2D(texture, 0, 0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, data);
-            stbi_image_free(data);
-        },
-        [&](fastgltf::sources::BufferView& view) {
-            auto& bufferView = viewer->asset.bufferViews[view.bufferViewIndex];
-            auto& buffer = viewer->asset.buffers[bufferView.bufferIndex];
-            // Yes, we've already loaded every buffer into some GL buffer. However, with GL it's simpler
-            // to just copy the buffer data again for the texture. Besides, this is just an example.
-            std::visit(fastgltf::visitor {
-                // We only care about VectorWithMime here, because we specify LoadExternalBuffers, meaning
-                // all buffers are already loaded into a vector.
-                [](auto& arg) {},
-                [&](fastgltf::sources::Array& vector) {
-                    int width, height, nrChannels;
-					unsigned char* data = stbi_load_from_memory(reinterpret_cast<const stbi_uc*>(vector.bytes.data() + bufferView.byteOffset),
-					                                            static_cast<int>(bufferView.byteLength), &width, &height, &nrChannels, 4);
-                    glTextureStorage2D(texture, getLevelCount(width, height), GL_RGBA8, width, height);
-                    glTextureSubImage2D(texture, 0, 0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, data);
-                    stbi_image_free(data);
-                }
-            }, buffer.data);
-        },
-    }, image.data);
+		const std::string path(filePath.uri.path().begin(),
+							   filePath.uri.path().end());  // Thanks C++.
+		unsigned char* data = stbi_load(path.c_str(), &width, &height, &nrChannels, 4);
+		glTextureStorage2D(texture, getLevelCount(width, height), GL_RGBA8, width, height);
+		glTextureSubImage2D(texture, 0, 0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, data);
+		stbi_image_free(data);
+	},
+				   [&](fastgltf::sources::Array& vector) {
+		int width, height, nrChannels;
+		unsigned char* data = stbi_load_from_memory(
+			reinterpret_cast<const stbi_uc*>(vector.bytes.data()),
+			static_cast<int>(vector.bytes.size()), &width, &height, &nrChannels, 4);
+		glTextureStorage2D(texture, getLevelCount(width, height), GL_RGBA8, width, height);
+		glTextureSubImage2D(texture, 0, 0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, data);
+		stbi_image_free(data);
+	},
+				   [&](fastgltf::sources::BufferView& view) {
+		auto& bufferView = viewer->asset.bufferViews[view.bufferViewIndex];
+		auto& buffer = viewer->asset.buffers[bufferView.bufferIndex];
+		// Yes, we've already loaded every buffer into some GL buffer. However, with GL it's simpler
+		// to just copy the buffer data again for the texture. Besides, this is just an example.
+		std::visit(fastgltf::visitor{// We only care about VectorWithMime here, because we specify
+									 // LoadExternalBuffers, meaning
+									 // all buffers are already loaded into a vector.
+									 [](auto& arg) {},
+									 [&](fastgltf::sources::Array& vector) {
+			int width, height, nrChannels;
+			unsigned char* data = stbi_load_from_memory(
+				reinterpret_cast<const stbi_uc*>(vector.bytes.data() + bufferView.byteOffset),
+				static_cast<int>(bufferView.byteLength), &width, &height, &nrChannels, 4);
+			glTextureStorage2D(texture, getLevelCount(width, height), GL_RGBA8, width, height);
+			glTextureSubImage2D(texture, 0, 0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, data);
+			stbi_image_free(data);
+		}},
+				   buffer.data);
+	},
+			   },
+			   image.data);
 
-    glGenerateTextureMipmap(texture);
+	glGenerateTextureMipmap(texture);
 
-    viewer->textures.emplace_back(Texture { texture });
-    return true;
+	viewer->textures.emplace_back(Texture{texture});
+	return true;
 }
 
 bool loadMaterial(Viewer* viewer, fastgltf::Material& material) {
-    MaterialUniforms uniforms = {};
-    uniforms.alphaCutoff = material.alphaCutoff;
+	MaterialUniforms uniforms = {};
+	uniforms.alphaCutoff = material.alphaCutoff;
 
-    uniforms.baseColorFactor = material.pbrData.baseColorFactor;
-    if (material.pbrData.baseColorTexture.has_value()) {
-        uniforms.flags |= MaterialUniformFlags::HasBaseColorTexture;
-    }
+	uniforms.baseColorFactor = material.pbrData.baseColorFactor;
+	if (material.pbrData.baseColorTexture.has_value()) {
+		uniforms.flags |= MaterialUniformFlags::HasBaseColorTexture;
+	}
 
-    viewer->materials.emplace_back(uniforms);
-    return true;
+	viewer->materials.emplace_back(uniforms);
+	return true;
 }
 
 bool loadCamera(Viewer* viewer, fastgltf::Camera& camera) {
 	// The following matrix math is for the projection matrices as defined by the glTF spec:
 	// https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#projection-matrices
-	std::visit(fastgltf::visitor {
-		[&](fastgltf::Camera::Perspective& perspective) {
-			fastgltf::math::fmat4x4 mat(0.0f);
+	std::visit(fastgltf::visitor{
+				   [&](fastgltf::Camera::Perspective& perspective) {
+		fastgltf::math::fmat4x4 mat(0.0f);
 
-			assert(viewer->windowDimensions[0] != 0 && viewer->windowDimensions[1] != 0);
-			auto aspectRatio = perspective.aspectRatio.value_or(
-				static_cast<float>(viewer->windowDimensions[0]) / static_cast<float>(viewer->windowDimensions[1]));
-			mat[0][0] = 1.f / (aspectRatio * tan(0.5f * perspective.yfov));
-			mat[1][1] = 1.f / (tan(0.5f * perspective.yfov));
-			mat[2][3] = -1;
+		assert(viewer->windowDimensions[0] != 0 && viewer->windowDimensions[1] != 0);
+		auto aspectRatio =
+			perspective.aspectRatio.value_or(static_cast<float>(viewer->windowDimensions[0]) /
+											 static_cast<float>(viewer->windowDimensions[1]));
+		mat[0][0] = 1.f / (aspectRatio * tan(0.5f * perspective.yfov));
+		mat[1][1] = 1.f / (tan(0.5f * perspective.yfov));
+		mat[2][3] = -1;
 
-			if (perspective.zfar.has_value()) {
-				// Finite projection matrix
-				mat[2][2] = (*perspective.zfar + perspective.znear) / (perspective.znear - *perspective.zfar);
-				mat[3][2] = (2 * *perspective.zfar * perspective.znear) / (perspective.znear - *perspective.zfar);
-			} else {
-				// Infinite projection matrix
-				mat[2][2] = -1;
-				mat[3][2] = -2 * perspective.znear;
-			}
-			viewer->cameras.emplace_back(mat);
-		},
-		[&](fastgltf::Camera::Orthographic& orthographic) {
-			fastgltf::math::fmat4x4 mat(1.0f);
-			mat[0][0] = 1.f / orthographic.xmag;
-			mat[1][1] = 1.f / orthographic.ymag;
-			mat[2][2] = 2.f / (orthographic.znear - orthographic.zfar);
-			mat[3][2] = (orthographic.zfar + orthographic.znear) / (orthographic.znear - orthographic.zfar);
-			viewer->cameras.emplace_back(mat);
-		},
-	}, camera.camera);
+		if (perspective.zfar.has_value()) {
+			// Finite projection matrix
+			mat[2][2] =
+				(*perspective.zfar + perspective.znear) / (perspective.znear - *perspective.zfar);
+			mat[3][2] = (2 * *perspective.zfar * perspective.znear) /
+						(perspective.znear - *perspective.zfar);
+		} else {
+			// Infinite projection matrix
+			mat[2][2] = -1;
+			mat[3][2] = -2 * perspective.znear;
+		}
+		viewer->cameras.emplace_back(mat);
+	},
+				   [&](fastgltf::Camera::Orthographic& orthographic) {
+		fastgltf::math::fmat4x4 mat(1.0f);
+		mat[0][0] = 1.f / orthographic.xmag;
+		mat[1][1] = 1.f / orthographic.ymag;
+		mat[2][2] = 2.f / (orthographic.znear - orthographic.zfar);
+		mat[3][2] =
+			(orthographic.zfar + orthographic.znear) / (orthographic.znear - orthographic.zfar);
+		viewer->cameras.emplace_back(mat);
+	},
+			   },
+			   camera.camera);
 	return true;
 }
 
 void drawMesh(Viewer* viewer, std::size_t meshIndex, fastgltf::math::fmat4x4 matrix) {
-    auto& mesh = viewer->meshes[meshIndex];
+	auto& mesh = viewer->meshes[meshIndex];
 
-    glBindBuffer(GL_DRAW_INDIRECT_BUFFER, mesh.drawsBuffer);
+	glBindBuffer(GL_DRAW_INDIRECT_BUFFER, mesh.drawsBuffer);
 
-    glUniformMatrix4fv(viewer->modelMatrixUniform, 1, GL_FALSE, &matrix[0][0]);
+	glUniformMatrix4fv(viewer->modelMatrixUniform, 1, GL_FALSE, &matrix[0][0]);
 
-    for (auto i = 0U; i < mesh.primitives.size(); ++i) {
-        auto& prim = mesh.primitives[i];
+	for (auto i = 0U; i < mesh.primitives.size(); ++i) {
+		auto& prim = mesh.primitives[i];
 		auto& gltfPrimitive = viewer->asset.meshes[meshIndex].primitives[i];
 
 		std::size_t materialIndex;
 		auto& mappings = gltfPrimitive.mappings;
 		if (!mappings.empty() && mappings[viewer->materialVariant].has_value()) {
-			materialIndex = mappings[viewer->materialVariant].value() + 1; // Adjust for default material
+			materialIndex =
+				mappings[viewer->materialVariant].value() + 1;  // Adjust for default material
 		} else {
 			materialIndex = prim.materialUniformsIndex;
 		}
 
-        auto& material = viewer->materialBuffers[materialIndex];
-        glBindTextureUnit(0, prim.albedoTexture);
-        glBindBufferBase(GL_UNIFORM_BUFFER, 0, material);
-        glBindVertexArray(prim.vertexArray);
+		auto& material = viewer->materialBuffers[materialIndex];
+		glBindTextureUnit(0, prim.albedoTexture);
+		glBindBufferBase(GL_UNIFORM_BUFFER, 0, material);
+		glBindVertexArray(prim.vertexArray);
 
 		// Update texture transform uniforms
 		glUniform2f(viewer->uvOffsetUniform, 0, 0);
@@ -640,20 +659,23 @@ void drawMesh(Viewer* viewer, std::size_t meshIndex, fastgltf::math::fmat4x4 mat
 		glUniform1f(viewer->uvRotationUniform, 0);
 		if (materialIndex != 0) {
 			auto& gltfMaterial = viewer->asset.materials[materialIndex - 1];
-			if (gltfMaterial.pbrData.baseColorTexture.has_value() && gltfMaterial.pbrData.baseColorTexture->transform) {
+			if (gltfMaterial.pbrData.baseColorTexture.has_value() &&
+				gltfMaterial.pbrData.baseColorTexture->transform) {
 				auto& transform = gltfMaterial.pbrData.baseColorTexture->transform;
-				glUniform2f(viewer->uvOffsetUniform, transform->uvOffset[0], transform->uvOffset[1]);
+				glUniform2f(viewer->uvOffsetUniform, transform->uvOffset[0],
+							transform->uvOffset[1]);
 				glUniform2f(viewer->uvScaleUniform, transform->uvScale[0], transform->uvScale[1]);
 				glUniform1f(viewer->uvRotationUniform, static_cast<float>(transform->rotation));
 			}
 		}
 
-        glDrawElementsIndirect(prim.primitiveType, prim.indexType,
-                               reinterpret_cast<const void*>(i * sizeof(Primitive)));
-    }
+		glDrawElementsIndirect(prim.primitiveType, prim.indexType,
+							   reinterpret_cast<const void*>(i * sizeof(Primitive)));
+	}
 }
 
-void updateCameraNodes(Viewer* viewer, std::vector<fastgltf::Node*>& cameraNodes, std::size_t nodeIndex) {
+void updateCameraNodes(Viewer* viewer, std::vector<fastgltf::Node*>& cameraNodes,
+					   std::size_t nodeIndex) {
 	// This function recursively traverses the node hierarchy starting with the node at nodeIndex
 	// to find any nodes holding cameras.
 	auto& node = viewer->asset.nodes[nodeIndex];
@@ -677,41 +699,44 @@ int wmain(int argc, wchar_t* argv[]) {
 		std::cerr << "No gltf file specified." << '\n';
 		return -1;
 	}
-	auto gltfFile = std::wstring_view { argv[1] };
+	auto gltfFile = std::wstring_view{argv[1]};
 #else
 int main(int argc, char* argv[]) {
-    if (argc < 2) {
-        std::cerr << "No gltf file specified." << '\n';
-        return -1;
-    }
-    auto gltfFile = std::string_view { argv[1] };
+	if (argc < 2) {
+		std::cerr << "No gltf file specified." << '\n';
+		return -1;
+	}
+	auto gltfFile = std::string_view{argv[1]};
 #endif
 
-    Viewer viewer;
+	Viewer viewer;
 
-    if (glfwInit() != GLFW_TRUE) {
-        std::cerr << "Failed to initialize glfw." << '\n';
-        return -1;
-    }
+	if (glfwInit() != GLFW_TRUE) {
+		std::cerr << "Failed to initialize glfw." << '\n';
+		return -1;
+	}
 
-    auto* mainMonitor = glfwGetPrimaryMonitor();
-    const auto* vidMode = glfwGetVideoMode(mainMonitor);
+	auto* mainMonitor = glfwGetPrimaryMonitor();
+	const auto* vidMode = glfwGetVideoMode(mainMonitor);
 
-    glfwWindowHint(GLFW_SAMPLES, 4);
+	glfwWindowHint(GLFW_SAMPLES, 4);
 
-    GLFWwindow* window = glfwCreateWindow(static_cast<int>(static_cast<float>(vidMode->width) * 0.9f), static_cast<int>(static_cast<float>(vidMode->height) * 0.9f), "gl_viewer", nullptr, nullptr);
-    if (window == nullptr) {
-        std::cerr << "Failed to create window" << '\n';
-        return -1;
-    }
-    glfwSetWindowUserPointer(window, &viewer);
-    glfwMakeContextCurrent(window);
+	GLFWwindow* window =
+		glfwCreateWindow(static_cast<int>(static_cast<float>(vidMode->width) * 0.9f),
+						 static_cast<int>(static_cast<float>(vidMode->height) * 0.9f), "gl_viewer",
+						 nullptr, nullptr);
+	if (window == nullptr) {
+		std::cerr << "Failed to create window" << '\n';
+		return -1;
+	}
+	glfwSetWindowUserPointer(window, &viewer);
+	glfwMakeContextCurrent(window);
 
-    glfwSetKeyCallback(window, keyCallback);
-    glfwSetCursorPosCallback(window, cursorCallback);
-    glfwSetWindowSizeCallback(window, windowSizeCallback);
+	glfwSetKeyCallback(window, keyCallback);
+	glfwSetCursorPosCallback(window, cursorCallback);
+	glfwSetWindowSizeCallback(window, windowSizeCallback);
 
-    // glfwSetInputMode(window, GLFW_CURSOR, GLFW_CURSOR_DISABLED);
+	// glfwSetInputMode(window, GLFW_CURSOR, GLFW_CURSOR_DISABLED);
 
 	IMGUI_CHECKVERSION();
 	ImGui::CreateContext();
@@ -721,54 +746,51 @@ int main(int argc, char* argv[]) {
 	ImGui_ImplGlfw_InitForOpenGL(window, true);
 	ImGui_ImplOpenGL3_Init();
 
-    if (!gladLoadGL(glfwGetProcAddress)) {
-        std::cerr << "Failed to initialize OpenGL context." << '\n';
-        return -1;
-    }
+	if (!gladLoadGL(glfwGetProcAddress)) {
+		std::cerr << "Failed to initialize OpenGL context." << '\n';
+		return -1;
+	}
 
-    const auto *glRenderer = glGetString(GL_RENDERER);
-    const auto *glVersion = glGetString(GL_VERSION);
-    std::cout << "GL Renderer: " << glRenderer << "\nGL Version: " << glVersion << '\n';
+	const auto* glRenderer = glGetString(GL_RENDERER);
+	const auto* glVersion = glGetString(GL_VERSION);
+	std::cout << "GL Renderer: " << glRenderer << "\nGL Version: " << glVersion << '\n';
 
-    if (GLAD_GL_VERSION_4_6 != 1) {
-        std::cerr << "Missing support for GL 4.6" << '\n';
-        return -1;
-    }
+	if (GLAD_GL_VERSION_4_6 != 1) {
+		std::cerr << "Missing support for GL 4.6" << '\n';
+		return -1;
+	}
 
-    glEnable(GL_DEBUG_OUTPUT);
+	glEnable(GL_DEBUG_OUTPUT);
 	glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);
-    glDebugMessageCallback(glMessageCallback, nullptr);
+	glDebugMessageCallback(glMessageCallback, nullptr);
 
-    // Compile the shaders
-    GLuint program = GL_NONE;
-    {
-        const GLuint fragmentShader = glCreateShader(GL_FRAGMENT_SHADER);
-        const GLuint vertexShader = glCreateShader(GL_VERTEX_SHADER);
+	// Compile the shaders
+	GLuint program = GL_NONE;
+	{
+		const GLuint fragmentShader = glCreateShader(GL_FRAGMENT_SHADER);
+		const GLuint vertexShader = glCreateShader(GL_VERTEX_SHADER);
 
-        const auto* frag = fragmentShaderSource.data();
-        const auto* vert = vertexShaderSource.data();
-        auto fragSize = static_cast<GLint>(fragmentShaderSource.size());
-        auto vertSize = static_cast<GLint>(vertexShaderSource.size());
+		const auto* frag = fragmentShaderSource.data();
+		const auto* vert = vertexShaderSource.data();
+		auto fragSize = static_cast<GLint>(fragmentShaderSource.size());
+		auto vertSize = static_cast<GLint>(vertexShaderSource.size());
 
-        glShaderSource(fragmentShader, 1, &frag, &fragSize);
-        glShaderSource(vertexShader, 1, &vert, &vertSize);
-        glCompileShader(fragmentShader);
-        glCompileShader(vertexShader);
-        if (!checkGlCompileErrors(fragmentShader))
-            return -1;
-        if (!checkGlCompileErrors(vertexShader))
-            return -1;
+		glShaderSource(fragmentShader, 1, &frag, &fragSize);
+		glShaderSource(vertexShader, 1, &vert, &vertSize);
+		glCompileShader(fragmentShader);
+		glCompileShader(vertexShader);
+		if (!checkGlCompileErrors(fragmentShader)) return -1;
+		if (!checkGlCompileErrors(vertexShader)) return -1;
 
-        program = glCreateProgram();
-        glAttachShader(program, fragmentShader);
-        glAttachShader(program, vertexShader);
-        glLinkProgram(program);
-        if (!checkGlLinkErrors(program))
-            return -1;
+		program = glCreateProgram();
+		glAttachShader(program, fragmentShader);
+		glAttachShader(program, vertexShader);
+		glLinkProgram(program);
+		if (!checkGlLinkErrors(program)) return -1;
 
-        glDeleteShader(fragmentShader);
-        glDeleteShader(vertexShader);
-    }
+		glDeleteShader(fragmentShader);
+		glDeleteShader(vertexShader);
+	}
 
 	{
 		// We just emulate the initial sizing of the window with a manual call.
@@ -778,11 +800,11 @@ int main(int argc, char* argv[]) {
 	}
 
 	// Load the glTF file
-    auto start = std::chrono::high_resolution_clock::now();
-    if (!loadGltf(&viewer, gltfFile)) {
-        std::cerr << "Failed to parse glTF" << '\n';
-        return -1;
-    }
+	auto start = std::chrono::high_resolution_clock::now();
+	if (!loadGltf(&viewer, gltfFile)) {
+		std::cerr << "Failed to parse glTF" << '\n';
+		return -1;
+	}
 
 	// Add a default material
 	auto& defaultMaterial = viewer.materials.emplace_back();
@@ -790,59 +812,61 @@ int main(int argc, char* argv[]) {
 	defaultMaterial.alphaCutoff = 0.0f;
 	defaultMaterial.flags = 0;
 
-    // We load images first.
-    auto& asset = viewer.asset;
-    for (auto& image : asset.images) {
-        loadImage(&viewer, image);
-    }
-    for (auto& material : asset.materials) {
-        loadMaterial(&viewer, material);
-    }
-    for (auto& mesh : asset.meshes) {
-        loadMesh(&viewer, mesh);
-    }
-	// Loading the cameras (possibly) requires knowing the viewport size, which we get using glfwGetWindowSize above.
+	// We load images first.
+	auto& asset = viewer.asset;
+	for (auto& image : asset.images) {
+		loadImage(&viewer, image);
+	}
+	for (auto& material : asset.materials) {
+		loadMaterial(&viewer, material);
+	}
+	for (auto& mesh : asset.meshes) {
+		loadMesh(&viewer, mesh);
+	}
+	// Loading the cameras (possibly) requires knowing the viewport size, which we get using
+	// glfwGetWindowSize above.
 	for (auto& camera : asset.cameras) {
 		loadCamera(&viewer, camera);
 	}
-	auto diff = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - start);
-    std::cout << "Loaded glTF file in " << diff.count() << "ms." << '\n';
+	auto diff = std::chrono::duration_cast<std::chrono::milliseconds>(
+		std::chrono::high_resolution_clock::now() - start);
+	std::cout << "Loaded glTF file in " << diff.count() << "ms." << '\n';
 
-    // Create the material uniform buffer
-    viewer.materialBuffers.resize(viewer.materials.size(), GL_NONE);
-    glCreateBuffers(static_cast<GLsizei>(viewer.materials.size()), viewer.materialBuffers.data());
-    for (auto i = 0UL; i < viewer.materialBuffers.size(); ++i) {
-        glNamedBufferStorage(viewer.materialBuffers[i], static_cast<GLsizeiptr>(sizeof(MaterialUniforms)),
-                             &viewer.materials[i], GL_MAP_WRITE_BIT);
-    }
+	// Create the material uniform buffer
+	viewer.materialBuffers.resize(viewer.materials.size(), GL_NONE);
+	glCreateBuffers(static_cast<GLsizei>(viewer.materials.size()), viewer.materialBuffers.data());
+	for (auto i = 0UL; i < viewer.materialBuffers.size(); ++i) {
+		glNamedBufferStorage(viewer.materialBuffers[i],
+							 static_cast<GLsizeiptr>(sizeof(MaterialUniforms)),
+							 &viewer.materials[i], GL_MAP_WRITE_BIT);
+	}
 
-    viewer.modelMatrixUniform = glGetUniformLocation(program, "modelMatrix");
-    viewer.viewProjectionMatrixUniform = glGetUniformLocation(program, "viewProjectionMatrix");
+	viewer.modelMatrixUniform = glGetUniformLocation(program, "modelMatrix");
+	viewer.viewProjectionMatrixUniform = glGetUniformLocation(program, "viewProjectionMatrix");
 	viewer.uvOffsetUniform = glGetUniformLocation(program, "uvOffset");
 	viewer.uvScaleUniform = glGetUniformLocation(program, "uvScale");
 	viewer.uvRotationUniform = glGetUniformLocation(program, "uvRotation");
-    glUseProgram(program);
+	glUseProgram(program);
 
-    glEnable(GL_BLEND);
-    glEnable(GL_MULTISAMPLE);
-    glEnable(GL_DEPTH_TEST);
+	glEnable(GL_BLEND);
+	glEnable(GL_MULTISAMPLE);
+	glEnable(GL_DEPTH_TEST);
 
 	auto& sceneIndex = viewer.sceneIndex = viewer.asset.defaultScene.value_or(0);
 
 	// Give every scene a readable name, if not yet available
 	for (std::size_t i = 0; i < asset.scenes.size(); ++i) {
-		if (!asset.scenes[i].name.empty())
-			continue;
+		if (!asset.scenes[i].name.empty()) continue;
 		asset.scenes[i].name = std::string("Scene ") + std::to_string(i);
 	}
 
 	// We keep a list of all camera nodes present in the current scene.
-	// When the cameraIndex has no value (because none is selected or there were none defined by the glTF),
-	// a default free camera should be used.
+	// When the cameraIndex has no value (because none is selected or there were none defined by the
+	// glTF), a default free camera should be used.
 	std::vector<fastgltf::Node*> cameraNodes;
 	if (!viewer.asset.scenes.empty() && sceneIndex < viewer.asset.scenes.size()) {
 		auto& scene = viewer.asset.scenes[sceneIndex];
-		for (auto& node: scene.nodeIndices) {
+		for (auto& node : scene.nodeIndices) {
 			updateCameraNodes(&viewer, cameraNodes, node);
 		}
 	}
@@ -851,28 +875,30 @@ int main(int argc, char* argv[]) {
 	viewer.position = fastgltf::math::fvec3(2.f, 2.f, 2.f);
 	viewer.direction = -viewer.position;
 	{
-		auto len = std::sqrtf(std::powf(viewer.direction.x(), 2) + std::powf(viewer.direction.z(), 2));
+		auto len =
+			std::sqrtf(std::powf(viewer.direction.x(), 2) + std::powf(viewer.direction.z(), 2));
 		viewer.pitch = fastgltf::math::degrees(std::tanf(viewer.direction.y() / len));
 		viewer.yaw = -135.f;
 	}
 
-    viewer.lastFrame = static_cast<float>(glfwGetTime());
-    while (glfwWindowShouldClose(window) != GLFW_TRUE) {
-        auto currentFrame = static_cast<float>(glfwGetTime());
-        viewer.deltaTime = currentFrame - viewer.lastFrame;
-        viewer.lastFrame = currentFrame;
+	viewer.lastFrame = static_cast<float>(glfwGetTime());
+	while (glfwWindowShouldClose(window) != GLFW_TRUE) {
+		auto currentFrame = static_cast<float>(glfwGetTime());
+		viewer.deltaTime = currentFrame - viewer.lastFrame;
+		viewer.lastFrame = currentFrame;
 
-        // Reset the acceleration
-        viewer.accelerationVector = fastgltf::math::fvec3(0.0f);
+		// Reset the acceleration
+		viewer.accelerationVector = fastgltf::math::fvec3(0.0f);
 
-        // Updates the acceleration vector and direction vectors.
-        glfwPollEvents();
+		// Updates the acceleration vector and direction vectors.
+		glfwPollEvents();
 
 		ImGui_ImplOpenGL3_NewFrame();
 		ImGui_ImplGlfw_NewFrame();
 		ImGui::NewFrame();
 
-		if (ImGui::Begin("gl_viewer", nullptr, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove)) {
+		if (ImGui::Begin("gl_viewer", nullptr,
+						 ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove)) {
 			auto& name = asset.scenes[sceneIndex].name;
 			if (ImGui::BeginCombo("Scene", name.c_str(), ImGuiComboFlags_None)) {
 				for (std::size_t i = 0; i < asset.scenes.size(); ++i) {
@@ -887,14 +913,15 @@ int main(int argc, char* argv[]) {
 							updateCameraNodes(&viewer, cameraNodes, node);
 						}
 					}
-					if (isSelected)
-						ImGui::SetItemDefaultFocus();
+					if (isSelected) ImGui::SetItemDefaultFocus();
 				}
 				ImGui::EndCombo();
 			}
 
 			if (ImGui::BeginCombo("Camera",
-								  viewer.cameraIndex.has_value() ? cameraNodes[*viewer.cameraIndex]->name.c_str() : "Default",
+								  viewer.cameraIndex.has_value()
+									  ? cameraNodes[*viewer.cameraIndex]->name.c_str()
+									  : "Default",
 								  ImGuiComboFlags_None)) {
 				{
 					// Default camera entry
@@ -920,16 +947,16 @@ int main(int argc, char* argv[]) {
 			}
 
 			ImGui::BeginDisabled(asset.materialVariants.empty());
-			const auto currentVariantName = asset.materialVariants.empty()
-				? "N/A"
-				: asset.materialVariants[viewer.materialVariant].c_str();
+			const auto currentVariantName =
+				asset.materialVariants.empty()
+					? "N/A"
+					: asset.materialVariants[viewer.materialVariant].c_str();
 			if (ImGui::BeginCombo("Variant", currentVariantName, ImGuiComboFlags_None)) {
 				for (std::size_t i = 0; i < asset.materialVariants.size(); ++i) {
 					const bool isSelected = i == viewer.materialVariant;
 					if (ImGui::Selectable(asset.materialVariants[i].c_str(), isSelected))
 						viewer.materialVariant = i;
-					if (isSelected)
-						ImGui::SetItemDefaultFocus();
+					if (isSelected) ImGui::SetItemDefaultFocus();
 				}
 				ImGui::EndCombo();
 			}
@@ -937,16 +964,17 @@ int main(int argc, char* argv[]) {
 		}
 		ImGui::End();
 
-        glClearColor(0.1f, 0.2f, 0.3f, 1.0f);
-        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+		glClearColor(0.1f, 0.2f, 0.3f, 1.0f);
+		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
-        glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
 		if (!asset.scenes.empty() && sceneIndex < asset.scenes.size()) {
 			// Update the camera view and projection matrices
 			if (viewer.cameraIndex.has_value()) {
-				fastgltf::iterateSceneNodes(asset, sceneIndex, fastgltf::math::fmat4x4(),
-											[&](fastgltf::Node& node, fastgltf::math::fmat4x4 matrix) {
+				fastgltf::iterateSceneNodes(
+					asset, sceneIndex, fastgltf::math::fmat4x4(),
+					[&](fastgltf::Node& node, fastgltf::math::fmat4x4 matrix) {
 					if (node.cameraIndex.has_value() && &node == cameraNodes[*viewer.cameraIndex]) {
 						viewer.viewMatrix = matrix;
 					}
@@ -961,10 +989,12 @@ int main(int argc, char* argv[]) {
 				viewer.velocity = viewer.velocity + (-viewer.velocity) * (2.0f * viewer.deltaTime);
 				// Add the velocity into the position
 				viewer.position += viewer.velocity * viewer.deltaTime;
-				viewer.viewMatrix = fastgltf::math::lookAtRH(viewer.position, viewer.position + viewer.direction,
-												fastgltf::math::fvec3(0.0f, 1.0f, 0.0f));
+				viewer.viewMatrix =
+					fastgltf::math::lookAtRH(viewer.position, viewer.position + viewer.direction,
+											 fastgltf::math::fvec3(0.0f, 1.0f, 0.0f));
 
-				auto aspectRatio = static_cast<float>(viewer.windowDimensions[0]) / static_cast<float>(viewer.windowDimensions[1]);
+				auto aspectRatio = static_cast<float>(viewer.windowDimensions[0]) /
+								   static_cast<float>(viewer.windowDimensions[1]);
 				viewer.projectionMatrix = fastgltf::math::perspectiveRH(
 					fastgltf::math::radians(75.0f), aspectRatio, 0.01f, 1000.0f);
 			}
@@ -983,25 +1013,25 @@ int main(int argc, char* argv[]) {
 		ImGui::Render();
 		ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 
-        glfwSwapBuffers(window);
-    }
+		glfwSwapBuffers(window);
+	}
 
-    for (auto& mesh : viewer.meshes) {
-        glDeleteBuffers(1, &mesh.drawsBuffer);
+	for (auto& mesh : viewer.meshes) {
+		glDeleteBuffers(1, &mesh.drawsBuffer);
 
-        for (auto& prim : mesh.primitives) {
-            glDeleteVertexArrays(1, &prim.vertexArray);
+		for (auto& prim : mesh.primitives) {
+			glDeleteVertexArrays(1, &prim.vertexArray);
 			glDeleteBuffers(1, &prim.indexBuffer);
 			glDeleteBuffers(1, &prim.vertexBuffer);
-        }
-    }
+		}
+	}
 
-    glDeleteProgram(program);
+	glDeleteProgram(program);
 
 	ImGui_ImplOpenGL3_Shutdown();
 	ImGui_ImplGlfw_Shutdown();
 	ImGui::DestroyContext();
 
 	glfwDestroyWindow(window);
-    glfwTerminate();
+	glfwTerminate();
 }

--- a/include/fastgltf/base64.hpp
+++ b/include/fastgltf/base64.hpp
@@ -28,64 +28,65 @@
 #define FASTGLTF_BASE_64_HPP
 
 #if !defined(FASTGLTF_USE_STD_MODULE) || !FASTGLTF_USE_STD_MODULE
-#include <cassert>
-#include <cstddef>
-#include <cstdint>
-#include <string_view>
+#	include <cassert>
+#	include <cstddef>
+#	include <cstdint>
+#	include <string_view>
 #endif
 
 #include <fastgltf/types.hpp>
 
 #ifdef _MSC_VER
-#pragma warning(push) // attribute 'x' is not recognized
-#pragma warning(disable : 5030)
+#	pragma warning(push)  // attribute 'x' is not recognized
+#	pragma warning(disable : 5030)
 #endif
 
 namespace fastgltf::base64 {
-    /**
-     * Calculates the amount of base64 padding chars ('=') at the end of the encoded string.
-     * @note There's at most 2 padding chars, and this function expects that the input string
-     * points to the original string that has a size that is a multiple of 4 and is at least
-     * 4 chars long.
-     */
-    FASTGLTF_EXPORT [[gnu::always_inline]] constexpr std::size_t getPadding(const std::string_view string) {
-        assert(string.size() >= 4 && string.size() % 4 == 0);
-        const auto size = string.size();
-        for (auto i = 1; i < 4; ++i)
-            if (string[size - i] != '=')
-                return i - 1;
-        return 0;
-    }
+/**
+ * Calculates the amount of base64 padding chars ('=') at the end of the encoded string.
+ * @note There's at most 2 padding chars, and this function expects that the input string
+ * points to the original string that has a size that is a multiple of 4 and is at least
+ * 4 chars long.
+ */
+FASTGLTF_EXPORT [[gnu::always_inline]] constexpr std::size_t getPadding(
+	const std::string_view string) {
+	assert(string.size() >= 4 && string.size() % 4 == 0);
+	const auto size = string.size();
+	for (auto i = 1; i < 4; ++i)
+		if (string[size - i] != '=') return i - 1;
+	return 0;
+}
 
-    /**
-     * Calculates the size of the decoded string based on the size of the base64 encoded string and
-     * the amount of padding the encoded data contains.
-     */
-    FASTGLTF_EXPORT [[gnu::always_inline]] constexpr std::size_t getOutputSize(
-            const std::size_t encodedSize, const std::size_t padding) noexcept {
-        assert(encodedSize % 4 == 0);
-        return (encodedSize / 4) * 3 - padding;
-    }
+/**
+ * Calculates the size of the decoded string based on the size of the base64 encoded string and
+ * the amount of padding the encoded data contains.
+ */
+FASTGLTF_EXPORT [[gnu::always_inline]] constexpr std::size_t getOutputSize(
+	const std::size_t encodedSize, const std::size_t padding) noexcept {
+	assert(encodedSize % 4 == 0);
+	return (encodedSize / 4) * 3 - padding;
+}
 
 #if defined(FASTGLTF_IS_X86)
-    void sse4_decode_inplace(std::string_view encoded, std::uint8_t* output, std::size_t padding);
-    void avx2_decode_inplace(std::string_view encoded, std::uint8_t* output, std::size_t padding);
+void sse4_decode_inplace(std::string_view encoded, std::uint8_t* output, std::size_t padding);
+void avx2_decode_inplace(std::string_view encoded, std::uint8_t* output, std::size_t padding);
 
-    [[nodiscard]] StaticVector<std::uint8_t> sse4_decode(std::string_view encoded);
-    [[nodiscard]] StaticVector<std::uint8_t> avx2_decode(std::string_view encoded);
+[[nodiscard]] StaticVector<std::uint8_t> sse4_decode(std::string_view encoded);
+[[nodiscard]] StaticVector<std::uint8_t> avx2_decode(std::string_view encoded);
 #elif defined(FASTGLTF_IS_A64)
-    void neon_decode_inplace(std::string_view encoded, std::uint8_t* output, std::size_t padding);
-    [[nodiscard]] StaticVector<std::uint8_t> neon_decode(std::string_view encoded);
+void neon_decode_inplace(std::string_view encoded, std::uint8_t* output, std::size_t padding);
+[[nodiscard]] StaticVector<std::uint8_t> neon_decode(std::string_view encoded);
 #endif
-    void fallback_decode_inplace(std::string_view encoded, std::uint8_t* output, std::size_t padding);
-    FASTGLTF_EXPORT void decode_inplace(std::string_view encoded, std::uint8_t* output, std::size_t padding);
+void fallback_decode_inplace(std::string_view encoded, std::uint8_t* output, std::size_t padding);
+FASTGLTF_EXPORT void decode_inplace(std::string_view encoded, std::uint8_t* output,
+									std::size_t padding);
 
-    [[nodiscard]] StaticVector<std::uint8_t> fallback_decode(std::string_view encoded);
-    FASTGLTF_EXPORT [[nodiscard]] StaticVector<std::uint8_t> decode(std::string_view encoded);
-} // namespace fastgltf::base64
+[[nodiscard]] StaticVector<std::uint8_t> fallback_decode(std::string_view encoded);
+FASTGLTF_EXPORT [[nodiscard]] StaticVector<std::uint8_t> decode(std::string_view encoded);
+}  // namespace fastgltf::base64
 
 #ifdef _MSC_VER
-#pragma warning(pop)
+#	pragma warning(pop)
 #endif
 
 #endif

--- a/include/fastgltf/core.hpp
+++ b/include/fastgltf/core.hpp
@@ -28,17 +28,17 @@
 #define FASTGLTF_CORE_HPP
 
 #if !defined(FASTGLTF_USE_STD_MODULE) || !FASTGLTF_USE_STD_MODULE
-#include <fstream>
-#include <memory>
-#include <tuple>
+#	include <fstream>
+#	include <memory>
+#	include <tuple>
 #endif
 
 #include <fastgltf/types.hpp>
 
 #ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 5030) // attribute 'x' is not recognized
-#pragma warning(disable : 4514) // unreferenced inline function has been removed
+#	pragma warning(push)
+#	pragma warning(disable : 5030)  // attribute 'x' is not recognized
+#	pragma warning(disable : 4514)  // unreferenced inline function has been removed
 #endif
 
 // fwd
@@ -47,96 +47,111 @@ struct AAssetManager;
 #endif
 
 namespace simdjson::dom {
-    class array;
-    class object;
-    class parser;
-} // namespace simdjson::dom
+class array;
+class object;
+class parser;
+}  // namespace simdjson::dom
 
 namespace fastgltf {
-	FASTGLTF_EXPORT enum class Error : std::uint64_t;
+FASTGLTF_EXPORT enum class Error : std::uint64_t;
 
-	FASTGLTF_EXPORT template <typename T>
-	class Expected;
-} // namespace fastgltf
+FASTGLTF_EXPORT template <typename T>
+class Expected;
+}  // namespace fastgltf
 
 namespace std {
-	template <typename T>
-	struct tuple_size<fastgltf::Expected<T>> : std::integral_constant<std::size_t, 2> {};
+template <typename T>
+struct tuple_size<fastgltf::Expected<T>> : std::integral_constant<std::size_t, 2> {};
 
-	template <typename T>
-	struct tuple_element<0, fastgltf::Expected<T>> { using type = fastgltf::Error; };
-	template <typename T>
-	struct tuple_element<1, fastgltf::Expected<T>> { using type = T; };
-} // namespace std
+template <typename T>
+struct tuple_element<0, fastgltf::Expected<T>> {
+	using type = fastgltf::Error;
+};
+template <typename T>
+struct tuple_element<1, fastgltf::Expected<T>> {
+	using type = T;
+};
+}  // namespace std
 
 namespace fastgltf {
-    struct BinaryGltfChunk;
+struct BinaryGltfChunk;
 
-    enum class Error : std::uint64_t {
-		None = 0,
-		InvalidPath = 1, ///< The glTF directory passed to load*GLTF is invalid.
-		MissingExtensions = 2, ///< One or more extensions are required by the glTF but not enabled in the Parser.
-		UnknownRequiredExtension = 3, ///< An extension required by the glTF is not supported by fastgltf.
-		InvalidJson = 4, ///< An error occurred while parsing the JSON.
-		InvalidGltf = 5, ///< The glTF is either missing something or has invalid data.
-		InvalidOrMissingAssetField = 6, ///< The glTF asset object is missing or invalid.
-		InvalidGLB = 7, ///< The GLB container is invalid.
-		/**
-		 * A field is missing in the JSON.
-		 * @note This is only used internally.
-		 */
-		MissingField = 8,
-		MissingExternalBuffer = 9, ///< With Options::LoadExternalBuffers, an external buffer was not found.
-		UnsupportedVersion = 10, ///< The glTF version is not supported by fastgltf.
-		InvalidURI = 11, ///< A URI from a buffer or image failed to be parsed.
-		InvalidFileData = 12, ///< The file data is invalid, or the file type could not be determined.
-		FailedWritingFiles = 13, ///< The exporter failed to write some files (buffers/images) to disk.
-		FileBufferAllocationFailed = 14, ///< The constructor of GltfDataBuffer failed to allocate a sufficiently large buffer.
-    };
+enum class Error : std::uint64_t {
+	None = 0,
+	InvalidPath = 1,  ///< The glTF directory passed to load*GLTF is invalid.
+	MissingExtensions =
+		2,  ///< One or more extensions are required by the glTF but not enabled in the Parser.
+	UnknownRequiredExtension =
+		3,            ///< An extension required by the glTF is not supported by fastgltf.
+	InvalidJson = 4,  ///< An error occurred while parsing the JSON.
+	InvalidGltf = 5,  ///< The glTF is either missing something or has invalid data.
+	InvalidOrMissingAssetField = 6,  ///< The glTF asset object is missing or invalid.
+	InvalidGLB = 7,                  ///< The GLB container is invalid.
+	/**
+	 * A field is missing in the JSON.
+	 * @note This is only used internally.
+	 */
+	MissingField = 8,
+	MissingExternalBuffer =
+		9,  ///< With Options::LoadExternalBuffers, an external buffer was not found.
+	UnsupportedVersion = 10,  ///< The glTF version is not supported by fastgltf.
+	InvalidURI = 11,          ///< A URI from a buffer or image failed to be parsed.
+	InvalidFileData = 12,  ///< The file data is invalid, or the file type could not be determined.
+	FailedWritingFiles = 13,  ///< The exporter failed to write some files (buffers/images) to disk.
+	FileBufferAllocationFailed =
+		14,  ///< The constructor of GltfDataBuffer failed to allocate a sufficiently large buffer.
+};
 
-	FASTGLTF_EXPORT constexpr std::string_view getErrorName(Error error) {
-		switch (error) {
-			case Error::None: return "None";
-			case Error::InvalidPath: return "InvalidPath";
-			case Error::MissingExtensions: return "MissingExtensions";
-			case Error::UnknownRequiredExtension: return "UnknownRequiredExtension";
-			case Error::InvalidJson: return "InvalidJson";
-			case Error::InvalidGltf: return "InvalidGltf";
-			case Error::InvalidOrMissingAssetField: return "InvalidOrMissingAssetField";
-			case Error::InvalidGLB: return "InvalidGLB";
-			case Error::MissingField: return "MissingField";
-			case Error::MissingExternalBuffer: return "MissingExternalBuffer";
-			case Error::UnsupportedVersion: return "UnsupportedVersion";
-			case Error::InvalidURI: return "InvalidURI";
-            case Error::InvalidFileData: return "InvalidFileData";
-            case Error::FailedWritingFiles: return "FailedWritingFiles";
-			case Error::FileBufferAllocationFailed: return "FileBufferAllocationFailed";
-			default: FASTGLTF_UNREACHABLE
-		}
+FASTGLTF_EXPORT constexpr std::string_view getErrorName(Error error) {
+	switch (error) {
+		case Error::None:                       return "None";
+		case Error::InvalidPath:                return "InvalidPath";
+		case Error::MissingExtensions:          return "MissingExtensions";
+		case Error::UnknownRequiredExtension:   return "UnknownRequiredExtension";
+		case Error::InvalidJson:                return "InvalidJson";
+		case Error::InvalidGltf:                return "InvalidGltf";
+		case Error::InvalidOrMissingAssetField: return "InvalidOrMissingAssetField";
+		case Error::InvalidGLB:                 return "InvalidGLB";
+		case Error::MissingField:               return "MissingField";
+		case Error::MissingExternalBuffer:      return "MissingExternalBuffer";
+		case Error::UnsupportedVersion:         return "UnsupportedVersion";
+		case Error::InvalidURI:                 return "InvalidURI";
+		case Error::InvalidFileData:            return "InvalidFileData";
+		case Error::FailedWritingFiles:         return "FailedWritingFiles";
+		case Error::FileBufferAllocationFailed: return "FileBufferAllocationFailed";
+		default:                                FASTGLTF_UNREACHABLE
 	}
+}
 
-	FASTGLTF_EXPORT constexpr std::string_view getErrorMessage(Error error) {
-		switch (error) {
-			case Error::None: return "";
-			case Error::InvalidPath: return "The glTF directory passed to load*GLTF is invalid";
-			case Error::MissingExtensions: return "One or more extensions are required by the glTF but not enabled in the Parser.";
-			case Error::UnknownRequiredExtension: return "An extension required by the glTF is not supported by fastgltf.";
-			case Error::InvalidJson: return "An error occurred while parsing the JSON.";
-			case Error::InvalidGltf: return "The glTF is either missing something or has invalid data.";
-			case Error::InvalidOrMissingAssetField: return "The glTF asset object is missing or invalid.";
-			case Error::InvalidGLB: return "The GLB container is invalid.";
-			case Error::MissingField: return "";
-			case Error::MissingExternalBuffer: return "An external buffer was not found.";
-			case Error::UnsupportedVersion: return "The glTF version is not supported by fastgltf.";
-			case Error::InvalidURI: return "A URI from a buffer or image failed to be parsed.";
-            case Error::InvalidFileData: return "The file data is invalid, or the file type could not be determined.";
-            case Error::FailedWritingFiles: return "The exporter failed to write some files (buffers/images) to disk.";
-			case Error::FileBufferAllocationFailed: return "The constructor of GltfDataBuffer failed to allocate a sufficiently large buffer.";
-			default: FASTGLTF_UNREACHABLE
-		}
+FASTGLTF_EXPORT constexpr std::string_view getErrorMessage(Error error) {
+	switch (error) {
+		case Error::None:        return "";
+		case Error::InvalidPath: return "The glTF directory passed to load*GLTF is invalid";
+		case Error::MissingExtensions:
+			return "One or more extensions are required by the glTF but not enabled in the Parser.";
+		case Error::UnknownRequiredExtension:
+			return "An extension required by the glTF is not supported by fastgltf.";
+		case Error::InvalidJson: return "An error occurred while parsing the JSON.";
+		case Error::InvalidGltf: return "The glTF is either missing something or has invalid data.";
+		case Error::InvalidOrMissingAssetField:
+			return "The glTF asset object is missing or invalid.";
+		case Error::InvalidGLB:            return "The GLB container is invalid.";
+		case Error::MissingField:          return "";
+		case Error::MissingExternalBuffer: return "An external buffer was not found.";
+		case Error::UnsupportedVersion:    return "The glTF version is not supported by fastgltf.";
+		case Error::InvalidURI:            return "A URI from a buffer or image failed to be parsed.";
+		case Error::InvalidFileData:
+			return "The file data is invalid, or the file type could not be determined.";
+		case Error::FailedWritingFiles:
+			return "The exporter failed to write some files (buffers/images) to disk.";
+		case Error::FileBufferAllocationFailed:
+			return "The constructor of GltfDataBuffer failed to allocate a sufficiently large "
+				   "buffer.";
+		default: FASTGLTF_UNREACHABLE
 	}
+}
 
-	// clang-format off
+// clang-format off
     FASTGLTF_EXPORT enum class Extensions : std::uint64_t {
         None = 0,
 
@@ -233,21 +248,22 @@ namespace fastgltf {
 		// See https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_diffuse_transmission
 		KHR_materials_diffuse_transmission = 1 << 30,
     };
-    // clang-format on
+// clang-format on
 
-    FASTGLTF_ARITHMETIC_OP_TEMPLATE_MACRO(Extensions, Extensions, |)
-    FASTGLTF_ARITHMETIC_OP_TEMPLATE_MACRO(Extensions, Extensions, &)
-	FASTGLTF_ARITHMETIC_OP_TEMPLATE_MACRO(Extensions, Extensions, -)
-    FASTGLTF_ASSIGNMENT_OP_TEMPLATE_MACRO(Extensions, Extensions, |)
-    FASTGLTF_ASSIGNMENT_OP_TEMPLATE_MACRO(Extensions, Extensions, &)
-    FASTGLTF_UNARY_OP_TEMPLATE_MACRO(Extensions, ~)
+FASTGLTF_ARITHMETIC_OP_TEMPLATE_MACRO(Extensions, Extensions, |)
+FASTGLTF_ARITHMETIC_OP_TEMPLATE_MACRO(Extensions, Extensions, &)
+FASTGLTF_ARITHMETIC_OP_TEMPLATE_MACRO(Extensions, Extensions, -)
+FASTGLTF_ASSIGNMENT_OP_TEMPLATE_MACRO(Extensions, Extensions, |)
+FASTGLTF_ASSIGNMENT_OP_TEMPLATE_MACRO(Extensions, Extensions, &)
+FASTGLTF_UNARY_OP_TEMPLATE_MACRO(Extensions, ~)
 
-	FASTGLTF_EXPORT constexpr Extensions operator-(const Extensions& a, const std::underlying_type_t<Extensions>& b) noexcept {
-		static_assert(std::is_enum_v<Extensions>);
-		return static_cast<Extensions>(to_underlying(a) - b);
-	}
+FASTGLTF_EXPORT constexpr Extensions operator-(
+	const Extensions& a, const std::underlying_type_t<Extensions>& b) noexcept {
+	static_assert(std::is_enum_v<Extensions>);
+	return static_cast<Extensions>(to_underlying(a) - b);
+}
 
-    // clang-format off
+// clang-format off
     FASTGLTF_EXPORT enum class Options : std::uint64_t {
         None                            = 0,
         /**
@@ -316,62 +332,66 @@ namespace fastgltf {
          */
         PrettyPrintJson                 = 1 << 2,
     };
-    // clang-format on
+// clang-format on
 
-    FASTGLTF_ARITHMETIC_OP_TEMPLATE_MACRO(Options, Options, |)
-    FASTGLTF_ARITHMETIC_OP_TEMPLATE_MACRO(Options, Options, &)
-    FASTGLTF_ASSIGNMENT_OP_TEMPLATE_MACRO(Options, Options, |)
-    FASTGLTF_ASSIGNMENT_OP_TEMPLATE_MACRO(Options, Options, &)
-    FASTGLTF_UNARY_OP_TEMPLATE_MACRO(Options, ~)
-    FASTGLTF_ARITHMETIC_OP_TEMPLATE_MACRO(ExportOptions, ExportOptions, |)
-    FASTGLTF_ARITHMETIC_OP_TEMPLATE_MACRO(ExportOptions, ExportOptions, &)
-    FASTGLTF_ASSIGNMENT_OP_TEMPLATE_MACRO(ExportOptions, ExportOptions, |)
-    FASTGLTF_ASSIGNMENT_OP_TEMPLATE_MACRO(ExportOptions, ExportOptions, &)
-    FASTGLTF_UNARY_OP_TEMPLATE_MACRO(ExportOptions, ~)
+FASTGLTF_ARITHMETIC_OP_TEMPLATE_MACRO(Options, Options, |)
+FASTGLTF_ARITHMETIC_OP_TEMPLATE_MACRO(Options, Options, &)
+FASTGLTF_ASSIGNMENT_OP_TEMPLATE_MACRO(Options, Options, |)
+FASTGLTF_ASSIGNMENT_OP_TEMPLATE_MACRO(Options, Options, &)
+FASTGLTF_UNARY_OP_TEMPLATE_MACRO(Options, ~)
+FASTGLTF_ARITHMETIC_OP_TEMPLATE_MACRO(ExportOptions, ExportOptions, |)
+FASTGLTF_ARITHMETIC_OP_TEMPLATE_MACRO(ExportOptions, ExportOptions, &)
+FASTGLTF_ASSIGNMENT_OP_TEMPLATE_MACRO(ExportOptions, ExportOptions, |)
+FASTGLTF_ASSIGNMENT_OP_TEMPLATE_MACRO(ExportOptions, ExportOptions, &)
+FASTGLTF_UNARY_OP_TEMPLATE_MACRO(ExportOptions, ~)
 
-    // String representations of glTF 2.0 extension identifiers.
-    namespace extensions {
-        constexpr std::string_view EXT_mesh_gpu_instancing = "EXT_mesh_gpu_instancing";
-        constexpr std::string_view EXT_meshopt_compression = "EXT_meshopt_compression";
-        constexpr std::string_view EXT_texture_webp = "EXT_texture_webp";
-		constexpr std::string_view GODOT_single_root = "GODOT_single_root";
-		constexpr std::string_view KHR_accessor_float64 = "KHR_accessor_float64";
-		constexpr std::string_view KHR_draco_mesh_compression = "KHR_draco_mesh_compression";
-        constexpr std::string_view KHR_lights_punctual = "KHR_lights_punctual";
-		constexpr std::string_view KHR_materials_anisotropy = "KHR_materials_anisotropy";
-        constexpr std::string_view KHR_materials_clearcoat = "KHR_materials_clearcoat";
-		constexpr std::string_view KHR_materials_diffuse_transmission = "KHR_materials_diffuse_transmission";
-		constexpr std::string_view KHR_materials_dispersion = "KHR_materials_dispersion";
-        constexpr std::string_view KHR_materials_emissive_strength = "KHR_materials_emissive_strength";
-        constexpr std::string_view KHR_materials_ior = "KHR_materials_ior";
-        constexpr std::string_view KHR_materials_iridescence = "KHR_materials_iridescence";
-        constexpr std::string_view KHR_materials_sheen = "KHR_materials_sheen";
-        constexpr std::string_view KHR_materials_specular = "KHR_materials_specular";
-        constexpr std::string_view KHR_materials_transmission = "KHR_materials_transmission";
-        constexpr std::string_view KHR_materials_unlit = "KHR_materials_unlit";
-		constexpr std::string_view KHR_materials_variants = "KHR_materials_variants";
-        constexpr std::string_view KHR_materials_volume = "KHR_materials_volume";
-        constexpr std::string_view KHR_mesh_quantization = "KHR_mesh_quantization";
-        constexpr std::string_view KHR_texture_basisu = "KHR_texture_basisu";
-        constexpr std::string_view KHR_texture_transform = "KHR_texture_transform";
-	    constexpr std::string_view MSFT_packing_normalRoughnessMetallic = "MSFT_packing_normalRoughnessMetallic";
-	    constexpr std::string_view MSFT_packing_occlusionRoughnessMetallic = "MSFT_packing_occlusionRoughnessMetallic";
-        constexpr std::string_view MSFT_texture_dds = "MSFT_texture_dds";
+// String representations of glTF 2.0 extension identifiers.
+namespace extensions {
+constexpr std::string_view EXT_mesh_gpu_instancing = "EXT_mesh_gpu_instancing";
+constexpr std::string_view EXT_meshopt_compression = "EXT_meshopt_compression";
+constexpr std::string_view EXT_texture_webp = "EXT_texture_webp";
+constexpr std::string_view GODOT_single_root = "GODOT_single_root";
+constexpr std::string_view KHR_accessor_float64 = "KHR_accessor_float64";
+constexpr std::string_view KHR_draco_mesh_compression = "KHR_draco_mesh_compression";
+constexpr std::string_view KHR_lights_punctual = "KHR_lights_punctual";
+constexpr std::string_view KHR_materials_anisotropy = "KHR_materials_anisotropy";
+constexpr std::string_view KHR_materials_clearcoat = "KHR_materials_clearcoat";
+constexpr std::string_view KHR_materials_diffuse_transmission =
+	"KHR_materials_diffuse_transmission";
+constexpr std::string_view KHR_materials_dispersion = "KHR_materials_dispersion";
+constexpr std::string_view KHR_materials_emissive_strength = "KHR_materials_emissive_strength";
+constexpr std::string_view KHR_materials_ior = "KHR_materials_ior";
+constexpr std::string_view KHR_materials_iridescence = "KHR_materials_iridescence";
+constexpr std::string_view KHR_materials_sheen = "KHR_materials_sheen";
+constexpr std::string_view KHR_materials_specular = "KHR_materials_specular";
+constexpr std::string_view KHR_materials_transmission = "KHR_materials_transmission";
+constexpr std::string_view KHR_materials_unlit = "KHR_materials_unlit";
+constexpr std::string_view KHR_materials_variants = "KHR_materials_variants";
+constexpr std::string_view KHR_materials_volume = "KHR_materials_volume";
+constexpr std::string_view KHR_mesh_quantization = "KHR_mesh_quantization";
+constexpr std::string_view KHR_texture_basisu = "KHR_texture_basisu";
+constexpr std::string_view KHR_texture_transform = "KHR_texture_transform";
+constexpr std::string_view MSFT_packing_normalRoughnessMetallic =
+	"MSFT_packing_normalRoughnessMetallic";
+constexpr std::string_view MSFT_packing_occlusionRoughnessMetallic =
+	"MSFT_packing_occlusionRoughnessMetallic";
+constexpr std::string_view MSFT_texture_dds = "MSFT_texture_dds";
 
 #if FASTGLTF_ENABLE_DEPRECATED_EXT
-        constexpr std::string_view KHR_materials_pbrSpecularGlossiness = "KHR_materials_pbrSpecularGlossiness";
+constexpr std::string_view KHR_materials_pbrSpecularGlossiness =
+	"KHR_materials_pbrSpecularGlossiness";
 #endif
 
 #if FASTGLTF_ENABLE_KHR_IMPLICIT_SHAPES
-		constexpr std::string_view KHR_implicit_shapes = "KHR_implicit_shapes";
+constexpr std::string_view KHR_implicit_shapes = "KHR_implicit_shapes";
 #endif
 
 #if FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES
-		constexpr std::string_view KHR_physics_rigid_bodies = "KHR_physics_rigid_bodies";
+constexpr std::string_view KHR_physics_rigid_bodies = "KHR_physics_rigid_bodies";
 #endif
-    } // namespace extensions
+}  // namespace extensions
 
-	// clang-format off
+// clang-format off
 	// An array of pairs of string representations of extension identifiers and their respective enum
 	// value used for enabling/disabling the loading of it. This also represents all extensions that
 	// fastgltf supports and understands.
@@ -414,655 +434,686 @@ namespace fastgltf {
 		{ extensions::KHR_physics_rigid_bodies,					Extensions::KHR_physics_rigid_bodies },
 #endif
 	});
-	// clang-format on
-	static constexpr std::size_t SUPPORTED_EXTENSION_COUNT = extensionStrings.size();
+// clang-format on
+static constexpr std::size_t SUPPORTED_EXTENSION_COUNT = extensionStrings.size();
 
-	/**
-	 * Returns the name of the passed glTF extension.
-	 *
-	 * @note If \p extensions has more than one bit set (multiple extensions), this
-	 * will return the name of the first set bit.
-	 */
-	FASTGLTF_EXPORT constexpr std::string_view stringifyExtension(Extensions extensions) {
-		// Remove everything but the rightmost bit
-		extensions = extensions - (extensions & (extensions - 1));
+/**
+ * Returns the name of the passed glTF extension.
+ *
+ * @note If \p extensions has more than one bit set (multiple extensions), this
+ * will return the name of the first set bit.
+ */
+FASTGLTF_EXPORT constexpr std::string_view stringifyExtension(Extensions extensions) {
+	// Remove everything but the rightmost bit
+	extensions = extensions - (extensions & (extensions - 1));
 
-		for (const auto& [string, value] : extensionStrings)
-			if (value == extensions)
-				return string;
-		return "";
-	}
+	for (const auto& [string, value] : extensionStrings)
+		if (value == extensions) return string;
+	return "";
+}
 
-	/**
-	 * Returns a list of extension names based on the given extension flags.
-	 */
-	FASTGLTF_EXPORT inline auto stringifyExtensionBits(const Extensions extensions) -> decltype(Asset::extensionsRequired) {
-		decltype(Asset::extensionsRequired) stringified;
-		for (std::uint8_t i = 0; i < std::numeric_limits<std::underlying_type_t<Extensions>>::digits; ++i) {
-			// The 1 has to be cast to the underlying type as uint8_t(1) << 9 will overflow and be effectively the same as uint8_t(1).
-			auto curExtension = static_cast<Extensions>(
-				static_cast<std::underlying_type_t<Extensions>>(1) << i);
-			if ((extensions & curExtension) == Extensions::None)
-				continue;
+/**
+ * Returns a list of extension names based on the given extension flags.
+ */
+FASTGLTF_EXPORT inline auto stringifyExtensionBits(const Extensions extensions)
+	-> decltype(Asset::extensionsRequired) {
+	decltype(Asset::extensionsRequired) stringified;
+	for (std::uint8_t i = 0; i < std::numeric_limits<std::underlying_type_t<Extensions>>::digits;
+		 ++i) {
+		// The 1 has to be cast to the underlying type as uint8_t(1) << 9 will overflow and be
+		// effectively the same as uint8_t(1).
+		auto curExtension =
+			static_cast<Extensions>(static_cast<std::underlying_type_t<Extensions>>(1) << i);
+		if ((extensions & curExtension) == Extensions::None) continue;
 
-			// Find the stringified extension name
-			for (const auto& [name, ext] : extensionStrings) {
-				if (ext == curExtension) {
-					stringified.emplace_back(name);
-					break;
-				}
+		// Find the stringified extension name
+		for (const auto& [name, ext] : extensionStrings) {
+			if (ext == curExtension) {
+				stringified.emplace_back(name);
+				break;
 			}
 		}
-		return stringified;
+	}
+	return stringified;
+}
+
+/**
+ * A type that stores an error together with an expected value.
+ * To use this type, first call error() to inspect if any errors have occurred.
+ * If error() is not fastgltf::Error::None,
+ * calling get(), operator->(), and operator*() is undefined behaviour.
+ */
+template <typename T>
+class Expected {
+	static_assert(std::is_default_constructible_v<T>);
+	static_assert(!std::is_same_v<Error, T>);
+
+	Error err;
+	T value;
+
+   public:
+	Expected(Error error) : err(error) {}
+	Expected(T&& value) : err(Error::None), value(std::forward<T>(value)) {}
+
+	Expected(const Expected& other) = delete;
+	Expected(Expected&& other) noexcept : err(other.err), value(std::move(other.value)) {}
+
+	Expected& operator=(const Expected& other) = delete;
+	Expected& operator=(Expected&& other) noexcept {
+		err = other.err;
+		value = std::move(other.value);
+		return *this;
+	}
+
+	[[nodiscard]] Error error() const noexcept { return err; }
+
+	/**
+	 * Returns a reference to the value of T.
+	 * When error() returns anything but Error::None, the returned value is undefined.
+	 */
+	[[nodiscard]] T& get() noexcept {
+		assert(err == Error::None);
+		return value;
 	}
 
 	/**
-	 * A type that stores an error together with an expected value.
-	 * To use this type, first call error() to inspect if any errors have occurred.
-	 * If error() is not fastgltf::Error::None,
-	 * calling get(), operator->(), and operator*() is undefined behaviour.
+	 * Returns the address of the value of T, or nullptr if error() returns anything but
+	 * Error::None.
 	 */
-	template <typename T>
-	class Expected {
-		static_assert(std::is_default_constructible_v<T>);
-		static_assert(!std::is_same_v<Error, T>);
+	[[nodiscard]] T* get_if() noexcept {
+		if (err != Error::None) return nullptr;
+		return std::addressof(value);
+	}
 
-		Error err;
-		T value;
-
-	public:
-		Expected(Error error) : err(error) {}
-		Expected(T&& value) : err(Error::None), value(std::forward<T>(value)) {}
-
-		Expected(const Expected& other) = delete;
-		Expected(Expected&& other) noexcept : err(other.err), value(std::move(other.value)) {}
-
-		Expected& operator=(const Expected& other) = delete;
-		Expected& operator=(Expected&& other) noexcept {
-			err = other.err;
-			value = std::move(other.value);
-			return *this;
-		}
-
-		[[nodiscard]] Error error() const noexcept {
+	template <std::size_t I>
+	[[nodiscard]] auto& get() noexcept {
+		if constexpr (I == 0)
 			return err;
-		}
-
-		/**
-		 * Returns a reference to the value of T.
-		 * When error() returns anything but Error::None, the returned value is undefined.
-		 */
-		[[nodiscard]] T& get() noexcept {
-			assert(err == Error::None);
+		else if constexpr (I == 1)
 			return value;
-		}
+	}
 
-		/**
-		 * Returns the address of the value of T, or nullptr if error() returns anything but Error::None.
-		 */
-		[[nodiscard]] T* get_if() noexcept {
-			if (err != Error::None)
-				return nullptr;
-			return std::addressof(value);
-		}
-
-		template <std::size_t I>
-		[[nodiscard]] auto& get() noexcept {
-			if constexpr (I == 0) return err;
-			else if constexpr (I == 1) return value;
-		}
-
-		template <std::size_t I>
-		[[nodiscard]] const auto& get() const noexcept {
-			if constexpr (I == 0) return err;
-			else if constexpr (I == 1) return value;
-		}
-
-		/**
-		 * Returns the address of the value of T.
-		 * When error() returns anything but Error::None, the returned value is undefined.
-		 */
-		[[nodiscard]] T* operator->() noexcept {
-			assert(err == Error::None);
-			return std::addressof(value);
-		}
-
-		/**
-		 * Returns the address of the const value of T.
-		 * When error() returns anything but Error::None, the returned value is undefined.
-		 */
-		[[nodiscard]] const T* operator->() const noexcept {
-			assert(err == Error::None);
-			return std::addressof(value);
-		}
-
-		[[nodiscard]] T&& operator*() && noexcept {
-			assert(err == Error::None);
-			return std::move(value);
-		}
-
-		[[nodiscard]] operator bool() const noexcept {
-			return err == Error::None;
-		}
-	};
-
-    FASTGLTF_EXPORT struct BufferInfo {
-        void* mappedMemory;
-        CustomBufferId customId;
-    };
-
-    FASTGLTF_EXPORT using BufferMapCallback = BufferInfo(std::uint64_t bufferSize, void* userPointer);
-    FASTGLTF_EXPORT using BufferUnmapCallback = void(BufferInfo* bufferInfo, void* userPointer);
-    FASTGLTF_EXPORT using Base64DecodeCallback = void(std::string_view base64, std::uint8_t* dataOutput, std::size_t padding, std::size_t dataOutputSize, void* userPointer);
-	FASTGLTF_EXPORT using ExtrasParseCallback = void(simdjson::dom::object* extras, std::size_t objectIndex, Category objectType, void* userPointer);
-	FASTGLTF_EXPORT using ExtrasWriteCallback = std::optional<std::string>(std::size_t objectIndex, Category objectType, void* userPointer);
+	template <std::size_t I>
+	[[nodiscard]] const auto& get() const noexcept {
+		if constexpr (I == 0)
+			return err;
+		else if constexpr (I == 1)
+			return value;
+	}
 
 	/**
-	 * This interface defines how the parser can read the bytes making up a glTF or GLB file.
+	 * Returns the address of the value of T.
+	 * When error() returns anything but Error::None, the returned value is undefined.
 	 */
-	FASTGLTF_EXPORT class GltfDataGetter {
-	public:
-		virtual ~GltfDataGetter() noexcept = default;
+	[[nodiscard]] T* operator->() noexcept {
+		assert(err == Error::None);
+		return std::addressof(value);
+	}
 
-		/**
-		 * The read functions expect the implementation to store an offset from the start
-		 * of the buffer/file to the current position. The parse process will always linearly
-		 * access the memory, meaning it will go through the memory once from start to finish.
-		 */
-		virtual void read(void* ptr, std::size_t count) = 0;
-		/**
-		 * Reads a chunk of memory from the current offset, with some amount of padding.
-		 * This padding is necessary for the simdjson parser, but can be initialized to anything.
-		 * The memory pointed to by the span only needs to live until the next call to read().
-		 */
-		[[nodiscard]] virtual std::span<std::byte> read(std::size_t count, std::size_t padding) = 0;
+	/**
+	 * Returns the address of the const value of T.
+	 * When error() returns anything but Error::None, the returned value is undefined.
+	 */
+	[[nodiscard]] const T* operator->() const noexcept {
+		assert(err == Error::None);
+		return std::addressof(value);
+	}
 
-		/**
-		 * Reset is used to put the offset index back to the start of the buffer/file.
-		 * This is only necessary for functionality like determineGltfFileType. However, reset()
-		 * will be called at the beginning of every parse process.
-		 */
-		virtual void reset() = 0;
+	[[nodiscard]] T&& operator*() && noexcept {
+		assert(err == Error::None);
+		return std::move(value);
+	}
 
-		[[nodiscard]] virtual std::size_t bytesRead() = 0;
-		[[nodiscard]] virtual std::size_t totalSize() = 0;
-	};
+	[[nodiscard]] operator bool() const noexcept { return err == Error::None; }
+};
 
-	FASTGLTF_EXPORT class GltfDataBuffer : public GltfDataGetter {
-	protected:
-		std::unique_ptr<std::byte[]> buffer;
+FASTGLTF_EXPORT struct BufferInfo {
+	void* mappedMemory;
+	CustomBufferId customId;
+};
 
-		std::size_t allocatedSize = 0;
-		std::size_t dataSize = 0;
+FASTGLTF_EXPORT using BufferMapCallback = BufferInfo(std::uint64_t bufferSize, void* userPointer);
+FASTGLTF_EXPORT using BufferUnmapCallback = void(BufferInfo * bufferInfo, void* userPointer);
+FASTGLTF_EXPORT using Base64DecodeCallback =
+	void(std::string_view base64, std::uint8_t* dataOutput, std::size_t padding,
+		 std::size_t dataOutputSize, void* userPointer);
+FASTGLTF_EXPORT using ExtrasParseCallback =
+	void(simdjson::dom::object * extras, std::size_t objectIndex, Category objectType,
+		 void* userPointer);
+FASTGLTF_EXPORT using ExtrasWriteCallback =
+	std::optional<std::string>(std::size_t objectIndex, Category objectType, void* userPointer);
 
-		std::size_t idx = 0;
+/**
+ * This interface defines how the parser can read the bytes making up a glTF or GLB file.
+ */
+FASTGLTF_EXPORT class GltfDataGetter {
+   public:
+	virtual ~GltfDataGetter() noexcept = default;
 
-		Error error = Error::None;
+	/**
+	 * The read functions expect the implementation to store an offset from the start
+	 * of the buffer/file to the current position. The parse process will always linearly
+	 * access the memory, meaning it will go through the memory once from start to finish.
+	 */
+	virtual void read(void* ptr, std::size_t count) = 0;
+	/**
+	 * Reads a chunk of memory from the current offset, with some amount of padding.
+	 * This padding is necessary for the simdjson parser, but can be initialized to anything.
+	 * The memory pointed to by the span only needs to live until the next call to read().
+	 */
+	[[nodiscard]] virtual std::span<std::byte> read(std::size_t count, std::size_t padding) = 0;
 
-		void allocateAndCopy(const std::byte* bytes) noexcept;
+	/**
+	 * Reset is used to put the offset index back to the start of the buffer/file.
+	 * This is only necessary for functionality like determineGltfFileType. However, reset()
+	 * will be called at the beginning of every parse process.
+	 */
+	virtual void reset() = 0;
 
-		explicit GltfDataBuffer(const std::filesystem::path& path) noexcept;
-		explicit GltfDataBuffer(const std::byte* bytes, std::size_t count) noexcept;
-		explicit GltfDataBuffer(std::span<std::byte> span) noexcept;
+	[[nodiscard]] virtual std::size_t bytesRead() = 0;
+	[[nodiscard]] virtual std::size_t totalSize() = 0;
+};
 
-	public:
-		explicit GltfDataBuffer() noexcept = default;
-		GltfDataBuffer(const GltfDataBuffer& other) = delete;
-		GltfDataBuffer& operator=(const GltfDataBuffer& other) = delete;
-		GltfDataBuffer(GltfDataBuffer&& other) noexcept = default;
-		GltfDataBuffer& operator=(GltfDataBuffer&& other) noexcept = default;
-		~GltfDataBuffer() noexcept override = default;
+FASTGLTF_EXPORT class GltfDataBuffer : public GltfDataGetter {
+   protected:
+	std::unique_ptr<std::byte[]> buffer;
 
-		static Expected<GltfDataBuffer> FromPath(const std::filesystem::path& path) noexcept {
-			GltfDataBuffer buffer(path);
-			if (buffer.error != Error::None) {
-				return buffer.error;
-			}
-			return buffer;
+	std::size_t allocatedSize = 0;
+	std::size_t dataSize = 0;
+
+	std::size_t idx = 0;
+
+	Error error = Error::None;
+
+	void allocateAndCopy(const std::byte* bytes) noexcept;
+
+	explicit GltfDataBuffer(const std::filesystem::path& path) noexcept;
+	explicit GltfDataBuffer(const std::byte* bytes, std::size_t count) noexcept;
+	explicit GltfDataBuffer(std::span<std::byte> span) noexcept;
+
+   public:
+	explicit GltfDataBuffer() noexcept = default;
+	GltfDataBuffer(const GltfDataBuffer& other) = delete;
+	GltfDataBuffer& operator=(const GltfDataBuffer& other) = delete;
+	GltfDataBuffer(GltfDataBuffer&& other) noexcept = default;
+	GltfDataBuffer& operator=(GltfDataBuffer&& other) noexcept = default;
+	~GltfDataBuffer() noexcept override = default;
+
+	static Expected<GltfDataBuffer> FromPath(const std::filesystem::path& path) noexcept {
+		GltfDataBuffer buffer(path);
+		if (buffer.error != Error::None) {
+			return buffer.error;
 		}
+		return buffer;
+	}
 
-		static Expected<GltfDataBuffer> FromBytes(const std::byte* bytes, std::size_t count) noexcept {
-			GltfDataBuffer buffer(bytes, count);
-			if (buffer.error != Error::None) {
-				return buffer.error;
-			}
-			return buffer;
+	static Expected<GltfDataBuffer> FromBytes(const std::byte* bytes, std::size_t count) noexcept {
+		GltfDataBuffer buffer(bytes, count);
+		if (buffer.error != Error::None) {
+			return buffer.error;
 		}
+		return buffer;
+	}
 
-		static Expected<GltfDataBuffer> FromSpan(const std::span<std::byte> data) noexcept {
-			GltfDataBuffer buffer(data);
-			if (buffer.buffer == nullptr) {
-				return buffer.error;
-			}
-			return buffer;
+	static Expected<GltfDataBuffer> FromSpan(const std::span<std::byte> data) noexcept {
+		GltfDataBuffer buffer(data);
+		if (buffer.buffer == nullptr) {
+			return buffer.error;
 		}
+		return buffer;
+	}
 
-		void read(void* ptr, std::size_t count) override;
+	void read(void* ptr, std::size_t count) override;
 
-		[[nodiscard]] std::span<std::byte> read(std::size_t count, std::size_t padding) override;
+	[[nodiscard]] std::span<std::byte> read(std::size_t count, std::size_t padding) override;
 
-		void reset() override;
+	void reset() override;
 
-		[[nodiscard]] std::size_t bytesRead() override;
+	[[nodiscard]] std::size_t bytesRead() override;
 
-		[[nodiscard]] std::size_t totalSize() override;
+	[[nodiscard]] std::size_t totalSize() override;
 
-		[[nodiscard]] explicit operator std::span<std::byte>() const {
-			return {buffer.get(), dataSize};
-		}
-	};
+	[[nodiscard]] explicit operator std::span<std::byte>() const {
+		return {buffer.get(), dataSize};
+	}
+};
 
 #if defined(_WIN32)
-#include <winapifamily.h>
+#	include <winapifamily.h>
 #endif
 
-#if defined(__APPLE__) || defined(__linux__) || (defined(_WIN32) && !(defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)))
-#define FASTGLTF_HAS_MEMORY_MAPPED_FILE 1
-	/**
-	 * Memory-maps a file. This uses mmap on macOS and Linux, and MapViewOfFile on Windows, and is not available elsewhere.
-	 * You should check for FASTGLTF_HAS_MEMORY_MAPPED_FILE before using this class.
-	 */
-	FASTGLTF_EXPORT class MappedGltfFile : public GltfDataGetter {
-		void* mappedFile = nullptr;
-#if defined(_WIN32)
-		// Windows requires us to keep the file handle alive. Win32 HANDLE is a void*.
-		void* fileHandle = nullptr;
-		void* fileMapping = nullptr;
-#endif
-		std::uint64_t fileSize = 0;
+#if defined(__APPLE__) || defined(__linux__) || \
+	(defined(_WIN32) && !(defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)))
+#	define FASTGLTF_HAS_MEMORY_MAPPED_FILE 1
+/**
+ * Memory-maps a file. This uses mmap on macOS and Linux, and MapViewOfFile on Windows, and is not
+ * available elsewhere. You should check for FASTGLTF_HAS_MEMORY_MAPPED_FILE before using this
+ * class.
+ */
+FASTGLTF_EXPORT class MappedGltfFile : public GltfDataGetter {
+	void* mappedFile = nullptr;
+#	if defined(_WIN32)
+	// Windows requires us to keep the file handle alive. Win32 HANDLE is a void*.
+	void* fileHandle = nullptr;
+	void* fileMapping = nullptr;
+#	endif
+	std::uint64_t fileSize = 0;
 
-		std::size_t idx = 0;
+	std::size_t idx = 0;
 
-		Error error = Error::None;
+	Error error = Error::None;
 
-		explicit MappedGltfFile(const std::filesystem::path& path) noexcept;
+	explicit MappedGltfFile(const std::filesystem::path& path) noexcept;
 
-	public:
-		explicit MappedGltfFile() = default;
-		MappedGltfFile(const MappedGltfFile& other) = delete;
-		MappedGltfFile& operator=(const MappedGltfFile& other) = delete;
-		MappedGltfFile(MappedGltfFile&& other) noexcept;
-		MappedGltfFile& operator=(MappedGltfFile&& other) noexcept;
-		~MappedGltfFile() noexcept override;
+   public:
+	explicit MappedGltfFile() = default;
+	MappedGltfFile(const MappedGltfFile& other) = delete;
+	MappedGltfFile& operator=(const MappedGltfFile& other) = delete;
+	MappedGltfFile(MappedGltfFile&& other) noexcept;
+	MappedGltfFile& operator=(MappedGltfFile&& other) noexcept;
+	~MappedGltfFile() noexcept override;
 
-		/** Memory maps a file. If this fails, you can check std::strerror for a more exact error. */
-		static Expected<MappedGltfFile> FromPath(const std::filesystem::path& path) noexcept {
-			MappedGltfFile buffer(path);
-			if (buffer.error != Error::None) {
-				return buffer.error;
-			}
-			return buffer;
+	/** Memory maps a file. If this fails, you can check std::strerror for a more exact error. */
+	static Expected<MappedGltfFile> FromPath(const std::filesystem::path& path) noexcept {
+		MappedGltfFile buffer(path);
+		if (buffer.error != Error::None) {
+			return buffer.error;
 		}
+		return buffer;
+	}
 
-		void read(void* ptr, std::size_t count) override;
+	void read(void* ptr, std::size_t count) override;
 
-		[[nodiscard]] std::span<std::byte> read(std::size_t count, std::size_t padding) override;
+	[[nodiscard]] std::span<std::byte> read(std::size_t count, std::size_t padding) override;
 
-		void reset() override;
+	void reset() override;
 
-		[[nodiscard]] std::size_t bytesRead() override;
+	[[nodiscard]] std::size_t bytesRead() override;
 
-		[[nodiscard]] std::size_t totalSize() override;
+	[[nodiscard]] std::size_t totalSize() override;
 
-		[[nodiscard]] explicit operator std::span<std::byte>() const {
-			return {static_cast<std::byte*>(mappedFile), fileSize};
-		}
-	};
+	[[nodiscard]] explicit operator std::span<std::byte>() const {
+		return {static_cast<std::byte*>(mappedFile), fileSize};
+	}
+};
 #endif
 
-	FASTGLTF_EXPORT class GltfFileStream : public GltfDataGetter {
-		std::ifstream fileStream;
-		std::vector<std::ifstream::char_type> buf;
+FASTGLTF_EXPORT class GltfFileStream : public GltfDataGetter {
+	std::ifstream fileStream;
+	std::vector<std::ifstream::char_type> buf;
 
-		std::size_t fileSize;
+	std::size_t fileSize;
 
-	public:
-		explicit GltfFileStream(const std::filesystem::path& path);
-		~GltfFileStream() noexcept override = default;
+   public:
+	explicit GltfFileStream(const std::filesystem::path& path);
+	~GltfFileStream() noexcept override = default;
 
-		[[nodiscard]] bool isOpen() const;
+	[[nodiscard]] bool isOpen() const;
 
-		void read(void* ptr, std::size_t count) override;
+	void read(void* ptr, std::size_t count) override;
 
-		[[nodiscard]] std::span<std::byte> read(std::size_t count, std::size_t padding) override;
+	[[nodiscard]] std::span<std::byte> read(std::size_t count, std::size_t padding) override;
 
-		void reset() override;
+	void reset() override;
 
-		[[nodiscard]] std::size_t bytesRead() override;
+	[[nodiscard]] std::size_t bytesRead() override;
 
-		[[nodiscard]] std::size_t totalSize() override;
-	};
+	[[nodiscard]] std::size_t totalSize() override;
+};
 
-    #if defined(__ANDROID__)
-	FASTGLTF_EXPORT void setAndroidAssetManager(AAssetManager* assetManager) noexcept;
-
-    FASTGLTF_EXPORT class AndroidGltfDataBuffer : public GltfDataBuffer {
-		explicit AndroidGltfDataBuffer(const std::filesystem::path& path, std::uint64_t byteOffset) noexcept;
-
-    public:
-        explicit AndroidGltfDataBuffer() noexcept = default;
-        AndroidGltfDataBuffer(const AndroidGltfDataBuffer& other) = delete;
-        AndroidGltfDataBuffer& operator=(const AndroidGltfDataBuffer& other) = delete;
-        AndroidGltfDataBuffer(AndroidGltfDataBuffer&& other) noexcept = default;
-        AndroidGltfDataBuffer& operator=(AndroidGltfDataBuffer&& other) noexcept = default;
-        ~AndroidGltfDataBuffer() noexcept override = default;
-
-		static Expected<AndroidGltfDataBuffer> FromAsset(const std::filesystem::path& path, std::uint64_t byteOffset = 0) noexcept {
-			AndroidGltfDataBuffer buffer(path, byteOffset);
-			if (buffer.buffer.get() == nullptr) {
-				return buffer.error;
-			}
-			return buffer;
-		}
-	};
-	#endif
-
-	/**
-	 * Enum to represent the type of a glTF file. glTFs can either be the standard JSON file with
-	 * paths to buffers or with a base64 embedded buffers, or they can be in a so called GLB
-	 * container format which has two or more chunks of binary data, where one represents buffers
-	 * and the other contains the JSON string.
-	 */
-	FASTGLTF_EXPORT enum class GltfType : std::uint8_t {
-		glTF,
-		GLB,
-		Invalid,
-	};
-
-	/**
-	 * This function starts reading into the buffer and tries to determine what type of glTF container it is.
-	 * This should be used to know whether to call Parser::loadGltfJson or Parser::loadGltfBinary.
-	 *
-	 * @note Usually, you'll want to just use Parser::loadGltf, which will call this itself.
-	 *
-	 * @return The type of the glTF file, either glTF, GLB, or Invalid if it was not determinable. If this function
-	 * returns Invalid it is highly likely that the buffer does not actually represent a valid glTF file.
-	 */
-	FASTGLTF_EXPORT GltfType determineGltfFileType(GltfDataGetter& data);
-
-	/**
-	 * This function further validates all the input more strictly that is parsed from the glTF.
-	 * Realistically, this should not be necessary in Release applications, but could be helpful
-	 * when debugging an asset related issue.
-	*/
-	FASTGLTF_EXPORT [[nodiscard]] Error validate(const Asset& asset);
-
-    /**
-     * Some internals the parser passes on to each glTF instance.
-     */
-    struct ParserInternalConfig {
-        BufferMapCallback* mapCallback = nullptr;
-        BufferUnmapCallback* unmapCallback = nullptr;
-        Base64DecodeCallback* decodeCallback = nullptr;
-		ExtrasParseCallback* extrasCallback = nullptr;
-
-        void* userPointer = nullptr;
-        Extensions extensions = Extensions::None;
-    };
-
-    /**
-     * A parser for one or more glTF files. It uses a SIMD based JSON parser to maximize efficiency
-     * and performance at runtime.
-     *
-     * @note This class is not thread-safe.
-     */
-    class Parser {
-        // The simdjson parser object. We want to share it between runs, so it does not need to
-        // reallocate over and over again. We're hiding it here to not leak the simdjson header.
-        std::unique_ptr<simdjson::dom::parser> jsonParser;
-
-		ParserInternalConfig config = {};
-		DataSource glbBuffer;
-#if !FASTGLTF_DISABLE_CUSTOM_MEMORY_POOL
-		std::shared_ptr<std::pmr::monotonic_buffer_resource> resourceAllocator;
-#endif
-		std::filesystem::path directory;
-		Options options = Options::None;
-
-		static auto getMimeTypeFromString(std::string_view mime) -> MimeType;
-		static void fillCategories(Category& inputCategories) noexcept;
-
-		template <typename T>
-		Error parseAttributes(simdjson::dom::object& object, T& attributes);
-
-		[[nodiscard]] auto decodeDataUri(const URIView& uri) const noexcept -> Expected<DataSource>;
-		[[nodiscard]] auto loadFileFromUri(URIView& uri) const noexcept -> Expected<DataSource>;
 #if defined(__ANDROID__)
-		[[nodiscard]] auto loadFileFromApk(const std::filesystem::path& filepath) const noexcept -> Expected<DataSource>;
+FASTGLTF_EXPORT void setAndroidAssetManager(AAssetManager* assetManager) noexcept;
+
+FASTGLTF_EXPORT class AndroidGltfDataBuffer : public GltfDataBuffer {
+	explicit AndroidGltfDataBuffer(const std::filesystem::path& path,
+								   std::uint64_t byteOffset) noexcept;
+
+   public:
+	explicit AndroidGltfDataBuffer() noexcept = default;
+	AndroidGltfDataBuffer(const AndroidGltfDataBuffer& other) = delete;
+	AndroidGltfDataBuffer& operator=(const AndroidGltfDataBuffer& other) = delete;
+	AndroidGltfDataBuffer(AndroidGltfDataBuffer&& other) noexcept = default;
+	AndroidGltfDataBuffer& operator=(AndroidGltfDataBuffer&& other) noexcept = default;
+	~AndroidGltfDataBuffer() noexcept override = default;
+
+	static Expected<AndroidGltfDataBuffer> FromAsset(const std::filesystem::path& path,
+													 std::uint64_t byteOffset = 0) noexcept {
+		AndroidGltfDataBuffer buffer(path, byteOffset);
+		if (buffer.buffer.get() == nullptr) {
+			return buffer.error;
+		}
+		return buffer;
+	}
+};
 #endif
 
-		Error generateMeshIndices(Asset& asset) const;
+/**
+ * Enum to represent the type of a glTF file. glTFs can either be the standard JSON file with
+ * paths to buffers or with a base64 embedded buffers, or they can be in a so called GLB
+ * container format which has two or more chunks of binary data, where one represents buffers
+ * and the other contains the JSON string.
+ */
+FASTGLTF_EXPORT enum class GltfType : std::uint8_t {
+	glTF,
+	GLB,
+	Invalid,
+};
 
-		Error parseAccessors(const simdjson::dom::array& array, Asset& asset);
-		Error parseAnimations(simdjson::dom::array& array, Asset& asset);
-		Error parseBuffers(simdjson::dom::array& array, Asset& asset);
-		Error parseBufferViews(const simdjson::dom::array& array, Asset& asset);
-		Error parseCameras(simdjson::dom::array& array, Asset& asset);
-		Error parseExtensions(const simdjson::dom::object& extensionsObject, Asset& asset);
-		Error parseImages(simdjson::dom::array& array, Asset& asset);
-		Error parseLights(const simdjson::dom::array& array, Asset& asset);
-		Error parseMaterialExtensions(simdjson::dom::object& object, Material& material);
-		Error parseMaterials(simdjson::dom::array& array, Asset& asset);
-		Error parsePrimitiveExtensions(const simdjson::dom::object& object, Primitive& primitive);
-		Error parseMeshes(simdjson::dom::array& array, Asset& asset);
-		Error parseNodes(simdjson::dom::array& array, Asset& asset);
-		Error parseSamplers(const simdjson::dom::array& array, Asset& asset);
-		Error parseScenes(const simdjson::dom::array& array, Asset& asset);
-		Error parseSkins(const simdjson::dom::array& array, Asset& asset);
-		Error parseTextures(const simdjson::dom::array& array, Asset& asset);
+/**
+ * This function starts reading into the buffer and tries to determine what type of glTF container
+ * it is. This should be used to know whether to call Parser::loadGltfJson or
+ * Parser::loadGltfBinary.
+ *
+ * @note Usually, you'll want to just use Parser::loadGltf, which will call this itself.
+ *
+ * @return The type of the glTF file, either glTF, GLB, or Invalid if it was not determinable. If
+ * this function returns Invalid it is highly likely that the buffer does not actually represent a
+ * valid glTF file.
+ */
+FASTGLTF_EXPORT GltfType determineGltfFileType(GltfDataGetter& data);
+
+/**
+ * This function further validates all the input more strictly that is parsed from the glTF.
+ * Realistically, this should not be necessary in Release applications, but could be helpful
+ * when debugging an asset related issue.
+ */
+FASTGLTF_EXPORT [[nodiscard]] Error validate(const Asset& asset);
+
+/**
+ * Some internals the parser passes on to each glTF instance.
+ */
+struct ParserInternalConfig {
+	BufferMapCallback* mapCallback = nullptr;
+	BufferUnmapCallback* unmapCallback = nullptr;
+	Base64DecodeCallback* decodeCallback = nullptr;
+	ExtrasParseCallback* extrasCallback = nullptr;
+
+	void* userPointer = nullptr;
+	Extensions extensions = Extensions::None;
+};
+
+/**
+ * A parser for one or more glTF files. It uses a SIMD based JSON parser to maximize efficiency
+ * and performance at runtime.
+ *
+ * @note This class is not thread-safe.
+ */
+class Parser {
+	// The simdjson parser object. We want to share it between runs, so it does not need to
+	// reallocate over and over again. We're hiding it here to not leak the simdjson header.
+	std::unique_ptr<simdjson::dom::parser> jsonParser;
+
+	ParserInternalConfig config = {};
+	DataSource glbBuffer;
+#if !FASTGLTF_DISABLE_CUSTOM_MEMORY_POOL
+	std::shared_ptr<std::pmr::monotonic_buffer_resource> resourceAllocator;
+#endif
+	std::filesystem::path directory;
+	Options options = Options::None;
+
+	static auto getMimeTypeFromString(std::string_view mime) -> MimeType;
+	static void fillCategories(Category& inputCategories) noexcept;
+
+	template <typename T>
+	Error parseAttributes(simdjson::dom::object& object, T& attributes);
+
+	[[nodiscard]] auto decodeDataUri(const URIView& uri) const noexcept -> Expected<DataSource>;
+	[[nodiscard]] auto loadFileFromUri(URIView& uri) const noexcept -> Expected<DataSource>;
+#if defined(__ANDROID__)
+	[[nodiscard]] auto loadFileFromApk(const std::filesystem::path& filepath) const noexcept
+		-> Expected<DataSource>;
+#endif
+
+	Error generateMeshIndices(Asset& asset) const;
+
+	Error parseAccessors(const simdjson::dom::array& array, Asset& asset);
+	Error parseAnimations(simdjson::dom::array& array, Asset& asset);
+	Error parseBuffers(simdjson::dom::array& array, Asset& asset);
+	Error parseBufferViews(const simdjson::dom::array& array, Asset& asset);
+	Error parseCameras(simdjson::dom::array& array, Asset& asset);
+	Error parseExtensions(const simdjson::dom::object& extensionsObject, Asset& asset);
+	Error parseImages(simdjson::dom::array& array, Asset& asset);
+	Error parseLights(const simdjson::dom::array& array, Asset& asset);
+	Error parseMaterialExtensions(simdjson::dom::object& object, Material& material);
+	Error parseMaterials(simdjson::dom::array& array, Asset& asset);
+	Error parsePrimitiveExtensions(const simdjson::dom::object& object, Primitive& primitive);
+	Error parseMeshes(simdjson::dom::array& array, Asset& asset);
+	Error parseNodes(simdjson::dom::array& array, Asset& asset);
+	Error parseSamplers(const simdjson::dom::array& array, Asset& asset);
+	Error parseScenes(const simdjson::dom::array& array, Asset& asset);
+	Error parseSkins(const simdjson::dom::array& array, Asset& asset);
+	Error parseTextures(const simdjson::dom::array& array, Asset& asset);
 #if FASTGLTF_ENABLE_KHR_IMPLICIT_SHAPES
-		Error parseShapes(const simdjson::dom::array& shapes, Asset& asset);
+	Error parseShapes(const simdjson::dom::array& shapes, Asset& asset);
 #endif
 #if FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES
-		Error parsePhysicsMaterials(const simdjson::dom::array& physicsMaterials, Asset& asset);
-		Error parseCollisionFilters(const simdjson::dom::array& collisionFilters, Asset& asset);
-		Error parsePhysicsJoints(const simdjson::dom::array& physicsJoints, Asset& asset);
+	Error parsePhysicsMaterials(const simdjson::dom::array& physicsMaterials, Asset& asset);
+	Error parseCollisionFilters(const simdjson::dom::array& collisionFilters, Asset& asset);
+	Error parsePhysicsJoints(const simdjson::dom::array& physicsJoints, Asset& asset);
 
-		Error parsePhysicsRigidBody(simdjson::dom::object& khr_physics_rigid_bodies, Node& node);
+	Error parsePhysicsRigidBody(simdjson::dom::object& khr_physics_rigid_bodies, Node& node);
 #endif
-		Expected<Asset> parse(simdjson::dom::object root, Category categories);
+	Expected<Asset> parse(simdjson::dom::object root, Category categories);
 
-    public:
-        explicit Parser(Extensions extensionsToLoad = Extensions::None) noexcept;
-        explicit Parser(const Parser& parser) = delete;
-        Parser(Parser&& parser) noexcept;
-        Parser& operator=(const Parser& parser) = delete;
-        Parser& operator=(Parser&& other) noexcept;
+   public:
+	explicit Parser(Extensions extensionsToLoad = Extensions::None) noexcept;
+	explicit Parser(const Parser& parser) = delete;
+	Parser(Parser&& parser) noexcept;
+	Parser& operator=(const Parser& parser) = delete;
+	Parser& operator=(Parser&& other) noexcept;
 
-        ~Parser();
-
-        /**
-         * Loads a glTF file from pre-loaded bytes.
-         *
-         * This function tries to detect wether the bytes represent a standard JSON glTF or a binary glTF.
-         *
-         * @return An Asset wrapped in an Expected type, which may contain an error if one occurred.
-         */
-        [[nodiscard]] Expected<Asset> loadGltf(GltfDataGetter& buffer, std::filesystem::path directory, Options options = Options::None, Category categories = Category::All);
-
-        /**
-         * Loads a glTF file from pre-loaded bytes representing a JSON file.
-         *
-         * @return An Asset wrapped in an Expected type, which may contain an error if one occurred.
-         */
-        [[nodiscard]] Expected<Asset> loadGltfJson(GltfDataGetter& buffer, std::filesystem::path directory, Options options = Options::None, Category categories = Category::All);
-
-		/**
-		 * Loads a glTF file embedded within a GLB container, which may contain the first buffer of the glTF asset.
-		 *
-         * @return An Asset wrapped in an Expected type, which may contain an error if one occurred.
-		 */
-		[[nodiscard]] Expected<Asset> loadGltfBinary(GltfDataGetter& buffer, std::filesystem::path directory, Options options = Options::None, Category categories = Category::All);
-
-        /**
-         * This function can be used to set callbacks so that you can control memory allocation for
-         * large buffers and images that are loaded from a glTF file. For example, one could use
-         * the callbacks to map a GPU buffer through Vulkan or DirectX so that fastgltf can write
-         * the buffer directly to the GPU to avoid a copy into RAM first. To remove the callbacks
-         * for a specific load, call this method with both parameters as nullptr before load*GLTF.
-         * Using Parser::setUserPointer you can also set a user pointer to access your
-         * own class or other data you may need.
-         *
-         * @param mapCallback function called when the parser requires a buffer to write data
-         * embedded in a GLB file or decoded from a base64 URI, cannot be nullptr.
-         * @param unmapCallback function called when the parser is done with writing into a
-         * buffer, can be nullptr.
-         * @note This is likely only useful for advanced users who know what they're doing.
-         */
-        void setBufferAllocationCallback(BufferMapCallback* mapCallback, BufferUnmapCallback* unmapCallback = nullptr) noexcept;
-
-        /**
-         * Allows setting callbacks for base64 decoding.
-         * This can be useful if you have another base64 decoder optimised for a certain platform or architecture,
-         * or want to use your own scheduler to schedule multiple threads for working on decoding individual chunks of the data.
-         * Using Parser::setUserPointer you can also set a user pointer to access your own class or other data you may need.
-         *
-         * It is still recommended to use fastgltf's base64 decoding features as they're highly optimised
-         * for SSE4, AVX2, and ARM Neon.
-         *
-         * @param decodeCallback function called when the parser tries to decode a base64 buffer
-         */
-        void setBase64DecodeCallback(Base64DecodeCallback* decodeCallback) noexcept;
-
-		void setExtrasParseCallback(ExtrasParseCallback* extrasCallback) noexcept;
-
-        void setUserPointer(void* pointer) noexcept;
-    };
-
-    /**
-     * This converts a compacted JSON string into a more readable pretty format.
-     */
-    void prettyPrintJson(std::string& json);
-
-    /**
-     * Escapes a string for use in JSON.
-     */
-    std::string escapeString(std::string_view string);
-
-    FASTGLTF_EXPORT template <typename T>
-    struct ExportResult {
-        T output;
-
-        std::vector<std::optional<std::filesystem::path>> bufferPaths;
-        std::vector<std::optional<std::filesystem::path>> imagePaths;
-    };
-
-    /**
-     * A exporter for serializing one or more glTF assets into JSON and GLB forms.
-     *
-     * @note This does not write anything to any files. This class only serializes data
-     * into memory structures, which can then be used to manually write them to disk.
-     * If you want to let fastgltf handle the file writing too, use fastgltf::FileExporter.
-     */
-    FASTGLTF_EXPORT class Exporter {
-    protected:
-        Error errorCode = Error::None;
-        ExportOptions options = ExportOptions::None;
-		bool exportingBinary = false;
-
-        std::filesystem::path bufferFolder = "";
-        std::filesystem::path imageFolder = "";
-
-		void* userPointer = nullptr;
-		ExtrasWriteCallback* extrasWriteCallback = nullptr;
-
-        std::vector<std::optional<std::filesystem::path>> bufferPaths;
-        std::vector<std::optional<std::filesystem::path>> imagePaths;
-
-        void writeAccessors(const Asset& asset, std::string& json);
-        void writeAnimations(const Asset& asset, std::string& json);
-        void writeBuffers(const Asset& asset, std::string& json);
-        void writeBufferViews(const Asset& asset, std::string& json);
-        void writeCameras(const Asset& asset, std::string& json);
-        void writeImages(const Asset& asset, std::string& json);
-        void writeLights(const Asset& asset, std::string& json);
-        void writeMaterials(const Asset& asset, std::string& json);
-        void writeMeshes(const Asset& asset, std::string& json);
-        void writeNodes(const Asset& asset, std::string& json);
-        void writeSamplers(const Asset& asset, std::string& json);
-        void writeScenes(const Asset& asset, std::string& json);
-        void writeSkins(const Asset& asset, std::string& json);
-        void writeTextures(const Asset& asset, std::string& json);
-#if FASTGLTF_ENABLE_KHR_IMPLICIT_SHAPES
-		void writeShapes(const Asset& asset, std::string& json);
-#endif
-#if FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES
-		void writePhysicsMaterials(const Asset& asset, std::string& json);
-		void writeCollisionFilters(const Asset& asset, std::string& json);
-		void writePhysicsJoints(const Asset& asset, std::string& json);
-#endif
-        void writeExtensions(const Asset& asset, std::string& json);
-
-        std::filesystem::path getBufferFilePath(const Asset& asset, std::size_t index);
-        std::filesystem::path getImageFilePath(const Asset& asset, std::size_t index, MimeType mimeType);
-
-        std::string writeJson(const Asset& asset);
-
-    public:
-        /**
-         * Sets the relative base path for buffer URIs.
-         *
-         * If folder.is_relative() returns false, this has no effect.
-         */
-        void setBufferPath(std::filesystem::path folder);
-        /**
-         * Sets the relative base path for image URIs.
-         *
-         * If folder.is_relative() returns false, this has no effect.
-         */
-        void setImagePath(std::filesystem::path folder);
-
-		void setExtrasWriteCallback(ExtrasWriteCallback* callback) noexcept;
-
-		void setUserPointer(void* pointer) noexcept;
-
-        /**
-         * Generates a glTF JSON string from the given asset.
-         */
-        Expected<ExportResult<std::string>> writeGltfJson(const Asset& asset, ExportOptions options = ExportOptions::None);
-
-        /**
-         * Generates a glTF binary (GLB) blob from the given asset.
-         *
-         * If the first buffer holds a sources::Vector, a sources::Array, a or sources::ByteView and the byte length is smaller than 2^32 (4.2GB),
-         * it will be embedded into the binary. Note that the returned vector might therefore get quite large.
-         */
-        Expected<ExportResult<std::vector<std::byte>>> writeGltfBinary(const Asset& asset, ExportOptions options = ExportOptions::None);
-    };
+	~Parser();
 
 	/**
-	 * A exporter for serializing one or more glTF files into JSON and GLB forms.
-	 * This exporter builds upon Exporter by writing all files automatically to the
-	 * given paths.
+	 * Loads a glTF file from pre-loaded bytes.
+	 *
+	 * This function tries to detect wether the bytes represent a standard JSON glTF or a binary
+	 * glTF.
+	 *
+	 * @return An Asset wrapped in an Expected type, which may contain an error if one occurred.
 	 */
-	FASTGLTF_EXPORT class FileExporter : public Exporter {
-        using Exporter::writeGltfJson;
-        using Exporter::writeGltfBinary;
+	[[nodiscard]] Expected<Asset> loadGltf(GltfDataGetter& buffer, std::filesystem::path directory,
+										   Options options = Options::None,
+										   Category categories = Category::All);
 
-	public:
-        /**
-         * Writes a glTF JSON string generated from the given asset to the specified target file. This will also write
-         * all buffers and textures to disk using the buffer and image paths set using Exporter::setBufferPath and
-         * Exporter::setImagePath.
-         */
-		Error writeGltfJson(const Asset& asset, const std::filesystem::path& target, ExportOptions options = ExportOptions::None);
+	/**
+	 * Loads a glTF file from pre-loaded bytes representing a JSON file.
+	 *
+	 * @return An Asset wrapped in an Expected type, which may contain an error if one occurred.
+	 */
+	[[nodiscard]] Expected<Asset> loadGltfJson(GltfDataGetter& buffer,
+											   std::filesystem::path directory,
+											   Options options = Options::None,
+											   Category categories = Category::All);
 
-		/**
-		 * Writes a glTF binary (GLB) blob from the given asset to the specified target file. This will also write
-         * all buffers and textures to disk using the buffer and image paths set using Exporter::setBufferPath and
-         * Exporter::setImagePath.
-         *
-		 * If the first buffer holds a sources::Vector, a sources::Array, a or sources::ByteView and the byte length is smaller than 2^32 (4.2GB),
-         * it will be embedded into the binary.
-         *
-		 * \see Exporter::writeGltfBinary
-		 */
-        Error writeGltfBinary(const Asset& asset, const std::filesystem::path& target, ExportOptions options = ExportOptions::None);
-	};
-} // namespace fastgltf
+	/**
+	 * Loads a glTF file embedded within a GLB container, which may contain the first buffer of the
+	 * glTF asset.
+	 *
+	 * @return An Asset wrapped in an Expected type, which may contain an error if one occurred.
+	 */
+	[[nodiscard]] Expected<Asset> loadGltfBinary(GltfDataGetter& buffer,
+												 std::filesystem::path directory,
+												 Options options = Options::None,
+												 Category categories = Category::All);
+
+	/**
+	 * This function can be used to set callbacks so that you can control memory allocation for
+	 * large buffers and images that are loaded from a glTF file. For example, one could use
+	 * the callbacks to map a GPU buffer through Vulkan or DirectX so that fastgltf can write
+	 * the buffer directly to the GPU to avoid a copy into RAM first. To remove the callbacks
+	 * for a specific load, call this method with both parameters as nullptr before load*GLTF.
+	 * Using Parser::setUserPointer you can also set a user pointer to access your
+	 * own class or other data you may need.
+	 *
+	 * @param mapCallback function called when the parser requires a buffer to write data
+	 * embedded in a GLB file or decoded from a base64 URI, cannot be nullptr.
+	 * @param unmapCallback function called when the parser is done with writing into a
+	 * buffer, can be nullptr.
+	 * @note This is likely only useful for advanced users who know what they're doing.
+	 */
+	void setBufferAllocationCallback(BufferMapCallback* mapCallback,
+									 BufferUnmapCallback* unmapCallback = nullptr) noexcept;
+
+	/**
+	 * Allows setting callbacks for base64 decoding.
+	 * This can be useful if you have another base64 decoder optimised for a certain platform or
+	 * architecture, or want to use your own scheduler to schedule multiple threads for working on
+	 * decoding individual chunks of the data. Using Parser::setUserPointer you can also set a user
+	 * pointer to access your own class or other data you may need.
+	 *
+	 * It is still recommended to use fastgltf's base64 decoding features as they're highly
+	 * optimised for SSE4, AVX2, and ARM Neon.
+	 *
+	 * @param decodeCallback function called when the parser tries to decode a base64 buffer
+	 */
+	void setBase64DecodeCallback(Base64DecodeCallback* decodeCallback) noexcept;
+
+	void setExtrasParseCallback(ExtrasParseCallback* extrasCallback) noexcept;
+
+	void setUserPointer(void* pointer) noexcept;
+};
+
+/**
+ * This converts a compacted JSON string into a more readable pretty format.
+ */
+void prettyPrintJson(std::string& json);
+
+/**
+ * Escapes a string for use in JSON.
+ */
+std::string escapeString(std::string_view string);
+
+FASTGLTF_EXPORT template <typename T>
+struct ExportResult {
+	T output;
+
+	std::vector<std::optional<std::filesystem::path>> bufferPaths;
+	std::vector<std::optional<std::filesystem::path>> imagePaths;
+};
+
+/**
+ * A exporter for serializing one or more glTF assets into JSON and GLB forms.
+ *
+ * @note This does not write anything to any files. This class only serializes data
+ * into memory structures, which can then be used to manually write them to disk.
+ * If you want to let fastgltf handle the file writing too, use fastgltf::FileExporter.
+ */
+FASTGLTF_EXPORT class Exporter {
+   protected:
+	Error errorCode = Error::None;
+	ExportOptions options = ExportOptions::None;
+	bool exportingBinary = false;
+
+	std::filesystem::path bufferFolder = "";
+	std::filesystem::path imageFolder = "";
+
+	void* userPointer = nullptr;
+	ExtrasWriteCallback* extrasWriteCallback = nullptr;
+
+	std::vector<std::optional<std::filesystem::path>> bufferPaths;
+	std::vector<std::optional<std::filesystem::path>> imagePaths;
+
+	void writeAccessors(const Asset& asset, std::string& json);
+	void writeAnimations(const Asset& asset, std::string& json);
+	void writeBuffers(const Asset& asset, std::string& json);
+	void writeBufferViews(const Asset& asset, std::string& json);
+	void writeCameras(const Asset& asset, std::string& json);
+	void writeImages(const Asset& asset, std::string& json);
+	void writeLights(const Asset& asset, std::string& json);
+	void writeMaterials(const Asset& asset, std::string& json);
+	void writeMeshes(const Asset& asset, std::string& json);
+	void writeNodes(const Asset& asset, std::string& json);
+	void writeSamplers(const Asset& asset, std::string& json);
+	void writeScenes(const Asset& asset, std::string& json);
+	void writeSkins(const Asset& asset, std::string& json);
+	void writeTextures(const Asset& asset, std::string& json);
+#if FASTGLTF_ENABLE_KHR_IMPLICIT_SHAPES
+	void writeShapes(const Asset& asset, std::string& json);
+#endif
+#if FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES
+	void writePhysicsMaterials(const Asset& asset, std::string& json);
+	void writeCollisionFilters(const Asset& asset, std::string& json);
+	void writePhysicsJoints(const Asset& asset, std::string& json);
+#endif
+	void writeExtensions(const Asset& asset, std::string& json);
+
+	std::filesystem::path getBufferFilePath(const Asset& asset, std::size_t index);
+	std::filesystem::path getImageFilePath(const Asset& asset, std::size_t index,
+										   MimeType mimeType);
+
+	std::string writeJson(const Asset& asset);
+
+   public:
+	/**
+	 * Sets the relative base path for buffer URIs.
+	 *
+	 * If folder.is_relative() returns false, this has no effect.
+	 */
+	void setBufferPath(std::filesystem::path folder);
+	/**
+	 * Sets the relative base path for image URIs.
+	 *
+	 * If folder.is_relative() returns false, this has no effect.
+	 */
+	void setImagePath(std::filesystem::path folder);
+
+	void setExtrasWriteCallback(ExtrasWriteCallback* callback) noexcept;
+
+	void setUserPointer(void* pointer) noexcept;
+
+	/**
+	 * Generates a glTF JSON string from the given asset.
+	 */
+	Expected<ExportResult<std::string>> writeGltfJson(const Asset& asset,
+													  ExportOptions options = ExportOptions::None);
+
+	/**
+	 * Generates a glTF binary (GLB) blob from the given asset.
+	 *
+	 * If the first buffer holds a sources::Vector, a sources::Array, a or sources::ByteView and the
+	 * byte length is smaller than 2^32 (4.2GB), it will be embedded into the binary. Note that the
+	 * returned vector might therefore get quite large.
+	 */
+	Expected<ExportResult<std::vector<std::byte>>> writeGltfBinary(
+		const Asset& asset, ExportOptions options = ExportOptions::None);
+};
+
+/**
+ * A exporter for serializing one or more glTF files into JSON and GLB forms.
+ * This exporter builds upon Exporter by writing all files automatically to the
+ * given paths.
+ */
+FASTGLTF_EXPORT class FileExporter : public Exporter {
+	using Exporter::writeGltfBinary;
+	using Exporter::writeGltfJson;
+
+   public:
+	/**
+	 * Writes a glTF JSON string generated from the given asset to the specified target file. This
+	 * will also write all buffers and textures to disk using the buffer and image paths set using
+	 * Exporter::setBufferPath and Exporter::setImagePath.
+	 */
+	Error writeGltfJson(const Asset& asset, const std::filesystem::path& target,
+						ExportOptions options = ExportOptions::None);
+
+	/**
+	 * Writes a glTF binary (GLB) blob from the given asset to the specified target file. This will
+	 * also write all buffers and textures to disk using the buffer and image paths set using
+	 * Exporter::setBufferPath and Exporter::setImagePath.
+	 *
+	 * If the first buffer holds a sources::Vector, a sources::Array, a or sources::ByteView and the
+	 * byte length is smaller than 2^32 (4.2GB), it will be embedded into the binary.
+	 *
+	 * \see Exporter::writeGltfBinary
+	 */
+	Error writeGltfBinary(const Asset& asset, const std::filesystem::path& target,
+						  ExportOptions options = ExportOptions::None);
+};
+}  // namespace fastgltf
 
 #ifdef _MSC_VER
-#pragma warning(pop)
+#	pragma warning(pop)
 #endif
 
 #endif

--- a/include/fastgltf/core.hpp
+++ b/include/fastgltf/core.hpp
@@ -648,7 +648,7 @@ namespace fastgltf {
 		[[nodiscard]] std::size_t totalSize() override;
 
 		[[nodiscard]] explicit operator std::span<std::byte>() const {
-			return std::span(buffer.get(), dataSize);
+			return {buffer.get(), dataSize};
 		}
 	};
 
@@ -705,7 +705,7 @@ namespace fastgltf {
 		[[nodiscard]] std::size_t totalSize() override;
 
 		[[nodiscard]] explicit operator std::span<std::byte>() const {
-			return std::span(static_cast<std::byte*>(mappedFile), fileSize);
+			return {static_cast<std::byte*>(mappedFile), fileSize};
 		}
 	};
 #endif

--- a/include/fastgltf/core.hpp
+++ b/include/fastgltf/core.hpp
@@ -375,7 +375,7 @@ namespace fastgltf {
 	// An array of pairs of string representations of extension identifiers and their respective enum
 	// value used for enabling/disabling the loading of it. This also represents all extensions that
 	// fastgltf supports and understands.
-	static constexpr auto extensionStrings = to_array<std::pair<std::string_view, Extensions>>({
+	static constexpr auto extensionStrings = std::to_array<std::pair<std::string_view, Extensions>>({
 		{ extensions::EXT_mesh_gpu_instancing,                  Extensions::EXT_mesh_gpu_instancing },
 		{ extensions::EXT_meshopt_compression,                  Extensions::EXT_meshopt_compression },
 		{ extensions::EXT_texture_webp,                         Extensions::EXT_texture_webp },
@@ -423,13 +423,7 @@ namespace fastgltf {
 	 * @note If \p extensions has more than one bit set (multiple extensions), this
 	 * will return the name of the first set bit.
 	 */
-	FASTGLTF_EXPORT
-#if FASTGLTF_CPP_20
-	constexpr
-#else
-	inline
-#endif
-	std::string_view stringifyExtension(Extensions extensions) {
+	FASTGLTF_EXPORT constexpr std::string_view stringifyExtension(Extensions extensions) {
 		// Remove everything but the rightmost bit
 		extensions = extensions - (extensions & (extensions - 1));
 
@@ -581,7 +575,7 @@ namespace fastgltf {
 		 * This padding is necessary for the simdjson parser, but can be initialized to anything.
 		 * The memory pointed to by the span only needs to live until the next call to read().
 		 */
-		[[nodiscard]] virtual span<std::byte> read(std::size_t count, std::size_t padding) = 0;
+		[[nodiscard]] virtual std::span<std::byte> read(std::size_t count, std::size_t padding) = 0;
 
 		/**
 		 * Reset is used to put the offset index back to the start of the buffer/file.
@@ -609,9 +603,7 @@ namespace fastgltf {
 
 		explicit GltfDataBuffer(const std::filesystem::path& path) noexcept;
 		explicit GltfDataBuffer(const std::byte* bytes, std::size_t count) noexcept;
-#if FASTGLTF_CPP_20
 		explicit GltfDataBuffer(std::span<std::byte> span) noexcept;
-#endif
 
 	public:
 		explicit GltfDataBuffer() noexcept = default;
@@ -637,19 +629,17 @@ namespace fastgltf {
 			return buffer;
 		}
 
-#if FASTGLTF_CPP_20
-		static Expected<GltfDataBuffer> FromSpan(std::span<std::byte> data) noexcept {
+		static Expected<GltfDataBuffer> FromSpan(const std::span<std::byte> data) noexcept {
 			GltfDataBuffer buffer(data);
-			if (buffer.buffer.get() == nullptr) {
+			if (buffer.buffer == nullptr) {
 				return buffer.error;
 			}
 			return buffer;
 		}
-#endif
 
 		void read(void* ptr, std::size_t count) override;
 
-		[[nodiscard]] span<std::byte> read(std::size_t count, std::size_t padding) override;
+		[[nodiscard]] std::span<std::byte> read(std::size_t count, std::size_t padding) override;
 
 		void reset() override;
 
@@ -657,8 +647,8 @@ namespace fastgltf {
 
 		[[nodiscard]] std::size_t totalSize() override;
 
-		[[nodiscard]] explicit operator span<std::byte>() const {
-			return span(buffer.get(), dataSize);
+		[[nodiscard]] explicit operator std::span<std::byte>() const {
+			return std::span(buffer.get(), dataSize);
 		}
 	};
 
@@ -706,7 +696,7 @@ namespace fastgltf {
 
 		void read(void* ptr, std::size_t count) override;
 
-		[[nodiscard]] span<std::byte> read(std::size_t count, std::size_t padding) override;
+		[[nodiscard]] std::span<std::byte> read(std::size_t count, std::size_t padding) override;
 
 		void reset() override;
 
@@ -714,8 +704,8 @@ namespace fastgltf {
 
 		[[nodiscard]] std::size_t totalSize() override;
 
-		[[nodiscard]] explicit operator span<std::byte>() const {
-			return span(static_cast<std::byte*>(mappedFile), fileSize);
+		[[nodiscard]] explicit operator std::span<std::byte>() const {
+			return std::span(static_cast<std::byte*>(mappedFile), fileSize);
 		}
 	};
 #endif
@@ -734,7 +724,7 @@ namespace fastgltf {
 
 		void read(void* ptr, std::size_t count) override;
 
-		[[nodiscard]] span<std::byte> read(std::size_t count, std::size_t padding) override;
+		[[nodiscard]] std::span<std::byte> read(std::size_t count, std::size_t padding) override;
 
 		void reset() override;
 

--- a/include/fastgltf/dxmath_element_traits.hpp
+++ b/include/fastgltf/dxmath_element_traits.hpp
@@ -30,66 +30,84 @@
 #include <fastgltf/tools.hpp>
 
 #if __has_include(<DirectXMath.h>)
-#include <DirectXMath.h>
+#	include <DirectXMath.h>
 #endif
 
 #if __has_include(<DirectXPackedVector.h>)
-#include <DirectXPackedVector.h>
+#	include <DirectXPackedVector.h>
 #endif
 
 namespace fastgltf {
 
-FASTGLTF_EXPORT template <typename ElementType, AccessorType EnumAccessorType, typename ComponentType = ElementType>
-using TransposedElementTraits = ElementTraitsBase<ElementType, EnumAccessorType, ComponentType, true>;
+FASTGLTF_EXPORT template <typename ElementType, AccessorType EnumAccessorType,
+						  typename ComponentType = ElementType>
+using TransposedElementTraits =
+	ElementTraitsBase<ElementType, EnumAccessorType, ComponentType, true>;
 
 template <>
-struct ElementTraits<DirectX::XMFLOAT2> : ElementTraitsBase<DirectX::XMFLOAT2, AccessorType::Vec2, float> {};
+struct ElementTraits<DirectX::XMFLOAT2>
+	: ElementTraitsBase<DirectX::XMFLOAT2, AccessorType::Vec2, float> {};
 
 template <>
-struct ElementTraits<DirectX::XMFLOAT3> : ElementTraitsBase<DirectX::XMFLOAT3, AccessorType::Vec3, float> {};
+struct ElementTraits<DirectX::XMFLOAT3>
+	: ElementTraitsBase<DirectX::XMFLOAT3, AccessorType::Vec3, float> {};
 
 template <>
-struct ElementTraits<DirectX::XMFLOAT4> : ElementTraitsBase<DirectX::XMFLOAT4, AccessorType::Vec4, float> {};
+struct ElementTraits<DirectX::XMFLOAT4>
+	: ElementTraitsBase<DirectX::XMFLOAT4, AccessorType::Vec4, float> {};
 
-template<>
-struct ElementTraits<DirectX::PackedVector::XMBYTE2> : ElementTraitsBase<DirectX::PackedVector::XMBYTE2, AccessorType::Vec2, std::int8_t> {};
+template <>
+struct ElementTraits<DirectX::PackedVector::XMBYTE2>
+	: ElementTraitsBase<DirectX::PackedVector::XMBYTE2, AccessorType::Vec2, std::int8_t> {};
 
-template<>
-struct ElementTraits<DirectX::PackedVector::XMBYTE4> : ElementTraitsBase<DirectX::PackedVector::XMBYTE4, AccessorType::Vec4, std::int8_t> {};
+template <>
+struct ElementTraits<DirectX::PackedVector::XMBYTE4>
+	: ElementTraitsBase<DirectX::PackedVector::XMBYTE4, AccessorType::Vec4, std::int8_t> {};
 
-template<>
-struct ElementTraits<DirectX::PackedVector::XMUBYTE2> : ElementTraitsBase<DirectX::PackedVector::XMUBYTE2, AccessorType::Vec2, std::uint8_t> {};
+template <>
+struct ElementTraits<DirectX::PackedVector::XMUBYTE2>
+	: ElementTraitsBase<DirectX::PackedVector::XMUBYTE2, AccessorType::Vec2, std::uint8_t> {};
 
-template<>
-struct ElementTraits<DirectX::PackedVector::XMUBYTE4> : ElementTraitsBase<DirectX::PackedVector::XMUBYTE4, AccessorType::Vec4, std::uint8_t> {};
+template <>
+struct ElementTraits<DirectX::PackedVector::XMUBYTE4>
+	: ElementTraitsBase<DirectX::PackedVector::XMUBYTE4, AccessorType::Vec4, std::uint8_t> {};
 
-template<>
-struct ElementTraits<DirectX::PackedVector::XMSHORT2> : ElementTraitsBase<DirectX::PackedVector::XMSHORT2, AccessorType::Vec2, std::int16_t> {};
+template <>
+struct ElementTraits<DirectX::PackedVector::XMSHORT2>
+	: ElementTraitsBase<DirectX::PackedVector::XMSHORT2, AccessorType::Vec2, std::int16_t> {};
 
-template<>
-struct ElementTraits<DirectX::PackedVector::XMSHORT4> : ElementTraitsBase<DirectX::PackedVector::XMSHORT4, AccessorType::Vec4, std::int16_t> {};
+template <>
+struct ElementTraits<DirectX::PackedVector::XMSHORT4>
+	: ElementTraitsBase<DirectX::PackedVector::XMSHORT4, AccessorType::Vec4, std::int16_t> {};
 
-template<>
-struct ElementTraits<DirectX::PackedVector::XMUSHORT2> : ElementTraitsBase<DirectX::PackedVector::XMUSHORT2, AccessorType::Vec2, std::uint16_t> {};
+template <>
+struct ElementTraits<DirectX::PackedVector::XMUSHORT2>
+	: ElementTraitsBase<DirectX::PackedVector::XMUSHORT2, AccessorType::Vec2, std::uint16_t> {};
 
-template<>
-struct ElementTraits<DirectX::PackedVector::XMUSHORT4> : ElementTraitsBase<DirectX::PackedVector::XMUSHORT4, AccessorType::Vec4, std::uint16_t> {};
+template <>
+struct ElementTraits<DirectX::PackedVector::XMUSHORT4>
+	: ElementTraitsBase<DirectX::PackedVector::XMUSHORT4, AccessorType::Vec4, std::uint16_t> {};
 
-template<>
-struct ElementTraits<DirectX::XMUINT2> : ElementTraitsBase<DirectX::XMUINT2, AccessorType::Vec2, std::uint32_t> {};
+template <>
+struct ElementTraits<DirectX::XMUINT2>
+	: ElementTraitsBase<DirectX::XMUINT2, AccessorType::Vec2, std::uint32_t> {};
 
-template<>
-struct ElementTraits<DirectX::XMUINT3> : ElementTraitsBase<DirectX::XMUINT3, AccessorType::Vec3, std::uint32_t> {};
+template <>
+struct ElementTraits<DirectX::XMUINT3>
+	: ElementTraitsBase<DirectX::XMUINT3, AccessorType::Vec3, std::uint32_t> {};
 
-template<>
-struct ElementTraits<DirectX::XMUINT4> : ElementTraitsBase<DirectX::XMUINT4, AccessorType::Vec4, std::uint32_t> {};
+template <>
+struct ElementTraits<DirectX::XMUINT4>
+	: ElementTraitsBase<DirectX::XMUINT4, AccessorType::Vec4, std::uint32_t> {};
 
-template<>
-struct ElementTraits<DirectX::XMFLOAT3X3> : TransposedElementTraits<DirectX::XMFLOAT3X3, AccessorType::Mat3, float> {};
+template <>
+struct ElementTraits<DirectX::XMFLOAT3X3>
+	: TransposedElementTraits<DirectX::XMFLOAT3X3, AccessorType::Mat3, float> {};
 
-template<>
-struct ElementTraits<DirectX::XMFLOAT4X4> : TransposedElementTraits<DirectX::XMFLOAT4X4, AccessorType::Mat4, float> {};
+template <>
+struct ElementTraits<DirectX::XMFLOAT4X4>
+	: TransposedElementTraits<DirectX::XMFLOAT4X4, AccessorType::Mat4, float> {};
 
-} // namespace fastgltf
+}  // namespace fastgltf
 
 #endif

--- a/include/fastgltf/glm_element_traits.hpp
+++ b/include/fastgltf/glm_element_traits.hpp
@@ -32,74 +32,89 @@
 // If we find glm in the default include path, we'll also include it ourselfs.
 // However, it is generally expected that the user will include glm before including this header.
 #if __has_include(<glm/glm.hpp>)
-#include <glm/glm.hpp>
+#	include <glm/glm.hpp>
 #endif
 
 namespace fastgltf {
 
-template<>
+template <>
 struct ElementTraits<glm::vec2> : ElementTraitsBase<glm::vec2, AccessorType::Vec2, float> {};
 
-template<>
+template <>
 struct ElementTraits<glm::vec3> : ElementTraitsBase<glm::vec3, AccessorType::Vec3, float> {};
 
-template<>
+template <>
 struct ElementTraits<glm::vec4> : ElementTraitsBase<glm::vec4, AccessorType::Vec4, float> {};
 
-template<>
-struct ElementTraits<glm::i8vec2> : ElementTraitsBase<glm::i8vec2, AccessorType::Vec2, std::int8_t> {};
+template <>
+struct ElementTraits<glm::i8vec2>
+	: ElementTraitsBase<glm::i8vec2, AccessorType::Vec2, std::int8_t> {};
 
-template<>
-struct ElementTraits<glm::i8vec3> : ElementTraitsBase<glm::i8vec3, AccessorType::Vec3, std::int8_t> {};
+template <>
+struct ElementTraits<glm::i8vec3>
+	: ElementTraitsBase<glm::i8vec3, AccessorType::Vec3, std::int8_t> {};
 
-template<>
-struct ElementTraits<glm::i8vec4> : ElementTraitsBase<glm::i8vec4, AccessorType::Vec4, std::int8_t> {};
+template <>
+struct ElementTraits<glm::i8vec4>
+	: ElementTraitsBase<glm::i8vec4, AccessorType::Vec4, std::int8_t> {};
 
-template<>
-struct ElementTraits<glm::u8vec2> : ElementTraitsBase<glm::u8vec2, AccessorType::Vec2, std::uint8_t> {};
+template <>
+struct ElementTraits<glm::u8vec2>
+	: ElementTraitsBase<glm::u8vec2, AccessorType::Vec2, std::uint8_t> {};
 
-template<>
-struct ElementTraits<glm::u8vec3> : ElementTraitsBase<glm::u8vec3, AccessorType::Vec3, std::uint8_t> {};
+template <>
+struct ElementTraits<glm::u8vec3>
+	: ElementTraitsBase<glm::u8vec3, AccessorType::Vec3, std::uint8_t> {};
 
-template<>
-struct ElementTraits<glm::u8vec4> : ElementTraitsBase<glm::u8vec4, AccessorType::Vec4, std::uint8_t> {};
+template <>
+struct ElementTraits<glm::u8vec4>
+	: ElementTraitsBase<glm::u8vec4, AccessorType::Vec4, std::uint8_t> {};
 
-template<>
-struct ElementTraits<glm::i16vec2> : ElementTraitsBase<glm::i16vec2, AccessorType::Vec2, std::int16_t> {};
+template <>
+struct ElementTraits<glm::i16vec2>
+	: ElementTraitsBase<glm::i16vec2, AccessorType::Vec2, std::int16_t> {};
 
-template<>
-struct ElementTraits<glm::i16vec3> : ElementTraitsBase<glm::i16vec3, AccessorType::Vec3, std::int16_t> {};
+template <>
+struct ElementTraits<glm::i16vec3>
+	: ElementTraitsBase<glm::i16vec3, AccessorType::Vec3, std::int16_t> {};
 
-template<>
-struct ElementTraits<glm::i16vec4> : ElementTraitsBase<glm::i16vec4, AccessorType::Vec4, std::int16_t> {};
+template <>
+struct ElementTraits<glm::i16vec4>
+	: ElementTraitsBase<glm::i16vec4, AccessorType::Vec4, std::int16_t> {};
 
-template<>
-struct ElementTraits<glm::u16vec2> : ElementTraitsBase<glm::u16vec2, AccessorType::Vec2, std::uint16_t> {};
+template <>
+struct ElementTraits<glm::u16vec2>
+	: ElementTraitsBase<glm::u16vec2, AccessorType::Vec2, std::uint16_t> {};
 
-template<>
-struct ElementTraits<glm::u16vec3> : ElementTraitsBase<glm::u16vec3, AccessorType::Vec3, std::uint16_t> {};
+template <>
+struct ElementTraits<glm::u16vec3>
+	: ElementTraitsBase<glm::u16vec3, AccessorType::Vec3, std::uint16_t> {};
 
-template<>
-struct ElementTraits<glm::u16vec4> : ElementTraitsBase<glm::u16vec4, AccessorType::Vec4, std::uint16_t> {};
+template <>
+struct ElementTraits<glm::u16vec4>
+	: ElementTraitsBase<glm::u16vec4, AccessorType::Vec4, std::uint16_t> {};
 
-template<>
-struct ElementTraits<glm::u32vec2> : ElementTraitsBase<glm::u32vec2, AccessorType::Vec2, std::uint32_t> {};
+template <>
+struct ElementTraits<glm::u32vec2>
+	: ElementTraitsBase<glm::u32vec2, AccessorType::Vec2, std::uint32_t> {};
 
-template<>
-struct ElementTraits<glm::u32vec3> : ElementTraitsBase<glm::u32vec3, AccessorType::Vec3, std::uint32_t> {};
+template <>
+struct ElementTraits<glm::u32vec3>
+	: ElementTraitsBase<glm::u32vec3, AccessorType::Vec3, std::uint32_t> {};
 
-template<>
-struct ElementTraits<glm::u32vec4> : ElementTraitsBase<glm::u32vec4, AccessorType::Vec4, std::uint32_t> {};
+template <>
+struct ElementTraits<glm::u32vec4>
+	: ElementTraitsBase<glm::u32vec4, AccessorType::Vec4, std::uint32_t> {};
 
-template<>
+template <>
 struct ElementTraits<glm::mat2> : ElementTraitsBase<glm::mat2, AccessorType::Mat2, float> {};
 
-template<>
+template <>
 struct ElementTraits<glm::mat3> : ElementTraitsBase<glm::mat3, AccessorType::Mat3, float> {};
 
-template<>
+template <>
 struct ElementTraits<glm::mat4> : ElementTraitsBase<glm::mat4, AccessorType::Mat4, float> {};
 
-} // namespace fastgltf
+}  // namespace fastgltf
 
 #endif

--- a/include/fastgltf/math.hpp
+++ b/include/fastgltf/math.hpp
@@ -84,7 +84,8 @@ namespace fastgltf::math {
 		}
 
 		/** Creates a new vector with N components from N values in the order X, Y, Z, W */
-		template <typename... Args, std::enable_if_t<sizeof...(Args) == N, bool> = true>
+		template <typename... Args>
+		requires (sizeof...(Args) == N)
 		constexpr explicit vec(Args... args) noexcept : _data { T(std::forward<Args>(args))... } {}
 
 		static constexpr auto fromPointer(T* ptr) noexcept {
@@ -97,37 +98,43 @@ namespace fastgltf::math {
 		constexpr vec(const vec&) noexcept = default;
 		constexpr vec& operator=(const vec& other) noexcept = default;
 
-		template <typename U, std::enable_if_t<!std::is_same_v<T, U>, bool> = true>
+		template <typename U>
+		requires (!std::is_same_v<T, U>)
 		constexpr explicit vec(const vec<U, N>& other) noexcept {
 			for (std::size_t i = 0; i < N; ++i)
 				(*this)[i] = static_cast<T>(other[i]);
 		}
-		template <typename U, std::enable_if_t<!std::is_same_v<T, U>, bool> = true>
-		constexpr vec<T, N>& operator=(const vec<U, N>& other) noexcept {
+		template <typename U>
+		requires (!std::is_same_v<T, U>)
+		constexpr vec& operator=(const vec<U, N>& other) noexcept {
 			for (std::size_t i = 0; i < N; ++i)
 				(*this)[i] = static_cast<T>(other[i]);
 			return *this;
 		}
 
-		template <std::size_t M, std::enable_if_t<M >= N, bool> = true>
+		template <std::size_t M>
+		requires (M >= N)
 		constexpr explicit vec(const vec<T, M>& other) noexcept {
 			for (std::size_t i = 0; i < N; ++i)
 				(*this)[i] = other[i];
 		}
-		template <std::size_t M, std::enable_if_t<M >= N, bool> = true>
-		constexpr vec<T, N>& operator=(const vec<T, M>& other) noexcept {
+		template <std::size_t M>
+		requires (M >= N)
+		constexpr vec& operator=(const vec<T, M>& other) noexcept {
 			for (std::size_t i = 0; i < N; ++i)
 				(*this)[i] = other[i];
 			return *this;
 		}
 
-		template <std::size_t M, std::enable_if_t<M < N, bool> = true>
+		template <std::size_t M>
+		requires (M < N)
 		constexpr explicit vec(const vec<T, M>& other) noexcept : vec(T(0)) {
 			for (std::size_t i = 0; i < M; ++i)
 				(*this)[i] = other[i];
 		}
-		template <std::size_t M, std::enable_if_t<M < N, bool> = true>
-		constexpr vec<T, N>& operator=(const vec<T, M>& other) noexcept {
+		template <std::size_t M>
+		requires (M < N)
+		constexpr vec& operator=(const vec<T, M>& other) noexcept {
 			for (std::size_t i = 0; i < N; ++i)
 				(*this)[i] = i < M ? other[i] : T(0);
 			return *this;
@@ -137,7 +144,7 @@ namespace fastgltf::math {
 			for (auto it = std::begin(list); it != std::end(list); ++it)
 				(*this)[std::distance(std::begin(list), it)] = *it;
 		}
-		constexpr vec<T, N>& operator=(std::initializer_list<T> list) noexcept {
+		constexpr vec& operator=(std::initializer_list<T> list) noexcept {
 			for (auto it = std::begin(list); it != std::end(list); ++it)
 				(*this)[std::distance(std::begin(list), it)] = *it;
 			return *this;
@@ -301,7 +308,8 @@ namespace fastgltf::math {
 			return ret;
 		}
 
-		template <std::size_t M, std::enable_if_t<M < N, bool> = true>
+		template <std::size_t M>
+		requires (M < N)
 		constexpr explicit operator vec<T, M>() const noexcept {
 			vec<T, M> ret;
 			for (std::size_t i = 0; i < M; ++i)
@@ -438,7 +446,8 @@ namespace fastgltf::math {
 		constexpr explicit quat() noexcept : _data {0.f, 0.f, 0.f, 1.f} {}
 
 		/** Creates a new quaternion from 4 floats in the order X, Y, Z, W */
-		template <typename... Args, std::enable_if_t<sizeof...(Args) == 4, bool> = true>
+		template <typename... Args>
+		requires (sizeof...(Args) == 4)
 		constexpr explicit quat(Args... args) noexcept : _data { std::forward<Args>(args)... } {}
 
 		static constexpr auto fromPointer(T* ptr) noexcept {
@@ -640,11 +649,13 @@ namespace fastgltf::math {
 		}
 
 		/** Creates a matrix from M vectors */
-		template <typename... Args, std::enable_if_t<sizeof...(Args) == M, bool> = true>
+		template <typename... Args>
+		requires (sizeof...(Args) == M)
 		constexpr explicit mat(Args... args) noexcept : _data { std::forward<Args>(args)... } {}
 
 		/** Creates a matrix from N * M floats */
-		template <typename... Args, std::enable_if_t<sizeof...(Args) == M * N, bool> = true>
+		template <typename... Args>
+		requires (sizeof...(Args) == M * N)
 		constexpr explicit mat(Args... args) noexcept {
 			const auto tuple = std::forward_as_tuple(args...);
 			copy_values(tuple, std::make_integer_sequence<std::size_t, sizeof...(Args)>());
@@ -653,14 +664,16 @@ namespace fastgltf::math {
 		constexpr mat(const mat& other) = default;
 
 		/** Truncates the matrix to a smaller one, discarding the additional rows and/or colums  */
-		template <std::size_t Q, std::size_t P, std::enable_if_t<N < Q && M < P, bool> = true>
+		template <std::size_t Q, std::size_t P>
+		requires (N < Q && M < P)
 		constexpr explicit mat(const mat<T, Q, P>& other) noexcept {
 			for (std::size_t i = 0; i < columns(); ++i)
 				(*this).col(i) = vec<T, N>(other.col(i));
 		}
 
 		/** Creates a larger matrix from a smaller one, while initializing the new components to identity  */
-		template <std::size_t Q, std::size_t P, std::enable_if_t<Q < N && P < M, bool> = true>
+		template <std::size_t Q, std::size_t P>
+		requires (Q < N && P < M)
 		constexpr explicit mat(const mat<T, Q, P>& other) noexcept : mat(T(1)) {
 			for (std::size_t i = 0; i < other.columns(); ++i)
 				(*this).col(i) = vec<T, N>(other.col(i));
@@ -753,7 +766,8 @@ namespace fastgltf::math {
 			return ret;
 		}
 
-		template <std::size_t P, std::size_t Q, std::enable_if_t<M == P, bool> = true>
+		template <std::size_t P, std::size_t Q>
+		requires (M == P)
 		constexpr auto operator*(const mat<T, P, Q>& other) const noexcept {
 			mat<T, N, Q> ret(0.f);
 			for (std::size_t i = 0; i < other.columns(); ++i)

--- a/include/fastgltf/tools.hpp
+++ b/include/fastgltf/tools.hpp
@@ -28,25 +28,25 @@
 #define FASTGLTF_TOOLS_HPP
 
 #if !defined(FASTGLTF_USE_STD_MODULE) || !FASTGLTF_USE_STD_MODULE
-#include <cstring>
-#include <iterator>
+#	include <cstring>
+#	include <iterator>
 #endif
 
 #include <fastgltf/types.hpp>
 
 #if FASTGLTF_CPP_23 && __has_include(<stdfloat>)
-#include <stdfloat>
+#	include <stdfloat>
 
-#if defined(__STDCPP_FLOAT32_T__) && __STDCPP_FLOAT32_T__
-#define FASTGLTF_HAS_FLOAT32 1
-#endif
+#	if defined(__STDCPP_FLOAT32_T__) && __STDCPP_FLOAT32_T__
+#		define FASTGLTF_HAS_FLOAT32 1
+#	endif
 
-#if defined(__STDCPP_FLOAT64_T__) && __STDCPP_FLOAT64_T__
-#define FASTGLTF_HAS_FLOAT64 1
-#endif
+#	if defined(__STDCPP_FLOAT64_T__) && __STDCPP_FLOAT64_T__
+#		define FASTGLTF_HAS_FLOAT64 1
+#	endif
 #else
-#define FASTGLTF_HAS_FLOAT32 0
-#define FASTGLTF_HAS_FLOAT64 0
+#	define FASTGLTF_HAS_FLOAT32 0
+#	define FASTGLTF_HAS_FLOAT64 0
 #endif
 
 namespace fastgltf {
@@ -54,42 +54,42 @@ namespace fastgltf {
 template <typename>
 struct ComponentTypeConverter;
 
-template<>
+template <>
 struct ComponentTypeConverter<std::int8_t> {
 	static constexpr auto type = ComponentType::Byte;
 };
 
-template<>
+template <>
 struct ComponentTypeConverter<std::uint8_t> {
 	static constexpr auto type = ComponentType::UnsignedByte;
 };
 
-template<>
+template <>
 struct ComponentTypeConverter<std::int16_t> {
 	static constexpr auto type = ComponentType::Short;
 };
 
-template<>
+template <>
 struct ComponentTypeConverter<std::uint16_t> {
 	static constexpr auto type = ComponentType::UnsignedShort;
 };
 
-template<>
+template <>
 struct ComponentTypeConverter<std::int32_t> {
 	static constexpr auto type = ComponentType::Int;
 };
 
-template<>
+template <>
 struct ComponentTypeConverter<std::uint32_t> {
 	static constexpr auto type = ComponentType::UnsignedInt;
 };
 
-template<>
+template <>
 struct ComponentTypeConverter<float> {
 	static constexpr auto type = ComponentType::Float;
 };
 
-template<>
+template <>
 struct ComponentTypeConverter<double> {
 	static constexpr auto type = ComponentType::Double;
 };
@@ -108,7 +108,8 @@ struct ComponentTypeConverter<std::float64_t> {
 };
 #endif
 
-FASTGLTF_EXPORT template <typename ElementType, AccessorType EnumAccessorType, typename ComponentType = ElementType, bool transpose = false>
+FASTGLTF_EXPORT template <typename ElementType, AccessorType EnumAccessorType,
+						  typename ComponentType = ElementType, bool transpose = false>
 struct ElementTraitsBase {
 	using element_type = ElementType;
 	using component_type = ComponentType;
@@ -120,66 +121,125 @@ struct ElementTraitsBase {
 FASTGLTF_EXPORT template <typename>
 struct ElementTraits;
 
-template<> struct ElementTraits<std::int8_t> : ElementTraitsBase<std::int8_t, AccessorType::Scalar> {};
-template<> struct ElementTraits<std::uint8_t> : ElementTraitsBase<std::uint8_t, AccessorType::Scalar> {};
-template<> struct ElementTraits<std::int16_t> : ElementTraitsBase<std::int16_t, AccessorType::Scalar> {};
-template<> struct ElementTraits<std::uint16_t> : ElementTraitsBase<std::uint16_t, AccessorType::Scalar> {};
-template<> struct ElementTraits<std::int32_t> : ElementTraitsBase<std::int32_t, AccessorType::Scalar> {};
-template<> struct ElementTraits<std::uint32_t> : ElementTraitsBase<std::uint32_t, AccessorType::Scalar> {};
+template <>
+struct ElementTraits<std::int8_t> : ElementTraitsBase<std::int8_t, AccessorType::Scalar> {};
+template <>
+struct ElementTraits<std::uint8_t> : ElementTraitsBase<std::uint8_t, AccessorType::Scalar> {};
+template <>
+struct ElementTraits<std::int16_t> : ElementTraitsBase<std::int16_t, AccessorType::Scalar> {};
+template <>
+struct ElementTraits<std::uint16_t> : ElementTraitsBase<std::uint16_t, AccessorType::Scalar> {};
+template <>
+struct ElementTraits<std::int32_t> : ElementTraitsBase<std::int32_t, AccessorType::Scalar> {};
+template <>
+struct ElementTraits<std::uint32_t> : ElementTraitsBase<std::uint32_t, AccessorType::Scalar> {};
 
-template<> struct ElementTraits<float> : ElementTraitsBase<float, AccessorType::Scalar> {};
-template<> struct ElementTraits<double> : ElementTraitsBase<double, AccessorType::Scalar> {};
+template <>
+struct ElementTraits<float> : ElementTraitsBase<float, AccessorType::Scalar> {};
+template <>
+struct ElementTraits<double> : ElementTraitsBase<double, AccessorType::Scalar> {};
 
 #if FASTGLTF_HAS_FLOAT32
-template<> struct ElementTraits<std::float32_t> : ElementTraitsBase<std::float32_t, AccessorType::Scalar> {};
+template <>
+struct ElementTraits<std::float32_t> : ElementTraitsBase<std::float32_t, AccessorType::Scalar> {};
 #endif
 
 #if FASTGLTF_HAS_FLOAT64
-template<> struct ElementTraits<std::float64_t> : ElementTraitsBase<std::float64_t, AccessorType::Scalar> {};
+template <>
+struct ElementTraits<std::float64_t> : ElementTraitsBase<std::float64_t, AccessorType::Scalar> {};
 #endif
 
-template<> struct ElementTraits<math::s8vec2> : ElementTraitsBase<math::s8vec2, AccessorType::Vec2, std::int8_t> {};
-template<> struct ElementTraits<math::s8vec3> : ElementTraitsBase<math::s8vec3, AccessorType::Vec3, std::int8_t> {};
-template<> struct ElementTraits<math::s8vec4> : ElementTraitsBase<math::s8vec4, AccessorType::Vec4, std::int8_t> {};
-template<> struct ElementTraits<math::u8vec2> : ElementTraitsBase<math::u8vec2, AccessorType::Vec2, std::uint8_t> {};
-template<> struct ElementTraits<math::u8vec3> : ElementTraitsBase<math::u8vec3, AccessorType::Vec3, std::uint8_t> {};
-template<> struct ElementTraits<math::u8vec4> : ElementTraitsBase<math::u8vec4, AccessorType::Vec4, std::uint8_t> {};
+template <>
+struct ElementTraits<math::s8vec2>
+	: ElementTraitsBase<math::s8vec2, AccessorType::Vec2, std::int8_t> {};
+template <>
+struct ElementTraits<math::s8vec3>
+	: ElementTraitsBase<math::s8vec3, AccessorType::Vec3, std::int8_t> {};
+template <>
+struct ElementTraits<math::s8vec4>
+	: ElementTraitsBase<math::s8vec4, AccessorType::Vec4, std::int8_t> {};
+template <>
+struct ElementTraits<math::u8vec2>
+	: ElementTraitsBase<math::u8vec2, AccessorType::Vec2, std::uint8_t> {};
+template <>
+struct ElementTraits<math::u8vec3>
+	: ElementTraitsBase<math::u8vec3, AccessorType::Vec3, std::uint8_t> {};
+template <>
+struct ElementTraits<math::u8vec4>
+	: ElementTraitsBase<math::u8vec4, AccessorType::Vec4, std::uint8_t> {};
 
-template<> struct ElementTraits<math::s16vec2> : ElementTraitsBase<math::s16vec2, AccessorType::Vec2, std::int16_t> {};
-template<> struct ElementTraits<math::s16vec3> : ElementTraitsBase<math::s16vec3, AccessorType::Vec3, std::int16_t> {};
-template<> struct ElementTraits<math::s16vec4> : ElementTraitsBase<math::s16vec4, AccessorType::Vec4, std::int16_t> {};
-template<> struct ElementTraits<math::u16vec2> : ElementTraitsBase<math::u16vec2, AccessorType::Vec2, std::uint16_t> {};
-template<> struct ElementTraits<math::u16vec3> : ElementTraitsBase<math::u16vec3, AccessorType::Vec3, std::uint16_t> {};
-template<> struct ElementTraits<math::u16vec4> : ElementTraitsBase<math::u16vec4, AccessorType::Vec4, std::uint16_t> {};
+template <>
+struct ElementTraits<math::s16vec2>
+	: ElementTraitsBase<math::s16vec2, AccessorType::Vec2, std::int16_t> {};
+template <>
+struct ElementTraits<math::s16vec3>
+	: ElementTraitsBase<math::s16vec3, AccessorType::Vec3, std::int16_t> {};
+template <>
+struct ElementTraits<math::s16vec4>
+	: ElementTraitsBase<math::s16vec4, AccessorType::Vec4, std::int16_t> {};
+template <>
+struct ElementTraits<math::u16vec2>
+	: ElementTraitsBase<math::u16vec2, AccessorType::Vec2, std::uint16_t> {};
+template <>
+struct ElementTraits<math::u16vec3>
+	: ElementTraitsBase<math::u16vec3, AccessorType::Vec3, std::uint16_t> {};
+template <>
+struct ElementTraits<math::u16vec4>
+	: ElementTraitsBase<math::u16vec4, AccessorType::Vec4, std::uint16_t> {};
 
-template<> struct ElementTraits<math::s32vec2> : ElementTraitsBase<math::s32vec2, AccessorType::Vec2, std::int16_t> {};
-template<> struct ElementTraits<math::s32vec3> : ElementTraitsBase<math::s32vec3, AccessorType::Vec3, std::int16_t> {};
-template<> struct ElementTraits<math::s32vec4> : ElementTraitsBase<math::s32vec4, AccessorType::Vec4, std::int16_t> {};
-template<> struct ElementTraits<math::u32vec2> : ElementTraitsBase<math::u32vec2, AccessorType::Vec2, std::uint32_t> {};
-template<> struct ElementTraits<math::u32vec3> : ElementTraitsBase<math::u32vec3, AccessorType::Vec3, std::uint32_t> {};
-template<> struct ElementTraits<math::u32vec4> : ElementTraitsBase<math::u32vec4, AccessorType::Vec4, std::uint32_t> {};
+template <>
+struct ElementTraits<math::s32vec2>
+	: ElementTraitsBase<math::s32vec2, AccessorType::Vec2, std::int16_t> {};
+template <>
+struct ElementTraits<math::s32vec3>
+	: ElementTraitsBase<math::s32vec3, AccessorType::Vec3, std::int16_t> {};
+template <>
+struct ElementTraits<math::s32vec4>
+	: ElementTraitsBase<math::s32vec4, AccessorType::Vec4, std::int16_t> {};
+template <>
+struct ElementTraits<math::u32vec2>
+	: ElementTraitsBase<math::u32vec2, AccessorType::Vec2, std::uint32_t> {};
+template <>
+struct ElementTraits<math::u32vec3>
+	: ElementTraitsBase<math::u32vec3, AccessorType::Vec3, std::uint32_t> {};
+template <>
+struct ElementTraits<math::u32vec4>
+	: ElementTraitsBase<math::u32vec4, AccessorType::Vec4, std::uint32_t> {};
 
-template<> struct ElementTraits<math::fvec2> : ElementTraitsBase<math::fvec2, AccessorType::Vec2, float> {};
-template<> struct ElementTraits<math::fvec3> : ElementTraitsBase<math::fvec3, AccessorType::Vec3, float> {};
-template<> struct ElementTraits<math::fvec4> : ElementTraitsBase<math::fvec4, AccessorType::Vec4, float> {};
-template<> struct ElementTraits<math::dvec2> : ElementTraitsBase<math::dvec2, AccessorType::Vec2, double> {};
-template<> struct ElementTraits<math::dvec3> : ElementTraitsBase<math::dvec3, AccessorType::Vec3, double> {};
-template<> struct ElementTraits<math::dvec4> : ElementTraitsBase<math::dvec4, AccessorType::Vec4, double> {};
+template <>
+struct ElementTraits<math::fvec2> : ElementTraitsBase<math::fvec2, AccessorType::Vec2, float> {};
+template <>
+struct ElementTraits<math::fvec3> : ElementTraitsBase<math::fvec3, AccessorType::Vec3, float> {};
+template <>
+struct ElementTraits<math::fvec4> : ElementTraitsBase<math::fvec4, AccessorType::Vec4, float> {};
+template <>
+struct ElementTraits<math::dvec2> : ElementTraitsBase<math::dvec2, AccessorType::Vec2, double> {};
+template <>
+struct ElementTraits<math::dvec3> : ElementTraitsBase<math::dvec3, AccessorType::Vec3, double> {};
+template <>
+struct ElementTraits<math::dvec4> : ElementTraitsBase<math::dvec4, AccessorType::Vec4, double> {};
 
-template<> struct ElementTraits<math::fquat> : ElementTraitsBase<math::fquat, AccessorType::Vec4, float> {};
-template<> struct ElementTraits<math::dquat> : ElementTraitsBase<math::dquat, AccessorType::Vec4, double> {};
+template <>
+struct ElementTraits<math::fquat> : ElementTraitsBase<math::fquat, AccessorType::Vec4, float> {};
+template <>
+struct ElementTraits<math::dquat> : ElementTraitsBase<math::dquat, AccessorType::Vec4, double> {};
 
-template<> struct ElementTraits<math::fmat2x2> : ElementTraitsBase<math::fmat2x2, AccessorType::Mat2, float> {};
-template<> struct ElementTraits<math::fmat3x3> : ElementTraitsBase<math::fmat3x3, AccessorType::Mat3, float> {};
-template<> struct ElementTraits<math::fmat4x4> : ElementTraitsBase<math::fmat4x4, AccessorType::Mat4, float> {};
+template <>
+struct ElementTraits<math::fmat2x2> : ElementTraitsBase<math::fmat2x2, AccessorType::Mat2, float> {
+};
+template <>
+struct ElementTraits<math::fmat3x3> : ElementTraitsBase<math::fmat3x3, AccessorType::Mat3, float> {
+};
+template <>
+struct ElementTraits<math::fmat4x4> : ElementTraitsBase<math::fmat4x4, AccessorType::Mat4, float> {
+};
 
 template <typename ElementType>
-concept Element = std::is_arithmetic_v<typename ElementTraits<ElementType>::component_type>
-		&& ElementTraits<ElementType>::type != AccessorType::Invalid
-		&& ElementTraits<ElementType>::enum_component_type != ComponentType::Invalid
-		&& std::is_default_constructible_v<ElementType>
-		&& std::is_constructible_v<ElementType>
-		&& std::is_move_assignable_v<ElementType>;
+concept Element = std::is_arithmetic_v<typename ElementTraits<ElementType>::component_type> &&
+				  ElementTraits<ElementType>::type != AccessorType::Invalid &&
+				  ElementTraits<ElementType>::enum_component_type != ComponentType::Invalid &&
+				  std::is_default_constructible_v<ElementType> &&
+				  std::is_constructible_v<ElementType> && std::is_move_assignable_v<ElementType>;
 
 namespace internal {
 
@@ -187,61 +247,63 @@ namespace internal {
  * This function deserializes some N bytes in little endian order (as required by the glTF spec)
  * into the given arithmetic type T in a standard-conforming fashion.
  *
- * This uses bit-shifts and ORs to correctly convert the bytes to avoid violating the strict aliasing
- * rule as if we would just use T*.
+ * This uses bit-shifts and ORs to correctly convert the bytes to avoid violating the strict
+ * aliasing rule as if we would just use T*.
  */
 template <typename T>
 constexpr T deserializeComponent(const std::byte* bytes, std::size_t index) {
-    static_assert(std::is_integral_v<T> && !std::is_same_v<T, bool>, "Component deserialization is only supported on basic arithmetic types.");
-    T ret = 0;
-    // Turns out that on some systems a byte is not 8-bit so this sizeof is not technically correct.
-    for (std::size_t i = 0; i < sizeof(T); ++i) {
-        ret |= (static_cast<T>(bytes[i + index * sizeof(T)]) << i * 8);
-    }
-    return ret;
+	static_assert(std::is_integral_v<T> && !std::is_same_v<T, bool>,
+				  "Component deserialization is only supported on basic arithmetic types.");
+	T ret = 0;
+	// Turns out that on some systems a byte is not 8-bit so this sizeof is not technically correct.
+	for (std::size_t i = 0; i < sizeof(T); ++i) {
+		ret |= (static_cast<T>(bytes[i + index * sizeof(T)]) << i * 8);
+	}
+	return ret;
 }
 
 #if FASTGLTF_HAS_FLOAT32
-template<>
-constexpr std::float32_t deserializeComponent<std::float32_t>(const std::byte* bytes, std::size_t index) {
+template <>
+constexpr std::float32_t deserializeComponent<std::float32_t>(const std::byte* bytes,
+															  std::size_t index) {
 	return std::bit_cast<std::float32_t>(deserializeComponent<std::uint32_t>(bytes, index));
 }
 
-template<>
+template <>
 constexpr float deserializeComponent<float>(const std::byte* bytes, std::size_t index) {
 	return static_cast<float>(deserializeComponent<std::float32_t>(bytes, index));
 }
 #else
-template<>
+template <>
 constexpr float deserializeComponent<float>(const std::byte* bytes, std::size_t index) {
-    static_assert(std::numeric_limits<float>::is_iec559 &&
-                  std::numeric_limits<float>::radix == 2 &&
-                  std::numeric_limits<float>::digits == 24 &&
-                  std::numeric_limits<float>::max_exponent == 128,
-                  "Float deserialization is only supported on IEE754 platforms");
-    return std::bit_cast<float>(deserializeComponent<std::uint32_t>(bytes, index));
+	static_assert(std::numeric_limits<float>::is_iec559 && std::numeric_limits<float>::radix == 2 &&
+					  std::numeric_limits<float>::digits == 24 &&
+					  std::numeric_limits<float>::max_exponent == 128,
+				  "Float deserialization is only supported on IEE754 platforms");
+	return std::bit_cast<float>(deserializeComponent<std::uint32_t>(bytes, index));
 }
 #endif
 
 #if FASTGLTF_HAS_FLOAT64
-template<>
-constexpr std::float64_t deserializeComponent<std::float64_t>(const std::byte* bytes, std::size_t index) {
+template <>
+constexpr std::float64_t deserializeComponent<std::float64_t>(const std::byte* bytes,
+															  std::size_t index) {
 	return std::bit_cast<std::float64_t>(deserializeComponent<std::uint64_t>(bytes, index));
 }
 
-template<>
+template <>
 constexpr double deserializeComponent<double>(const std::byte* bytes, std::size_t index) {
 	return static_cast<double>(deserializeComponent<std::float64_t>(bytes, index));
 }
 #else
-template<>
+template <>
 constexpr double deserializeComponent<double>(const std::byte* bytes, std::size_t index) {
-    static_assert(std::numeric_limits<double>::is_iec559 &&
-                  std::numeric_limits<double>::radix == 2 &&
-                  std::numeric_limits<double>::digits == 53 &&
-                  std::numeric_limits<double>::max_exponent == 1024,
-                  "Float deserialization is only supported on IEE754 platforms");
-    return std::bit_cast<double>(deserializeComponent<std::uint64_t>(bytes, index));
+	static_assert(std::numeric_limits<double>::is_iec559 &&
+					  std::numeric_limits<double>::radix == 2 &&
+					  std::numeric_limits<double>::digits == 53 &&
+					  std::numeric_limits<double>::max_exponent == 1024,
+				  "Float deserialization is only supported on IEE754 platforms");
+	return std::bit_cast<double>(deserializeComponent<std::uint64_t>(bytes, index));
 }
 #endif
 
@@ -250,7 +312,8 @@ constexpr DestType convertComponent(const SourceType& source, bool normalized) {
 	if (normalized) {
 		if constexpr (std::is_floating_point_v<SourceType> && std::is_integral_v<DestType>) {
 			// float -> int conversion
-			return static_cast<DestType>(std::round(source * static_cast<SourceType>(std::numeric_limits<DestType>::max())));
+			return static_cast<DestType>(
+				std::round(source * static_cast<SourceType>(std::numeric_limits<DestType>::max())));
 		} else if constexpr (std::is_integral_v<SourceType> && std::is_floating_point_v<DestType>) {
 			// int -> float conversion
 			DestType minValue;
@@ -260,10 +323,11 @@ constexpr DestType convertComponent(const SourceType& source, bool normalized) {
 				minValue = static_cast<DestType>(0.0);
 			}
 
-			// We have to use max here because for uchar -> float we could have -128 but 1.0 should represent 127,
-			// which is why -128 and -127 both equate to 1.0.
-			return fastgltf::max(static_cast<DestType>(source) / static_cast<DestType>(std::numeric_limits<SourceType>::max()),
-			                     minValue);
+			// We have to use max here because for uchar -> float we could have -128 but 1.0 should
+			// represent 127, which is why -128 and -127 both equate to 1.0.
+			return fastgltf::max(static_cast<DestType>(source) /
+									 static_cast<DestType>(std::numeric_limits<SourceType>::max()),
+								 minValue);
 		}
 	}
 
@@ -271,17 +335,21 @@ constexpr DestType convertComponent(const SourceType& source, bool normalized) {
 }
 
 template <typename DestType, typename SourceType>
-constexpr DestType convertComponent(const std::byte* bytes, std::size_t index, AccessorType accessorType, bool normalized) {
+constexpr DestType convertComponent(const std::byte* bytes, std::size_t index,
+									AccessorType accessorType, bool normalized) {
 	if (isMatrix(accessorType)) {
 		const auto rowCount = getElementRowCount(accessorType);
 		const auto componentSize = sizeof(SourceType);
 		if ((rowCount * componentSize) % 4 != 0) {
-			// There's only four cases where this happens, but the glTF spec requires us to insert some padding for each column.
+			// There's only four cases where this happens, but the glTF spec requires us to insert
+			// some padding for each column.
 			auto paddedIndex = index + (index / rowCount) * (4 - (rowCount % 4));
-			return convertComponent<DestType>(deserializeComponent<SourceType>(bytes, paddedIndex), normalized);
+			return convertComponent<DestType>(deserializeComponent<SourceType>(bytes, paddedIndex),
+											  normalized);
 		}
 
-		return convertComponent<DestType>(deserializeComponent<SourceType>(bytes, index), normalized);
+		return convertComponent<DestType>(deserializeComponent<SourceType>(bytes, index),
+										  normalized);
 	}
 
 	return convertComponent<DestType>(deserializeComponent<SourceType>(bytes, index), normalized);
@@ -297,7 +365,9 @@ constexpr std::size_t getComponentIndex(std::size_t i, AccessorType type, bool t
 }
 
 template <typename DestType>
-constexpr DestType getAccessorComponentAt(ComponentType componentType, AccessorType type, const std::byte* bytes, std::size_t componentIdx, bool normalized = false, bool transposed = false) {
+constexpr DestType getAccessorComponentAt(ComponentType componentType, AccessorType type,
+										  const std::byte* bytes, std::size_t componentIdx,
+										  bool normalized = false, bool transposed = false) {
 	auto idx = getComponentIndex(componentIdx, type, transposed);
 	switch (componentType) {
 		case ComponentType::Byte:
@@ -307,40 +377,46 @@ constexpr DestType getAccessorComponentAt(ComponentType componentType, AccessorT
 		case ComponentType::Short:
 			return internal::convertComponent<DestType, std::int16_t>(bytes, idx, type, normalized);
 		case ComponentType::UnsignedShort:
-			return internal::convertComponent<DestType, std::uint16_t>(bytes, idx, type, normalized);
+			return internal::convertComponent<DestType, std::uint16_t>(bytes, idx, type,
+																	   normalized);
 		case ComponentType::Int:
 			return internal::convertComponent<DestType, std::int32_t>(bytes, idx, type, normalized);
 		case ComponentType::UnsignedInt:
-			return internal::convertComponent<DestType, std::uint32_t>(bytes, idx, type, normalized);
+			return internal::convertComponent<DestType, std::uint32_t>(bytes, idx, type,
+																	   normalized);
 		case ComponentType::Float:
 			return internal::convertComponent<DestType, float>(bytes, idx, type, normalized);
 		case ComponentType::Double:
 			return internal::convertComponent<DestType, double>(bytes, idx, type, normalized);
 		case ComponentType::Invalid:
-		default:
-			return DestType {};
+		default:                     return DestType{};
 	}
 }
 
 template <typename ElementType, typename SourceType, std::size_t... I>
 requires Element<ElementType>
-constexpr ElementType convertAccessorElement(const std::byte* bytes, bool normalized, std::index_sequence<I...>) {
+constexpr ElementType convertAccessorElement(const std::byte* bytes, bool normalized,
+											 std::index_sequence<I...>) {
 	using Traits = ElementTraits<ElementType>;
-	static_assert(std::is_arithmetic_v<typename Traits::component_type>, "Accessor traits must provide a valid component type");
+	static_assert(std::is_arithmetic_v<typename Traits::component_type>,
+				  "Accessor traits must provide a valid component type");
 
 	if constexpr (std::is_aggregate_v<ElementType>) {
 		return {convertComponent<typename Traits::component_type, SourceType>(
-				bytes, getComponentIndex(I, Traits::type, Traits::needs_transpose), Traits::type, normalized)...};
+			bytes, getComponentIndex(I, Traits::type, Traits::needs_transpose), Traits::type,
+			normalized)...};
 	} else {
 		return ElementType(convertComponent<typename Traits::component_type, SourceType>(
-				bytes, getComponentIndex(I, Traits::type, Traits::needs_transpose), Traits::type, normalized)...);
+			bytes, getComponentIndex(I, Traits::type, Traits::needs_transpose), Traits::type,
+			normalized)...);
 	}
 }
 
-template <typename ElementType,
-		typename Seq = std::make_index_sequence<getNumComponents(ElementTraits<ElementType>::type)>>
+template <typename ElementType, typename Seq = std::make_index_sequence<
+									getNumComponents(ElementTraits<ElementType>::type)>>
 requires Element<ElementType>
-ElementType getAccessorElementAt(ComponentType componentType, const std::byte* bytes, bool normalized = false) {
+ElementType getAccessorElementAt(ComponentType componentType, const std::byte* bytes,
+								 bool normalized = false) {
 	switch (componentType) {
 		case ComponentType::Byte:
 			return convertAccessorElement<ElementType, std::int8_t>(bytes, normalized, Seq{});
@@ -359,15 +435,15 @@ ElementType getAccessorElementAt(ComponentType componentType, const std::byte* b
 		case ComponentType::Double:
 			return convertAccessorElement<ElementType, double>(bytes, normalized, Seq{});
 		case ComponentType::Invalid:
-		default:
-			return ElementType{};
+		default:                     return ElementType{};
 	}
 }
 
-// Performs a binary search for the index into the sparse index list whose value matches the desired index
+// Performs a binary search for the index into the sparse index list whose value matches the desired
+// index
 template <typename ElementType>
 bool findSparseIndex(const std::byte* indices, std::size_t indexCount, std::size_t desiredIndex,
-		std::size_t& resultIndex) {
+					 std::size_t& resultIndex) {
 	auto count = indexCount;
 
 	resultIndex = 0;
@@ -376,7 +452,8 @@ bool findSparseIndex(const std::byte* indices, std::size_t indexCount, std::size
 		auto step = count / 2;
 		auto index = resultIndex + step;
 
-		if (deserializeComponent<ElementType>(indices, index) < static_cast<ElementType>(desiredIndex)) {
+		if (deserializeComponent<ElementType>(indices, index) <
+			static_cast<ElementType>(desiredIndex)) {
 			resultIndex = index + 1;
 			count -= step + 1;
 		} else {
@@ -384,12 +461,14 @@ bool findSparseIndex(const std::byte* indices, std::size_t indexCount, std::size
 		}
 	}
 
-	return resultIndex < indexCount && deserializeComponent<ElementType>(indices, resultIndex) == static_cast<ElementType>(desiredIndex);
+	return resultIndex < indexCount && deserializeComponent<ElementType>(indices, resultIndex) ==
+										   static_cast<ElementType>(desiredIndex);
 }
 
 // Finds the index of the nearest sparse index to the desired index
-inline bool findSparseIndex(ComponentType componentType, const std::byte* bytes, std::size_t indexCount,
-		std::size_t desiredIndex, std::size_t& resultIndex) {
+inline bool findSparseIndex(ComponentType componentType, const std::byte* bytes,
+							std::size_t indexCount, std::size_t desiredIndex,
+							std::size_t& resultIndex) {
 	switch (componentType) {
 		case ComponentType::Byte:
 			return findSparseIndex<std::int8_t>(bytes, indexCount, desiredIndex, resultIndex);
@@ -405,38 +484,39 @@ inline bool findSparseIndex(ComponentType componentType, const std::byte* bytes,
 			return findSparseIndex<std::uint32_t>(bytes, indexCount, desiredIndex, resultIndex);
 		case ComponentType::Float:
 		case ComponentType::Double:
-		case ComponentType::Invalid:
-			return false;
+		case ComponentType::Invalid: return false;
 	}
 
 	return false;
 }
 
-} // namespace internal
+}  // namespace internal
 
 FASTGLTF_EXPORT struct DefaultBufferDataAdapter {
 	auto operator()(const Asset& asset, const std::size_t bufferViewIdx) const {
 		const auto& bufferView = asset.bufferViews[bufferViewIdx];
 
-		const auto data = std::visit(visitor {
-			[](auto&) -> std::span<const std::byte> {
-				assert(false && "Tried accessing a buffer with no data, likely because no buffers were loaded. Perhaps you forgot to specify the LoadExternalBuffers option?");
-				return {};
+		const auto data = std::visit(
+			visitor{
+				[](auto&) -> std::span<const std::byte> {
+			assert(false &&
+				   "Tried accessing a buffer with no data, likely because no buffers were loaded. "
+				   "Perhaps you forgot to specify the LoadExternalBuffers option?");
+			return {};
+		},
+				[](const sources::Fallback&) -> std::span<const std::byte> {
+			assert(false && "Tried accessing data of a fallback buffer.");
+			return {};
+		},
+				[&](const sources::Array& array) -> std::span<const std::byte> {
+			return {array.bytes.data(), array.bytes.size_bytes()};
+		},
+				[&](const sources::Vector& vec) -> std::span<const std::byte> {
+			return {vec.bytes.data(), vec.bytes.size()};
+		},
+				[&](const sources::ByteView& bv) -> std::span<const std::byte> { return bv.bytes; },
 			},
-			[](const sources::Fallback&) -> std::span<const std::byte> {
-				assert(false && "Tried accessing data of a fallback buffer.");
-				return {};
-			},
-			[&](const sources::Array& array) -> std::span<const std::byte> {
-				return {array.bytes.data(), array.bytes.size_bytes()};
-			},
-			[&](const sources::Vector& vec) -> std::span<const std::byte> {
-				return {vec.bytes.data(), vec.bytes.size()};
-			},
-			[&](const sources::ByteView& bv) -> std::span<const std::byte> {
-				return bv.bytes;
-			},
-		}, asset.buffers[bufferView.bufferIndex].data);
+			asset.buffers[bufferView.bufferIndex].data);
 
 		return data.subspan(bufferView.byteOffset, bufferView.byteLength);
 	}
@@ -447,30 +527,32 @@ class IterableAccessor;
 
 template <typename ElementType, typename BufferDataAdapter = DefaultBufferDataAdapter>
 class AccessorIterator {
-protected:
+   protected:
 	const IterableAccessor<ElementType, BufferDataAdapter>* accessor = nullptr;
 	std::size_t idx = std::numeric_limits<std::size_t>::max();
 	mutable std::size_t sparseIdx = 0;
 	mutable std::size_t nextSparseIndex = 0;
 
-public:
+   public:
 	using value_type = ElementType;
 	using reference = ElementType&;
 	using pointer = ElementType*;
 	using difference_type = std::ptrdiff_t;
 
-	// This iterator isn't truly random access (as per the C++ definition), but we do want to support
-	// some things that these come with (e.g. std::distance using operator-).
+	// This iterator isn't truly random access (as per the C++ definition), but we do want to
+	// support some things that these come with (e.g. std::distance using operator-).
 	using iterator_category = std::input_iterator_tag;
 
 	AccessorIterator() = default;
 
-	AccessorIterator(const IterableAccessor<ElementType, BufferDataAdapter>* accessor, std::size_t idx = 0)
-			: accessor(accessor), idx(idx) {
+	AccessorIterator(const IterableAccessor<ElementType, BufferDataAdapter>* accessor,
+					 std::size_t idx = 0)
+		: accessor(accessor), idx(idx) {
 		if (accessor->accessor.sparse.has_value()) {
 			// Get the first sparse index.
-			nextSparseIndex = internal::getAccessorElementAt<std::uint32_t>(accessor->indexComponentType,
-			                                                                &accessor->indicesBytes[accessor->indexStride * sparseIdx]);
+			nextSparseIndex = internal::getAccessorElementAt<std::uint32_t>(
+				accessor->indexComponentType,
+				&accessor->indicesBytes[accessor->indexStride * sparseIdx]);
 		}
 	}
 
@@ -491,11 +573,10 @@ public:
 
 	[[nodiscard]] bool operator==(const AccessorIterator& iterator) const noexcept {
 		// We don't compare sparse properties
-		return accessor == iterator.accessor &&
-			idx == iterator.idx &&
-			accessor->bufferBytes.data() == iterator.accessor->bufferBytes.data() &&
-			accessor->stride == iterator.accessor->stride &&
-			accessor->componentType == iterator.accessor->componentType;
+		return accessor == iterator.accessor && idx == iterator.idx &&
+			   accessor->bufferBytes.data() == iterator.accessor->bufferBytes.data() &&
+			   accessor->stride == iterator.accessor->stride &&
+			   accessor->componentType == iterator.accessor->componentType;
 	}
 
 	[[nodiscard]] bool operator!=(const AccessorIterator& iterator) const noexcept {
@@ -506,27 +587,30 @@ public:
 		if (accessor->accessor.sparse.has_value()) {
 			if (idx == nextSparseIndex) {
 				// Get the sparse value for this index
-				auto value = internal::getAccessorElementAt<ElementType>(accessor->componentType,
-																		 &accessor->valuesBytes[accessor->valueStride * sparseIdx],
-																		 accessor->accessor.normalized);
+				auto value = internal::getAccessorElementAt<ElementType>(
+					accessor->componentType,
+					&accessor->valuesBytes[accessor->valueStride * sparseIdx],
+					accessor->accessor.normalized);
 
 				// Find the next sparse index.
 				++sparseIdx;
 				if (sparseIdx < accessor->sparseCount) {
-					nextSparseIndex = internal::getAccessorElementAt<std::uint32_t>(accessor->indexComponentType,
-					                                                                &accessor->indicesBytes[accessor->indexStride * sparseIdx]);
+					nextSparseIndex = internal::getAccessorElementAt<std::uint32_t>(
+						accessor->indexComponentType,
+						&accessor->indicesBytes[accessor->indexStride * sparseIdx]);
 				}
 				return value;
 			}
 		}
 
-		return internal::getAccessorElementAt<ElementType>(accessor->componentType,
-														   &accessor->bufferBytes[idx * accessor->stride],
-														   accessor->accessor.normalized);
+		return internal::getAccessorElementAt<ElementType>(
+			accessor->componentType, &accessor->bufferBytes[idx * accessor->stride],
+			accessor->accessor.normalized);
 	}
 };
 
-static_assert(std::input_iterator<AccessorIterator<math::fvec4>>, "AccessorIterator needs to satisfy input_iterator");
+static_assert(std::input_iterator<AccessorIterator<math::fvec4>>,
+			  "AccessorIterator needs to satisfy input_iterator");
 
 template <typename ElementType, typename BufferDataAdapter = DefaultBufferDataAdapter>
 class IterableAccessor {
@@ -547,24 +631,31 @@ class IterableAccessor {
 	std::size_t valueStride;
 	std::size_t sparseCount;
 
-public:
+   public:
 	using iterator = AccessorIterator<ElementType, BufferDataAdapter>;
 
-	explicit IterableAccessor(const Asset& asset, const Accessor& accessor, const BufferDataAdapter& adapter) : asset(asset), accessor(accessor) {
-		assert(accessor.type == ElementTraits<ElementType>::type && "The destination type needs to have the same AccessorType as the accessor.");
+	explicit IterableAccessor(const Asset& asset, const Accessor& accessor,
+							  const BufferDataAdapter& adapter)
+		: asset(asset), accessor(accessor) {
+		assert(accessor.type == ElementTraits<ElementType>::type &&
+			   "The destination type needs to have the same AccessorType as the accessor.");
 		componentType = accessor.componentType;
 
 		const auto& view = asset.bufferViews[*accessor.bufferViewIndex];
-		stride = view.byteStride ? *view.byteStride : getElementByteSize(accessor.type, accessor.componentType);
+		stride = view.byteStride ? *view.byteStride
+								 : getElementByteSize(accessor.type, accessor.componentType);
 
 		bufferBytes = adapter(asset, *accessor.bufferViewIndex).subspan(accessor.byteOffset);
 
 		if (accessor.sparse.has_value()) {
-			indicesBytes = adapter(asset, accessor.sparse->indicesBufferView).subspan(accessor.sparse->indicesByteOffset);
+			indicesBytes = adapter(asset, accessor.sparse->indicesBufferView)
+							   .subspan(accessor.sparse->indicesByteOffset);
 
-			indexStride = getElementByteSize(AccessorType::Scalar, accessor.sparse->indexComponentType);
+			indexStride =
+				getElementByteSize(AccessorType::Scalar, accessor.sparse->indexComponentType);
 
-			valuesBytes = adapter(asset, accessor.sparse->valuesBufferView).subspan(accessor.sparse->valuesByteOffset);
+			valuesBytes = adapter(asset, accessor.sparse->valuesBufferView)
+							  .subspan(accessor.sparse->valuesByteOffset);
 
 			// "The index of the bufferView with sparse values. The referenced buffer view MUST NOT
 			// have its target or byteStride properties defined."
@@ -575,49 +666,52 @@ public:
 		}
 	}
 
-	[[nodiscard]] iterator begin() const noexcept {
-		return iterator(this, 0);
-	}
+	[[nodiscard]] iterator begin() const noexcept { return iterator(this, 0); }
 
-	[[nodiscard]] iterator end() const noexcept {
-		return iterator(this, accessor.count);
-	}
+	[[nodiscard]] iterator end() const noexcept { return iterator(this, accessor.count); }
 };
 
-static_assert(std::ranges::input_range<IterableAccessor<math::fvec4>>, "IterableAccessor needs to satisfy input_range");
+static_assert(std::ranges::input_range<IterableAccessor<math::fvec4>>,
+			  "IterableAccessor needs to satisfy input_range");
 
-FASTGLTF_EXPORT template <typename ElementType, typename BufferDataAdapter = DefaultBufferDataAdapter>
+FASTGLTF_EXPORT template <typename ElementType,
+						  typename BufferDataAdapter = DefaultBufferDataAdapter>
 requires Element<ElementType>
 ElementType getAccessorElement(const Asset& asset, const Accessor& accessor, size_t index,
-		const BufferDataAdapter& adapter = {}) {
+							   const BufferDataAdapter& adapter = {}) {
 	using Traits = ElementTraits<ElementType>;
-	static_assert(Traits::type != AccessorType::Invalid, "Accessor traits must provide a valid Accessor Type");
-	static_assert(std::is_default_constructible_v<ElementType>, "Element type must be default constructible");
+	static_assert(Traits::type != AccessorType::Invalid,
+				  "Accessor traits must provide a valid Accessor Type");
+	static_assert(std::is_default_constructible_v<ElementType>,
+				  "Element type must be default constructible");
 	static_assert(std::is_constructible_v<ElementType>, "Element type must be constructible");
 	static_assert(std::is_move_assignable_v<ElementType>, "Element type must be move-assignable");
 
-	assert(accessor.type == Traits::type && "The destination type needs to have the same AccessorType as the accessor.");
+	assert(accessor.type == Traits::type &&
+		   "The destination type needs to have the same AccessorType as the accessor.");
 
 	if (accessor.sparse) {
-		auto indicesBytes = adapter(asset, accessor.sparse->indicesBufferView).subspan(accessor.sparse->indicesByteOffset);
+		auto indicesBytes = adapter(asset, accessor.sparse->indicesBufferView)
+								.subspan(accessor.sparse->indicesByteOffset);
 
-		auto valuesBytes = adapter(asset, accessor.sparse->valuesBufferView).subspan(accessor.sparse->valuesByteOffset);
+		auto valuesBytes = adapter(asset, accessor.sparse->valuesBufferView)
+							   .subspan(accessor.sparse->valuesByteOffset);
 		// "The index of the bufferView with sparse values. The referenced buffer view MUST NOT
 		// have its target or byteStride properties defined."
 		auto valueStride = getElementByteSize(accessor.type, accessor.componentType);
 
 		std::size_t sparseIndex{};
-		if (internal::findSparseIndex(accessor.sparse->indexComponentType, indicesBytes.data(), accessor.sparse->count,
-				index, sparseIndex)) {
-			return internal::getAccessorElementAt<ElementType>(accessor.componentType,
-					&valuesBytes[valueStride * sparseIndex],
-					accessor.normalized);
+		if (internal::findSparseIndex(accessor.sparse->indexComponentType, indicesBytes.data(),
+									  accessor.sparse->count, index, sparseIndex)) {
+			return internal::getAccessorElementAt<ElementType>(
+				accessor.componentType, &valuesBytes[valueStride * sparseIndex],
+				accessor.normalized);
 		}
 	}
 
 	// 5.1.1. accessor.bufferView
-	// The index of the buffer view. When undefined, the accessor MUST be initialized with zeros; sparse
-	// property or extensions MAY override zeros with actual values.
+	// The index of the buffer view. When undefined, the accessor MUST be initialized with zeros;
+	// sparse property or extensions MAY override zeros with actual values.
 	if (!accessor.bufferViewIndex) {
 		if constexpr (std::is_aggregate_v<ElementType>) {
 			return ElementType{};
@@ -627,38 +721,49 @@ ElementType getAccessorElement(const Asset& asset, const Accessor& accessor, siz
 	}
 
 	const auto& view = asset.bufferViews[*accessor.bufferViewIndex];
-    auto stride = view.byteStride.value_or(getElementByteSize(accessor.type, accessor.componentType));
+	auto stride =
+		view.byteStride.value_or(getElementByteSize(accessor.type, accessor.componentType));
 
 	auto bytes = adapter(asset, *accessor.bufferViewIndex).subspan(accessor.byteOffset);
 
-	return internal::getAccessorElementAt<ElementType>(
-            accessor.componentType, &bytes[index * stride], accessor.normalized);
+	return internal::getAccessorElementAt<ElementType>(accessor.componentType,
+													   &bytes[index * stride], accessor.normalized);
 }
 
-FASTGLTF_EXPORT template<typename ElementType, typename BufferDataAdapter = DefaultBufferDataAdapter>
+FASTGLTF_EXPORT template <typename ElementType,
+						  typename BufferDataAdapter = DefaultBufferDataAdapter>
 requires Element<ElementType>
-IterableAccessor<ElementType, BufferDataAdapter> iterateAccessor(const Asset& asset, const Accessor& accessor, const BufferDataAdapter& adapter = {}) {
+IterableAccessor<ElementType, BufferDataAdapter> iterateAccessor(
+	const Asset& asset, const Accessor& accessor, const BufferDataAdapter& adapter = {}) {
 	return IterableAccessor<ElementType, BufferDataAdapter>(asset, accessor, adapter);
 }
 
-FASTGLTF_EXPORT template <typename ElementType, typename Functor, typename BufferDataAdapter = DefaultBufferDataAdapter>
+FASTGLTF_EXPORT template <typename ElementType, typename Functor,
+						  typename BufferDataAdapter = DefaultBufferDataAdapter>
 requires Element<ElementType> && std::is_invocable_v<Functor, ElementType>
 void iterateAccessor(const Asset& asset, const Accessor& accessor, Functor&& func,
-		const BufferDataAdapter& adapter = {}) {
+					 const BufferDataAdapter& adapter = {}) {
 	using Traits = ElementTraits<ElementType>;
-	static_assert(Traits::type != AccessorType::Invalid, "Accessor traits must provide a valid accessor type");
-	static_assert(Traits::enum_component_type != ComponentType::Invalid, "Accessor traits must provide a valid component type");
-	static_assert(std::is_default_constructible_v<ElementType>, "Element type must be default constructible");
+	static_assert(Traits::type != AccessorType::Invalid,
+				  "Accessor traits must provide a valid accessor type");
+	static_assert(Traits::enum_component_type != ComponentType::Invalid,
+				  "Accessor traits must provide a valid component type");
+	static_assert(std::is_default_constructible_v<ElementType>,
+				  "Element type must be default constructible");
 	static_assert(std::is_constructible_v<ElementType>, "Element type must be constructible");
 	static_assert(std::is_move_assignable_v<ElementType>, "Element type must be move-assignable");
 
-	assert(accessor.type == Traits::type && "The destination type needs to have the same AccessorType as the accessor.");
+	assert(accessor.type == Traits::type &&
+		   "The destination type needs to have the same AccessorType as the accessor.");
 
 	if (accessor.sparse && accessor.sparse->count > 0) {
-		auto indicesBytes = adapter(asset, accessor.sparse->indicesBufferView).subspan(accessor.sparse->indicesByteOffset);
-		auto indexStride = getElementByteSize(AccessorType::Scalar, accessor.sparse->indexComponentType);
+		auto indicesBytes = adapter(asset, accessor.sparse->indicesBufferView)
+								.subspan(accessor.sparse->indicesByteOffset);
+		auto indexStride =
+			getElementByteSize(AccessorType::Scalar, accessor.sparse->indexComponentType);
 
-		auto valuesBytes = adapter(asset, accessor.sparse->valuesBufferView).subspan(accessor.sparse->valuesByteOffset);
+		auto valuesBytes = adapter(asset, accessor.sparse->valuesBufferView)
+							   .subspan(accessor.sparse->valuesByteOffset);
 		// "The index of the bufferView with sparse values. The referenced buffer view MUST NOT
 		// have its target or byteStride properties defined."
 		auto valueStride = getElementByteSize(accessor.type, accessor.componentType);
@@ -667,23 +772,24 @@ void iterateAccessor(const Asset& asset, const Accessor& accessor, Functor&& fun
 		std::size_t srcStride = 0;
 
 		// 5.1.1. accessor.bufferView
-		// The index of the buffer view. When undefined, the accessor MUST be initialized with zeros; sparse
-		// property or extensions MAY override zeros with actual values.
+		// The index of the buffer view. When undefined, the accessor MUST be initialized with
+		// zeros; sparse property or extensions MAY override zeros with actual values.
 		if (accessor.bufferViewIndex) {
 			auto& view = asset.bufferViews[*accessor.bufferViewIndex];
 			srcBytes = adapter(asset, *accessor.bufferViewIndex).subspan(accessor.byteOffset);
-            srcStride = view.byteStride.value_or(getElementByteSize(accessor.type, accessor.componentType));
-        }
+			srcStride =
+				view.byteStride.value_or(getElementByteSize(accessor.type, accessor.componentType));
+		}
 
 		auto nextSparseIndex = internal::getAccessorElementAt<std::uint32_t>(
-				accessor.sparse->indexComponentType, indicesBytes.data());
+			accessor.sparse->indexComponentType, indicesBytes.data());
 		std::size_t sparseIndexCount = 0;
 
 		for (std::size_t i = 0; i < accessor.count; ++i) {
 			if (i == nextSparseIndex) {
-				auto element = internal::getAccessorElementAt<ElementType>(accessor.componentType,
-						&valuesBytes[valueStride * sparseIndexCount],
-						accessor.normalized);
+				auto element = internal::getAccessorElementAt<ElementType>(
+					accessor.componentType, &valuesBytes[valueStride * sparseIndexCount],
+					accessor.normalized);
 
 				std::invoke(func, element);
 
@@ -691,16 +797,16 @@ void iterateAccessor(const Asset& asset, const Accessor& accessor, Functor&& fun
 
 				if (sparseIndexCount < accessor.sparse->count) {
 					nextSparseIndex = internal::getAccessorElementAt<std::uint32_t>(
-							accessor.sparse->indexComponentType, &indicesBytes[indexStride * sparseIndexCount]);
+						accessor.sparse->indexComponentType,
+						&indicesBytes[indexStride * sparseIndexCount]);
 				}
 			} else if (accessor.bufferViewIndex) {
-				auto element = internal::getAccessorElementAt<ElementType>(accessor.componentType,
-						&srcBytes[srcStride * i],
-						accessor.normalized);
+				auto element = internal::getAccessorElementAt<ElementType>(
+					accessor.componentType, &srcBytes[srcStride * i], accessor.normalized);
 
 				std::invoke(func, element);
 			} else {
-				std::invoke(func, ElementType {});
+				std::invoke(func, ElementType{});
 			}
 		}
 
@@ -708,15 +814,16 @@ void iterateAccessor(const Asset& asset, const Accessor& accessor, Functor&& fun
 	}
 
 	// 5.1.1. accessor.bufferView
-	// The index of the buffer view. When undefined, the accessor MUST be initialized with zeros; sparse
-	// property or extensions MAY override zeros with actual values.
+	// The index of the buffer view. When undefined, the accessor MUST be initialized with zeros;
+	// sparse property or extensions MAY override zeros with actual values.
 	if (!accessor.bufferViewIndex) {
 		for (std::size_t i = 0; i < accessor.count; ++i) {
-			std::invoke(func, ElementType {});
+			std::invoke(func, ElementType{});
 		}
 	} else {
 		auto& view = asset.bufferViews[*accessor.bufferViewIndex];
-        auto stride = view.byteStride.value_or(getElementByteSize(accessor.type, accessor.componentType));
+		auto stride =
+			view.byteStride.value_or(getElementByteSize(accessor.type, accessor.componentType));
 
 		auto bytes = adapter(asset, *accessor.bufferViewIndex).subspan(accessor.byteOffset);
 
@@ -728,10 +835,11 @@ void iterateAccessor(const Asset& asset, const Accessor& accessor, Functor&& fun
 	}
 }
 
-FASTGLTF_EXPORT template <typename ElementType, typename Functor, typename BufferDataAdapter = DefaultBufferDataAdapter>
+FASTGLTF_EXPORT template <typename ElementType, typename Functor,
+						  typename BufferDataAdapter = DefaultBufferDataAdapter>
 requires Element<ElementType> && std::is_invocable_v<Functor, ElementType, std::size_t>
 void iterateAccessorWithIndex(const Asset& asset, const Accessor& accessor, Functor&& func,
-                     const BufferDataAdapter& adapter = {}) {
+							  const BufferDataAdapter& adapter = {}) {
 	std::size_t idx = 0;
 	iterateAccessor<ElementType>(asset, accessor, [&](auto&& elementType) {
 		std::invoke(func, std::forward<ElementType>(elementType), idx++);
@@ -739,23 +847,28 @@ void iterateAccessorWithIndex(const Asset& asset, const Accessor& accessor, Func
 }
 
 FASTGLTF_EXPORT template <typename ElementType, std::size_t TargetStride = sizeof(ElementType),
-    typename BufferDataAdapter = DefaultBufferDataAdapter>
+						  typename BufferDataAdapter = DefaultBufferDataAdapter>
 requires Element<ElementType>
 void copyFromAccessor(const Asset& asset, const Accessor& accessor, void* dest,
-		const BufferDataAdapter& adapter = {}) {
+					  const BufferDataAdapter& adapter = {}) {
 	using Traits = ElementTraits<ElementType>;
-	static_assert(Traits::type != AccessorType::Invalid, "Accessor traits must provide a valid accessor type");
-	static_assert(Traits::enum_component_type != ComponentType::Invalid, "Accessor traits must provide a valid component type");
-	static_assert(std::is_default_constructible_v<ElementType>, "Element type must be default constructible");
+	static_assert(Traits::type != AccessorType::Invalid,
+				  "Accessor traits must provide a valid accessor type");
+	static_assert(Traits::enum_component_type != ComponentType::Invalid,
+				  "Accessor traits must provide a valid component type");
+	static_assert(std::is_default_constructible_v<ElementType>,
+				  "Element type must be default constructible");
 	static_assert(std::is_constructible_v<ElementType>, "Element type must be constructible");
 	static_assert(std::is_move_assignable_v<ElementType>, "Element type must be move-assignable");
 
-	assert(accessor.type == Traits::type && "The destination type needs to have the same AccessorType as the accessor.");
+	assert(accessor.type == Traits::type &&
+		   "The destination type needs to have the same AccessorType as the accessor.");
 
 	auto* dstBytes = static_cast<std::byte*>(dest);
 
 	if (accessor.sparse && accessor.sparse->count > 0) {
-		return iterateAccessorWithIndex<ElementType>(asset, accessor, [&](auto&& value, std::size_t index) {
+		return iterateAccessorWithIndex<ElementType>(asset, accessor,
+													 [&](auto&& value, std::size_t index) {
 			auto* pDest = reinterpret_cast<ElementType*>(dstBytes + TargetStride * index);
 			*pDest = std::forward<ElementType>(value);
 		}, adapter);
@@ -764,8 +877,8 @@ void copyFromAccessor(const Asset& asset, const Accessor& accessor, void* dest,
 	auto elemSize = getElementByteSize(accessor.type, accessor.componentType);
 
 	// 5.1.1. accessor.bufferView
-	// The index of the buffer view. When undefined, the accessor MUST be initialized with zeros; sparse
-	// property or extensions MAY override zeros with actual values.
+	// The index of the buffer view. When undefined, the accessor MUST be initialized with zeros;
+	// sparse property or extensions MAY override zeros with actual values.
 	if (!accessor.bufferViewIndex) {
 		if constexpr (std::is_trivially_copyable_v<ElementType>) {
 			if (TargetStride == elemSize) {
@@ -780,7 +893,7 @@ void copyFromAccessor(const Asset& asset, const Accessor& accessor, void* dest,
 				auto* pDest = reinterpret_cast<ElementType*>(dstBytes + TargetStride * i);
 
 				if constexpr (std::is_aggregate_v<ElementType>) {
-					*pDest = ElementType {};
+					*pDest = ElementType{};
 				} else {
 					*pDest = ElementType();
 				}
@@ -795,8 +908,10 @@ void copyFromAccessor(const Asset& asset, const Accessor& accessor, void* dest,
 
 	auto srcBytes = adapter(asset, *accessor.bufferViewIndex).subspan(accessor.byteOffset);
 
-    // If the data is normalized or the component/accessor type is different, we have to convert each element and can't memcpy.
-	if (std::is_trivially_copyable_v<ElementType> && !accessor.normalized && accessor.componentType == Traits::enum_component_type && !isMatrix(accessor.type)) {
+	// If the data is normalized or the component/accessor type is different, we have to convert
+	// each element and can't memcpy.
+	if (std::is_trivially_copyable_v<ElementType> && !accessor.normalized &&
+		accessor.componentType == Traits::enum_component_type && !isMatrix(accessor.type)) {
 		if (srcStride == elemSize && srcStride == TargetStride) {
 			std::memcpy(dest, srcBytes.data(), elemSize * accessor.count);
 		} else {
@@ -807,8 +922,8 @@ void copyFromAccessor(const Asset& asset, const Accessor& accessor, void* dest,
 	} else {
 		for (std::size_t i = 0; i < accessor.count; ++i) {
 			auto* pDest = reinterpret_cast<ElementType*>(dstBytes + TargetStride * i);
-			*pDest = internal::getAccessorElementAt<ElementType>(
-                    accessor.componentType, &srcBytes[srcStride * i]);
+			*pDest = internal::getAccessorElementAt<ElementType>(accessor.componentType,
+																 &srcBytes[srcStride * i]);
 		}
 	}
 }
@@ -819,11 +934,14 @@ void copyFromAccessor(const Asset& asset, const Accessor& accessor, void* dest,
  * It is advised to *not* use this function unless necessary, like for example when implementing
  * a generic animation interface.
  */
-FASTGLTF_EXPORT template <typename ComponentType, typename BufferDataAdapter = DefaultBufferDataAdapter>
-void copyComponentsFromAccessor(const Asset& asset, const Accessor& accessor, void* dest, const BufferDataAdapter& adapter = {}) {
+FASTGLTF_EXPORT template <typename ComponentType,
+						  typename BufferDataAdapter = DefaultBufferDataAdapter>
+void copyComponentsFromAccessor(const Asset& asset, const Accessor& accessor, void* dest,
+								const BufferDataAdapter& adapter = {}) {
 	constexpr auto DestType = ComponentTypeConverter<ComponentType>::type;
 
-	assert((!bool(accessor.sparse) || accessor.sparse->count == 0) && "copyComponentsFromAccessor currently does not support sparse accessors.");
+	assert((!bool(accessor.sparse) || accessor.sparse->count == 0) &&
+		   "copyComponentsFromAccessor currently does not support sparse accessors.");
 
 	auto* dstBytes = static_cast<std::byte*>(dest);
 
@@ -848,7 +966,8 @@ void copyComponentsFromAccessor(const Asset& asset, const Accessor& accessor, vo
 			for (std::size_t j = 0; j < componentCount; ++j) {
 				auto* pDest = reinterpret_cast<ComponentType*>(dstBytes + elemSize * i) + j;
 				*pDest = internal::getAccessorComponentAt<ComponentType>(
-					accessor.componentType, accessor.type, &srcBytes[i * srcStride], j, accessor.normalized);
+					accessor.componentType, accessor.type, &srcBytes[i * srcStride], j,
+					accessor.normalized);
 			}
 		}
 	}
@@ -857,25 +976,24 @@ void copyComponentsFromAccessor(const Asset& asset, const Accessor& accessor, vo
 /**
  * Computes the transform matrix for a given node, and multiplies the given base with that matrix.
  */
-FASTGLTF_EXPORT inline auto getTransformMatrix(const Node& node, const math::fmat4x4& base = math::fmat4x4()) {
-	return visit_exhaustive(visitor {
-		[&](const math::fmat4x4& matrix) {
-			return base * matrix;
-		},
-		[&](const TRS& trs) {
-			return scale(rotate(translate(base, trs.translation), trs.rotation), trs.scale);
-		}
-	}, node.transform);
+FASTGLTF_EXPORT inline auto getTransformMatrix(const Node& node,
+											   const math::fmat4x4& base = math::fmat4x4()) {
+	return visit_exhaustive(visitor{[&](const math::fmat4x4& matrix) { return base * matrix; },
+									[&](const TRS& trs) {
+		return scale(rotate(translate(base, trs.translation), trs.rotation), trs.scale);
+	}},
+							node.transform);
 }
 
 /**
- * Iterates over every node within a scene recursively, computing the world space transform of each node,
- * and calling the callback function with that node and the transform.
+ * Iterates over every node within a scene recursively, computing the world space transform of each
+ * node, and calling the callback function with that node and the transform.
  */
 FASTGLTF_EXPORT template <typename AssetType, typename Callback>
-requires std::same_as<std::remove_cvref_t<AssetType>, Asset>
-      && std::is_invocable_v<Callback, fastgltf::Node&, const fastgltf::math::fmat4x4&>
-void iterateSceneNodes(AssetType&& asset, std::size_t sceneIndex, math::fmat4x4 initial, Callback callback) {
+requires std::same_as<std::remove_cvref_t<AssetType>, Asset> &&
+		 std::is_invocable_v<Callback, fastgltf::Node&, const fastgltf::math::fmat4x4&>
+void iterateSceneNodes(AssetType&& asset, std::size_t sceneIndex, math::fmat4x4 initial,
+					   Callback callback) {
 	auto& scene = asset.scenes[sceneIndex];
 
 	auto function = [&](std::size_t nodeIndex, math::fmat4x4 nodeMatrix, auto& self) -> void {
@@ -895,6 +1013,6 @@ void iterateSceneNodes(AssetType&& asset, std::size_t sceneIndex, math::fmat4x4 
 	}
 }
 
-} // namespace fastgltf
+}  // namespace fastgltf
 
 #endif

--- a/include/fastgltf/types.hpp
+++ b/include/fastgltf/types.hpp
@@ -28,64 +28,65 @@
 #define FASTGLTF_TYPES_HPP
 
 #if !defined(FASTGLTF_USE_STD_MODULE) || !FASTGLTF_USE_STD_MODULE
-#include <cassert>
-#include <filesystem>
-#include <optional>
-#include <span>
-#include <string>
-#include <utility>
-#include <vector>
+#	include <cassert>
+#	include <filesystem>
+#	include <optional>
+#	include <span>
+#	include <string>
+#	include <utility>
+#	include <vector>
 #endif
 
 // Utils header already includes some headers, which we'll try and avoid including twice.
-#include <fastgltf/util.hpp>
 #include <fastgltf/math.hpp>
+#include <fastgltf/util.hpp>
 
 #if defined(_GLIBCXX_USE_CXX11_ABI) && !_GLIBCXX_USE_CXX11_ABI
 // polymorphic allocators are only supported with the 'new' GCC ABI.
 // Older compilers (older than GCC 5.1) default to the old ABI and sometimes the old ABI is
 // explicitly selected on even the newest compilers, which we want to support.
-#define FASTGLTF_DISABLE_CUSTOM_MEMORY_POOL 1
+#	define FASTGLTF_DISABLE_CUSTOM_MEMORY_POOL 1
 #endif
 
 #ifndef FASTGLTF_DISABLE_CUSTOM_MEMORY_POOL
-#define FASTGLTF_DISABLE_CUSTOM_MEMORY_POOL 0
+#	define FASTGLTF_DISABLE_CUSTOM_MEMORY_POOL 0
 #endif
 
 #if __has_include(<memory_resource>)
-#define FASTGLTF_MISSING_MEMORY_RESOURCE 0
+#	define FASTGLTF_MISSING_MEMORY_RESOURCE 0
 #else
-#define FASTGLTF_MISSING_MEMORY_RESOURCE 1
-#if defined(FASTGLTF_DISABLE_CUSTOM_MEMORY_POOL)
-#undef FASTGLTF_DISABLE_CUSTOM_MEMORY_POOL
-#endif
-#define FASTGLTF_DISABLE_CUSTOM_MEMORY_POOL 1
+#	define FASTGLTF_MISSING_MEMORY_RESOURCE 1
+#	if defined(FASTGLTF_DISABLE_CUSTOM_MEMORY_POOL)
+#		undef FASTGLTF_DISABLE_CUSTOM_MEMORY_POOL
+#	endif
+#	define FASTGLTF_DISABLE_CUSTOM_MEMORY_POOL 1
 #endif
 
 #if !FASTGLTF_DISABLE_CUSTOM_MEMORY_POOL
-#if !defined(FASTGLTF_USE_STD_MODULE) || !FASTGLTF_USE_STD_MODULE
-#include <memory_resource>
-#endif
+#	if !defined(FASTGLTF_USE_STD_MODULE) || !FASTGLTF_USE_STD_MODULE
+#		include <memory_resource>
+#	endif
 #endif
 
 #if FASTGLTF_DISABLE_CUSTOM_MEMORY_POOL
-#define FASTGLTF_STD_PMR_NS ::std
-#define FASTGLTF_FG_PMR_NS ::fastgltf
+#	define FASTGLTF_STD_PMR_NS ::std
+#	define FASTGLTF_FG_PMR_NS ::fastgltf
 
-#define FASTGLTF_CONSTRUCT_PMR_RESOURCE(type, memoryResource, ...) type(__VA_ARGS__)
-#define FASTGLTF_IF_PMR(expr)
+#	define FASTGLTF_CONSTRUCT_PMR_RESOURCE(type, memoryResource, ...) type(__VA_ARGS__)
+#	define FASTGLTF_IF_PMR(expr)
 #else
-#define FASTGLTF_STD_PMR_NS ::std::pmr
-#define FASTGLTF_FG_PMR_NS ::fastgltf::pmr
+#	define FASTGLTF_STD_PMR_NS ::std::pmr
+#	define FASTGLTF_FG_PMR_NS ::fastgltf::pmr
 
-#define FASTGLTF_CONSTRUCT_PMR_RESOURCE(type, memoryResource, ...) type(__VA_ARGS__, memoryResource)
-#define FASTGLTF_IF_PMR(expr) expr
+#	define FASTGLTF_CONSTRUCT_PMR_RESOURCE(type, memoryResource, ...) \
+		type(__VA_ARGS__, memoryResource)
+#	define FASTGLTF_IF_PMR(expr) expr
 #endif
 
 #ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 5030) // attribute 'x' is not recognized
-#pragma warning(disable : 4514) // unreferenced inline function has been removed
+#	pragma warning(push)
+#	pragma warning(disable : 5030)  // attribute 'x' is not recognized
+#	pragma warning(disable : 4514)  // unreferenced inline function has been removed
 #endif
 
 #define FASTGLTF_QUOTE_Q(x) #x
@@ -96,19 +97,19 @@
 
 namespace fastgltf {
 #if defined(FASTGLTF_USE_64BIT_FLOAT) && FASTGLTF_USE_64BIT_FLOAT
-	using num = double;
+using num = double;
 #else
-	using num = float;
+using num = float;
 #endif
 
-	namespace math {
-		FASTGLTF_EXPORT using nvec2 = vec<num, 2>;
-		FASTGLTF_EXPORT using nvec3 = vec<num, 3>;
-		FASTGLTF_EXPORT using nvec4 = vec<num, 4>;
-	}
+namespace math {
+FASTGLTF_EXPORT using nvec2 = vec<num, 2>;
+FASTGLTF_EXPORT using nvec3 = vec<num, 3>;
+FASTGLTF_EXPORT using nvec4 = vec<num, 4>;
+}  // namespace math
 
 #pragma region Enums
-    // clang-format off
+// clang-format off
     FASTGLTF_EXPORT enum class PrimitiveType : std::uint8_t {
         Points = 0,
         Lines = 1,
@@ -313,2508 +314,2428 @@ namespace fastgltf {
     FASTGLTF_ASSIGNMENT_OP_TEMPLATE_MACRO(Category, Category, |)
     FASTGLTF_ASSIGNMENT_OP_TEMPLATE_MACRO(Category, Category, &)
     FASTGLTF_UNARY_OP_TEMPLATE_MACRO(Category, ~)
-    // clang-format on
+// clang-format on
 
 #if FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES
-	FASTGLTF_EXPORT enum class CombineMode : std::uint8_t {
-        Average,
-		Minimum,
-		Maximum,
-		Multiply,
-		Invalid,
-    };
+FASTGLTF_EXPORT enum class CombineMode : std::uint8_t {
+	Average,
+	Minimum,
+	Maximum,
+	Multiply,
+	Invalid,
+};
 
-	FASTGLTF_EXPORT enum class DriveType : std::uint8_t {
-	    Linear,
-		Angular,
-		Invalid
-	};
+FASTGLTF_EXPORT enum class DriveType : std::uint8_t { Linear, Angular, Invalid };
 
-	FASTGLTF_EXPORT enum class DriveMode : std::uint8_t {
-	    Force,
-		Acceleration,
-	    Invalid
-	};
+FASTGLTF_EXPORT enum class DriveMode : std::uint8_t { Force, Acceleration, Invalid };
 #endif
 #pragma endregion
 
 #pragma region ConversionFunctions
-    /**
-     * Gets the number of components for each element for the given accessor type. For example, with
-     * a Vec3 accessor type this will return 3, as a Vec3 contains 3 components.
-     */
-    FASTGLTF_EXPORT constexpr auto getNumComponents(AccessorType type) noexcept {
-    	static_assert(std::is_same_v<std::underlying_type_t<AccessorType>, std::uint8_t>);
-        return static_cast<std::size_t>(to_underlying(type) >> 3U);
-    }
+/**
+ * Gets the number of components for each element for the given accessor type. For example, with
+ * a Vec3 accessor type this will return 3, as a Vec3 contains 3 components.
+ */
+FASTGLTF_EXPORT constexpr auto getNumComponents(AccessorType type) noexcept {
+	static_assert(std::is_same_v<std::underlying_type_t<AccessorType>, std::uint8_t>);
+	return static_cast<std::size_t>(to_underlying(type) >> 3U);
+}
 
-    /**
-     * Returns the number of rows in the given accessor type.
-     */
-    FASTGLTF_EXPORT constexpr auto getElementRowCount(AccessorType type) noexcept {
-        switch (type) {
-            case AccessorType::Mat2:
-            case AccessorType::Vec2:
-                return static_cast<std::size_t>(2U);
-            case AccessorType::Mat3:
-            case AccessorType::Vec3:
-                return static_cast<std::size_t>(3U);
-            case AccessorType::Mat4:
-            case AccessorType::Vec4:
-                return static_cast<std::size_t>(4U);
-            default:
-                return static_cast<std::size_t>(1U);
-        }
-    }
-
-    FASTGLTF_EXPORT constexpr bool isMatrix(AccessorType type) noexcept {
-        return type == AccessorType::Mat2 || type == AccessorType::Mat3 || type == AccessorType::Mat4;
-    }
-
-	FASTGLTF_EXPORT constexpr auto getComponentByteSize(ComponentType componentType) noexcept {
-		static_assert(std::is_same_v<std::underlying_type_t<ComponentType>, std::uint16_t>);
-		if (componentType == ComponentType::Invalid)
-			return static_cast<std::size_t>(0U);
-		return static_cast<std::size_t>(to_underlying(componentType) >> 13U) + 1;
+/**
+ * Returns the number of rows in the given accessor type.
+ */
+FASTGLTF_EXPORT constexpr auto getElementRowCount(AccessorType type) noexcept {
+	switch (type) {
+		case AccessorType::Mat2:
+		case AccessorType::Vec2: return static_cast<std::size_t>(2U);
+		case AccessorType::Mat3:
+		case AccessorType::Vec3: return static_cast<std::size_t>(3U);
+		case AccessorType::Mat4:
+		case AccessorType::Vec4: return static_cast<std::size_t>(4U);
+		default:                 return static_cast<std::size_t>(1U);
 	}
+}
 
-	FASTGLTF_EXPORT constexpr auto getComponentBitSize(ComponentType componentType) noexcept {
-		return getComponentByteSize(componentType) * 8U;
+FASTGLTF_EXPORT constexpr bool isMatrix(AccessorType type) noexcept {
+	return type == AccessorType::Mat2 || type == AccessorType::Mat3 || type == AccessorType::Mat4;
+}
+
+FASTGLTF_EXPORT constexpr auto getComponentByteSize(ComponentType componentType) noexcept {
+	static_assert(std::is_same_v<std::underlying_type_t<ComponentType>, std::uint16_t>);
+	if (componentType == ComponentType::Invalid) return static_cast<std::size_t>(0U);
+	return static_cast<std::size_t>(to_underlying(componentType) >> 13U) + 1;
+}
+
+FASTGLTF_EXPORT constexpr auto getComponentBitSize(ComponentType componentType) noexcept {
+	return getComponentByteSize(componentType) * 8U;
+}
+
+FASTGLTF_EXPORT constexpr auto getElementByteSize(AccessorType type,
+												  ComponentType componentType) noexcept {
+	const auto componentSize = getComponentByteSize(componentType);
+	auto numComponents = getNumComponents(type);
+	const auto rowCount = getElementRowCount(type);
+	if (isMatrix(type) && (rowCount * componentSize) % 4 != 0) {
+		// Matrices need extra padding per-column which affects their size.
+		numComponents += rowCount * (4 - (rowCount % 4));
 	}
+	return numComponents * componentSize;
+}
 
-    FASTGLTF_EXPORT constexpr auto getElementByteSize(AccessorType type, ComponentType componentType) noexcept {
-        const auto componentSize = getComponentByteSize(componentType);
-        auto numComponents = getNumComponents(type);
-        const auto rowCount = getElementRowCount(type);
-        if (isMatrix(type) && (rowCount * componentSize) % 4 != 0) {
-            // Matrices need extra padding per-column which affects their size.
-            numComponents += rowCount * (4 - (rowCount % 4));
-        }
-        return numComponents * componentSize;
-    }
+/**
+ * Returns the OpenGL component type enumeration for the given component type.
+ * All OpenGL enumerations use GLenum, which is a 32-bit wide integer, which is why
+ * this function returns a std::uint32_t.
+ *
+ * For example, getGLComponentType(ComponentType::Float) will return GL_FLOAT (0x1406).
+ */
+FASTGLTF_EXPORT constexpr auto getGLComponentType(ComponentType type) noexcept {
+	static_assert(std::is_same_v<std::underlying_type_t<ComponentType>, std::uint16_t>);
+	return static_cast<std::uint32_t>(to_underlying(type) &
+									  0x1FFF);  // 2^13 - 1 in hex, to mask the lower 13 bits.
+}
 
-    /**
-     * Returns the OpenGL component type enumeration for the given component type.
-     * All OpenGL enumerations use GLenum, which is a 32-bit wide integer, which is why
-     * this function returns a std::uint32_t.
-     *
-     * For example, getGLComponentType(ComponentType::Float) will return GL_FLOAT (0x1406).
-     */
-    FASTGLTF_EXPORT constexpr auto getGLComponentType(ComponentType type) noexcept {
-    	static_assert(std::is_same_v<std::underlying_type_t<ComponentType>, std::uint16_t>);
-        return static_cast<std::uint32_t>(to_underlying(type) & 0x1FFF); // 2^13 - 1 in hex, to mask the lower 13 bits.
-    }
+/**
+ * Don't use this, use getComponentType instead.
+ * This order matters as we assume that their glTF constant is ascending to index it.
+ */
+static constexpr std::array components = {
+	ComponentType::Byte,          ComponentType::UnsignedByte, ComponentType::Short,
+	ComponentType::UnsignedShort, ComponentType::Int,          ComponentType::UnsignedInt,
+	ComponentType::Float,         ComponentType::Invalid,      ComponentType::Invalid,
+	ComponentType::Invalid,       ComponentType::Double,
+};
 
-    /**
-     * Don't use this, use getComponentType instead.
-     * This order matters as we assume that their glTF constant is ascending to index it.
-     */
-    static constexpr std::array components = {
-        ComponentType::Byte,
-        ComponentType::UnsignedByte,
-        ComponentType::Short,
-        ComponentType::UnsignedShort,
-        ComponentType::Int,
-        ComponentType::UnsignedInt,
-        ComponentType::Float,
-        ComponentType::Invalid,
-        ComponentType::Invalid,
-        ComponentType::Invalid,
-        ComponentType::Double,
-    };
+constexpr auto getComponentType(std::underlying_type_t<ComponentType> componentType) noexcept {
+	const auto index =
+		static_cast<std::size_t>(componentType - getGLComponentType(ComponentType::Byte));
+	if (index >= components.size()) {
+		return ComponentType::Invalid;
+	}
+	return components[index];
+}
 
-    constexpr auto getComponentType(std::underlying_type_t<ComponentType> componentType) noexcept {
-        const auto index = static_cast<std::size_t>(componentType - getGLComponentType(ComponentType::Byte));
-        if (index >= components.size()) {
-            return ComponentType::Invalid;
+// This order matters as we assume that their glTF constant is ascending to index it.
+static constexpr std::array accessorTypes = {
+	AccessorType::Scalar, AccessorType::Vec2, AccessorType::Vec3, AccessorType::Vec4,
+	AccessorType::Mat2,   AccessorType::Mat3, AccessorType::Mat4,
+};
+
+/**
+ * Gets the AccessorType by its string representation found in glTF files.
+ */
+constexpr auto getAccessorType(std::string_view accessorTypeName) noexcept {
+	assert(!accessorTypeName.empty());
+	switch (accessorTypeName[0]) {
+		case 'S': return AccessorType::Scalar;
+		case 'V': {
+			const auto componentCount = static_cast<std::size_t>(accessorTypeName[3] - '2');
+			if (componentCount + 1 >= accessorTypes.size()) {
+				return AccessorType::Invalid;
+			}
+			return accessorTypes[componentCount + 1];
 		}
-        return components[index];
-    }
-
-    // This order matters as we assume that their glTF constant is ascending to index it.
-    static constexpr std::array accessorTypes = {
-        AccessorType::Scalar,
-        AccessorType::Vec2,
-        AccessorType::Vec3,
-        AccessorType::Vec4,
-        AccessorType::Mat2,
-        AccessorType::Mat3,
-        AccessorType::Mat4,
-    };
-
-    /**
-     * Gets the AccessorType by its string representation found in glTF files.
-     */
-    constexpr auto getAccessorType(std::string_view accessorTypeName) noexcept {
-        assert(!accessorTypeName.empty());
-        switch (accessorTypeName[0]) {
-            case 'S': return AccessorType::Scalar;
-            case 'V': {
-                const auto componentCount = static_cast<std::size_t>(accessorTypeName[3] - '2');
-                if (componentCount + 1 >= accessorTypes.size()) {
-                    return AccessorType::Invalid;
-                }
-                return accessorTypes[componentCount + 1];
-            }
-            case 'M': {
-                const auto componentCount = static_cast<std::size_t>(accessorTypeName[3] - '2');
-                if (componentCount + 4 >= accessorTypes.size()) {
-                    return AccessorType::Invalid;
-                }
-                return accessorTypes[componentCount + 4];
-            }
-        	default:
-        		return AccessorType::Invalid;
-        }
-    }
-
-	static constexpr std::array<std::string_view, 7> accessorTypeNames = {
-		"SCALAR",
-		"VEC2",
-		"VEC3",
-		"VEC4",
-		"MAT2",
-		"MAT3",
-		"MAT4"
-	};
-
-	constexpr std::string_view getAccessorTypeName(AccessorType type) noexcept {
-    	static_assert(std::is_same_v<std::underlying_type_t<AccessorType>, std::uint8_t>);
-		if (type == AccessorType::Invalid)
-			return "";
-		auto idx = to_underlying(type) & 0x7;
-		return accessorTypeNames[idx - 1];
-	}
-
-	constexpr std::string_view mimeTypeJpeg = "image/jpeg";
-	constexpr std::string_view mimeTypePng = "image/png";
-	constexpr std::string_view mimeTypeKtx = "image/ktx2";
-	constexpr std::string_view mimeTypeDds = "image/vnd-ms.dds";
-	constexpr std::string_view mimeTypeGltfBuffer = "application/gltf-buffer";
-	constexpr std::string_view mimeTypeOctetStream = "application/octet-stream";
-	constexpr std::string_view mimeTypeWebp = "image/webp";
-
-	constexpr std::string_view getMimeTypeString(MimeType mimeType) noexcept {
-		switch (mimeType) {
-			case MimeType::JPEG:
-				return mimeTypeJpeg;
-			case MimeType::PNG:
-				return mimeTypePng;
-			case MimeType::KTX2:
-				return mimeTypeKtx;
-			case MimeType::DDS:
-				return mimeTypeDds;
-			case MimeType::GltfBuffer:
-				return mimeTypeGltfBuffer;
-			case MimeType::OctetStream:
-				return mimeTypeOctetStream;
-			case MimeType::WEBP:
-				return mimeTypeWebp;
-			default:
-				return "";
+		case 'M': {
+			const auto componentCount = static_cast<std::size_t>(accessorTypeName[3] - '2');
+			if (componentCount + 4 >= accessorTypes.size()) {
+				return AccessorType::Invalid;
+			}
+			return accessorTypes[componentCount + 4];
 		}
+		default: return AccessorType::Invalid;
 	}
+}
+
+static constexpr std::array<std::string_view, 7> accessorTypeNames = {
+	"SCALAR", "VEC2", "VEC3", "VEC4", "MAT2", "MAT3", "MAT4"};
+
+constexpr std::string_view getAccessorTypeName(AccessorType type) noexcept {
+	static_assert(std::is_same_v<std::underlying_type_t<AccessorType>, std::uint8_t>);
+	if (type == AccessorType::Invalid) return "";
+	auto idx = to_underlying(type) & 0x7;
+	return accessorTypeNames[idx - 1];
+}
+
+constexpr std::string_view mimeTypeJpeg = "image/jpeg";
+constexpr std::string_view mimeTypePng = "image/png";
+constexpr std::string_view mimeTypeKtx = "image/ktx2";
+constexpr std::string_view mimeTypeDds = "image/vnd-ms.dds";
+constexpr std::string_view mimeTypeGltfBuffer = "application/gltf-buffer";
+constexpr std::string_view mimeTypeOctetStream = "application/octet-stream";
+constexpr std::string_view mimeTypeWebp = "image/webp";
+
+constexpr std::string_view getMimeTypeString(MimeType mimeType) noexcept {
+	switch (mimeType) {
+		case MimeType::JPEG:        return mimeTypeJpeg;
+		case MimeType::PNG:         return mimeTypePng;
+		case MimeType::KTX2:        return mimeTypeKtx;
+		case MimeType::DDS:         return mimeTypeDds;
+		case MimeType::GltfBuffer:  return mimeTypeGltfBuffer;
+		case MimeType::OctetStream: return mimeTypeOctetStream;
+		case MimeType::WEBP:        return mimeTypeWebp;
+		default:                    return "";
+	}
+}
 
 #if FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES
-	[[nodiscard]] constexpr auto getCombineMode(const std::string_view name) noexcept {
-		assert(!name.empty());
-	    if(name[0] == 'a') {
-			return CombineMode::Average;
-	    }
-
-		switch(name[1]) {
-	    case 'i':
-			return CombineMode::Minimum;
-
-	    case 'a':
-			return CombineMode::Maximum;
-
-	    case 'u':
-			return CombineMode::Multiply;
-		}
-
-		return CombineMode::Invalid;
+[[nodiscard]] constexpr auto getCombineMode(const std::string_view name) noexcept {
+	assert(!name.empty());
+	if (name[0] == 'a') {
+		return CombineMode::Average;
 	}
 
-	static constexpr std::array<std::string_view, 4> frictionCombineNames{
-        "average",
-        "minimum",
-        "maximum",
-        "multiply"
-	};
+	switch (name[1]) {
+		case 'i': return CombineMode::Minimum;
 
-	[[nodiscard]] constexpr std::string_view getFrictionCombineName(const CombineMode frictionCombine) noexcept {
-		static_assert(std::is_same_v<std::underlying_type_t<CombineMode>, std::uint8_t>);
-		const auto idx = to_underlying(frictionCombine) & 0x3;
-		return frictionCombineNames[idx];
+		case 'a': return CombineMode::Maximum;
+
+		case 'u': return CombineMode::Multiply;
 	}
 
-	[[nodiscard]] constexpr auto getDriveType(const std::string_view name) noexcept {
-		if (name[0] == 'l') {
-			return DriveType::Linear;
-		} else if (name[0] == 'a') {
-			return DriveType::Angular;
-		} else {
-			return DriveType::Invalid;
-		}
-	}
+	return CombineMode::Invalid;
+}
 
-	[[nodiscard]] constexpr auto getDriveMode(const std::string_view name) noexcept {
-	    if (name[0] == 'f') {
-			return DriveMode::Force;
-	    } else if (name[0] == 'a') {
-			return DriveMode::Acceleration;
-	    } else {
-			return DriveMode::Invalid;
-	    }
+static constexpr std::array<std::string_view, 4> frictionCombineNames{"average", "minimum",
+																	  "maximum", "multiply"};
+
+[[nodiscard]] constexpr std::string_view getFrictionCombineName(
+	const CombineMode frictionCombine) noexcept {
+	static_assert(std::is_same_v<std::underlying_type_t<CombineMode>, std::uint8_t>);
+	const auto idx = to_underlying(frictionCombine) & 0x3;
+	return frictionCombineNames[idx];
+}
+
+[[nodiscard]] constexpr auto getDriveType(const std::string_view name) noexcept {
+	if (name[0] == 'l') {
+		return DriveType::Linear;
+	} else if (name[0] == 'a') {
+		return DriveType::Angular;
+	} else {
+		return DriveType::Invalid;
 	}
+}
+
+[[nodiscard]] constexpr auto getDriveMode(const std::string_view name) noexcept {
+	if (name[0] == 'f') {
+		return DriveMode::Force;
+	} else if (name[0] == 'a') {
+		return DriveMode::Acceleration;
+	} else {
+		return DriveMode::Invalid;
+	}
+}
 #endif
 #pragma endregion
 
 #pragma region Containers
-    /**
-     * A static vector which cannot be resized freely. When constructed, the backing array is allocated once.
-     */
-    FASTGLTF_EXPORT template <typename T>
-    class StaticVector final {
-	public:
-		using value_type = T;
-		using size_type = std::size_t;
-        using array_t = value_type[];
+/**
+ * A static vector which cannot be resized freely. When constructed, the backing array is allocated
+ * once.
+ */
+FASTGLTF_EXPORT template <typename T>
+class StaticVector final {
+   public:
+	using value_type = T;
+	using size_type = std::size_t;
+	using array_t = value_type[];
 
-	private:
-		size_type _size = 0;
-        std::unique_ptr<array_t> _array;
+   private:
+	size_type _size = 0;
+	std::unique_ptr<array_t> _array;
 
-		void copy(const T* first, size_type count, T* result) {
-            if (count > 0) {
-				if constexpr (std::is_trivially_copyable_v<T>) {
-					std::memcpy(result, first, count * sizeof(T));
-				} else {
-					*result++ = *first;
-					for (size_type i = 1; i < count; ++i) {
-						*result++ = *++first;
-					}
-				}
-            }
-        }
-
-    public:
-		using reference = value_type&;
-		using const_reference = const value_type&;
-        using pointer = value_type*;
-        using const_pointer = const value_type*;
-        using iterator = pointer;
-        using const_iterator = const_pointer;
-
-        explicit StaticVector(std::size_t size) : _size(size), _array(std::make_unique_for_overwrite<array_t>(size)) {}
-		explicit StaticVector(std::size_t size, const T& initialValue) : _size(size), _array(std::make_unique_for_overwrite<array_t>(size)) {
-			for (auto& value : *this) {
-				value = initialValue;
-			}
-		}
-
-        StaticVector(const StaticVector& other) {
-            if (other.size() == 0) {
-                _array.reset();
-                _size = 0;
-            } else {
-                _array.reset(new std::remove_extent_t<array_t>[other.size()]);
-                _size = other.size();
-				copy(other.begin(), _size, begin());
-            }
-        }
-
-        StaticVector(StaticVector&& other) noexcept {
-            _array = std::move(other._array);
-            _size = other.size();
-        }
-
-		StaticVector& operator=(StaticVector&& other) noexcept {
-			_array = std::move(other._array);
-			_size = other.size();
-			return *this;
-		}
-
-		/**
-		 * Copies the contents of the given vector into a new StaticVector.
-		 */
-		static auto fromVector(const std::vector<T>& vector) {
-			StaticVector staticVector(vector.size());
+	void copy(const T* first, size_type count, T* result) {
+		if (count > 0) {
 			if constexpr (std::is_trivially_copyable_v<T>) {
-				std::memcpy(staticVector.data(), vector.data(), vector.size());
+				std::memcpy(result, first, count * sizeof(T));
 			} else {
-				for (auto it = vector.begin(); it != vector.end(); ++it) {
-					staticVector[std::distance(vector.begin(), it)] = *it;
-				}
-			}
-			return staticVector;
-		}
-
-        [[nodiscard]] pointer data() noexcept {
-            return &_array.get()[0];
-        }
-
-        [[nodiscard]] const_pointer data() const noexcept {
-            return &_array.get()[0];
-        }
-
-        [[nodiscard]] size_type size() const noexcept {
-            return _size;
-        }
-
-        [[nodiscard]] size_type size_bytes() const noexcept {
-            return _size * sizeof(value_type);
-        }
-
-        [[nodiscard]] bool empty() const noexcept {
-            return _size == 0;
-        }
-
-        [[nodiscard]] iterator begin() noexcept { return data(); }
-        [[nodiscard]] const_iterator begin() const noexcept { return data(); }
-        [[nodiscard]] const_iterator cbegin() const noexcept { return data(); }
-        [[nodiscard]] iterator end() noexcept { return begin() + size(); }
-        [[nodiscard]] const_iterator end() const noexcept { return begin() + size(); }
-        [[nodiscard]] const_iterator cend() const noexcept { return begin() + size(); }
-
-		[[nodiscard]] T& operator[](std::size_t idx) {
-            assert(idx < size());
-            return begin()[idx];
-        }
-        [[nodiscard]] const T& operator[](std::size_t idx) const {
-            assert(idx < size());
-            return begin()[idx];
-        }
-
-        bool operator==(const StaticVector& other) const {
-            if (other.size() != size()) return false;
-            return std::memcmp(data(), other.data(), size_bytes()) == 0;
-        }
-
-        // This is mostly just here for compatibility and the tests
-        bool operator==(const std::vector<value_type>& other) const {
-            if (other.size() != size()) return false;
-            return std::memcmp(data(), other.data(), size_bytes()) == 0;
-        }
-    };
-
-	/*
-	 * The amount of items that the SmallVector can initially store in the storage
-	 * allocated within the object itself.
-	 */
-	static constexpr auto initialSmallVectorStorage = 8;
-
-    /**
-     * A custom vector class for fastgltf, which can store up to N objects within itself.
-     * This is useful for cases where the vector is expected to only ever hold a tiny amount of small objects,
-     * such as a node's children.
-     * SmallVector is also mostly conformant to C++17's std::vector, and can therefore be used as a drop-in replacement.
-     * @note It is also available with polymorphic allocators in the fastgltf::pmr namespace.
-     */
-    FASTGLTF_EXPORT template <typename T, std::size_t N = initialSmallVectorStorage, typename Allocator = std::allocator<T>>
-    class SmallVector final {
-        static_assert(N != 0, "Cannot create a SmallVector with 0 initial capacity");
-
-        alignas(T) std::array<std::byte, N * sizeof(T)> storage = {};
-
-		Allocator allocator;
-
-        T* _data;
-        std::size_t _size = 0, _capacity = N;
-
-        void copy(const T* first, std::size_t count, T* result) {
-            if (count > 0) {
-				if constexpr (std::is_trivially_copyable_v<T>) {
-					std::memcpy(result, first, count * sizeof(T));
-				} else {
-					*result++ = *first;
-					for (std::size_t i = 1; i < count; ++i) {
-						*result++ = *++first;
-					}
-				}
-            }
-        }
-
-    public:
-		using iterator = T*;
-		using const_iterator = const T*;
-
-        SmallVector() : _data(reinterpret_cast<T*>(storage.data())) {}
-
-		explicit SmallVector(const Allocator& allocator) noexcept : allocator(allocator), _data(reinterpret_cast<T*>(storage.data())) {}
-
-        explicit SmallVector(std::size_t size, const Allocator& allocator = Allocator()) : allocator(allocator), _data(reinterpret_cast<T*>(storage.data())) {
-            resize(size);
-        }
-
-        SmallVector(std::size_t size, const T& value, const Allocator& allocator = Allocator()) : allocator(allocator), _data(reinterpret_cast<T*>(storage.data())) {
-            assign(size, value);
-        }
-
-        SmallVector(std::initializer_list<T> init, const Allocator& allocator = Allocator()) : allocator(allocator), _data(reinterpret_cast<T*>(storage.data())) {
-            assign(init);
-        }
-
-        SmallVector(const SmallVector& other) noexcept : _data(reinterpret_cast<T*>(storage.data())) {
-            resize(other.size());
-            copy(other.begin(), other.size(), begin());
-        }
-
-        SmallVector(SmallVector&& other) noexcept : _data(reinterpret_cast<T*>(storage.data())) {
-            if (other.isUsingStack()) {
-                if (!other.empty()) {
-                    resize(other.size());
-                    copy(other.begin(), other.size(), begin());
-                    other._data = reinterpret_cast<T*>(other.storage.data()); // Reset pointer
-                    _size = std::exchange(other._size, 0);
-                    _capacity = std::exchange(other._capacity, N);
-                }
-            } else {
-                _data = std::exchange(other._data, nullptr);
-                _size = std::exchange(other._size, 0);
-                _capacity = std::exchange(other._capacity, N);
-            }
-        }
-
-        SmallVector& operator=(const SmallVector& other) {
-            if (std::addressof(other) != this) {
-                if (!isUsingStack() && _data) {
-	                std::destroy(begin(), end());
-					allocator.deallocate(_data, _capacity);
-                    _data = reinterpret_cast<T*>(storage.data());
-                    _size = _capacity = 0;
-                }
-
-                resize(other.size());
-                copy(other.begin(), other.size(), begin());
-            }
-            return *this;
-        }
-
-        SmallVector& operator=(SmallVector&& other) noexcept {
-            if (std::addressof(other) != this) {
-                if (other.isUsingStack()) {
-                    if (!other.empty()) {
-                        resize(other.size());
-                        copy(other.begin(), other.size(), begin());
-                        other._data = reinterpret_cast<T*>(other.storage.data()); // Reset pointer
-                        _size = std::exchange(other._size, 0);
-                        _capacity = std::exchange(other._capacity, N);
-                    }
-                } else {
-                    _data = std::exchange(other._data, nullptr);
-                    _size = std::exchange(other._size, 0);
-                    _capacity = std::exchange(other._capacity, N);
-                }
-            }
-            return *this;
-        }
-
-        ~SmallVector() {
-			// As we use an array of std::byte for the stack storage, we have to destruct those manually too.
-			std::destroy(begin(), end());
-
-            if (!isUsingStack() && _data) {
-                // Not using the stack, we'll have to free.
-	            allocator.deallocate(_data, _capacity);
-            }
-        }
-
-	    [[nodiscard]] iterator begin() noexcept { return _data; }
-        [[nodiscard]] const_iterator begin() const noexcept { return _data; }
-	    [[nodiscard]] const_iterator cbegin() const noexcept { return _data; }
-	    [[nodiscard]] iterator end() noexcept { return begin() + size(); }
-	    [[nodiscard]] const_iterator end() const noexcept { return begin() + size(); }
-	    [[nodiscard]] const_iterator cend() const noexcept { return begin() + size(); }
-
-        [[nodiscard]] std::reverse_iterator<T*> rbegin() { return end(); }
-        [[nodiscard]] std::reverse_iterator<const T*> rbegin() const { return end(); }
-        [[nodiscard]] std::reverse_iterator<const T*> crbegin() const { return end(); }
-        [[nodiscard]] std::reverse_iterator<T*> rend() { return begin(); }
-        [[nodiscard]] std::reverse_iterator<const T*> rend() const { return begin(); }
-        [[nodiscard]] std::reverse_iterator<const T*> crend() const { return begin(); }
-
-        [[nodiscard]] T* data() noexcept { return _data; }
-        [[nodiscard]] const T* data() const noexcept { return _data; }
-        [[nodiscard]] std::size_t size() const noexcept { return _size; }
-        [[nodiscard]] std::size_t size_in_bytes() const noexcept { return _size * sizeof(T); }
-        [[nodiscard]] std::size_t capacity() const noexcept { return _capacity; }
-
-        [[nodiscard]] bool empty() const noexcept { return _size == 0; }
-        [[nodiscard]] bool isUsingStack() const noexcept { return data() == reinterpret_cast<const T*>(storage.data()); }
-
-        void reserve(std::size_t newCapacity) {
-	        static_assert(std::is_move_constructible_v<T> || std::is_copy_constructible_v<T>, "T needs to be copy constructible.");
-
-            // We don't want to reduce capacity with reserve, only with shrink_to_fit.
-            if (newCapacity <= capacity()) {
-                return;
-            }
-
-            // If the new capacity is lower than what we can hold on the stack, we ignore this request.
-            if (newCapacity <= N && isUsingStack()) {
-                _capacity = newCapacity;
-                if (_size > _capacity) {
-                    _size = _capacity;
-                }
-                return;
-            }
-
-            // We use geometric growth, similarly to std::vector.
-            newCapacity = static_cast<std::size_t>(1) << (std::numeric_limits<decltype(newCapacity)>::digits - std::countl_zero(newCapacity));
-
-			T* alloc = allocator.allocate(newCapacity);
-
-			// Copy/Move the old data into the new memory
-			for (std::size_t i = 0; i < size(); ++i) {
-				auto& x = (*this)[i];
-				if constexpr (std::is_nothrow_move_constructible_v<T>) {
-					new(alloc + i) T(std::move(x));
-				} else if constexpr (std::is_copy_constructible_v<T>) {
-					new(alloc + i) T(x);
-				} else {
-					new(alloc + i) T(std::move(x));
-				}
-			}
-
-			// Destroy all objects in the old allocation
-			std::destroy(begin(), end());
-
-            if (!isUsingStack() && _data && size() != 0) {
-				allocator.deallocate(_data, _capacity);
-            }
-
-            _data = alloc;
-            _capacity = newCapacity;
-        }
-
-        void resize(std::size_t newSize) {
-			static_assert(std::is_constructible_v<T>, "T has to be constructible");
-			if (newSize == size()) {
-				return;
-			}
-
-			if (newSize < size()) {
-				// Just destroy the "overflowing" elements.
-				std::destroy(begin() + newSize, end());
-			} else {
-                // Reserve enough capacity and copy the new value over.
-                auto oldSize = _size;
-                reserve(newSize);
-                for (auto it = begin() + oldSize; it != begin() + newSize; ++it) {
-                    new (it) T();
-                }
-            }
-
-            _size = newSize;
-        }
-
-		void resize(std::size_t newSize, const T& value) {
-			static_assert(std::is_copy_constructible_v<T>, "T needs to be copy constructible.");
-			if (newSize == size()) {
-				return;
-			}
-
-			if (newSize < size()) {
-				// Just destroy the "overflowing" elements.
-				std::destroy(begin() + newSize, end());
-			} else {
-				// Reserve enough capacity and copy the new value over.
-				auto oldSize = _size;
-				reserve(newSize);
-				for (auto it = begin() + oldSize; it != begin() + newSize; ++it) {
-					if (it == nullptr)
-						break;
-
-					if constexpr (std::is_move_constructible_v<T>) {
-						new (it) T(std::move(value));
-					} else if constexpr (std::is_trivially_copyable_v<T>) {
-						std::memcpy(it, std::addressof(value), sizeof(T));
-					} else {
-						new (it) T(value);
-					}
-				}
-			}
-
-			_size = newSize;
-		}
-
-		void shrink_to_fit() {
-			// Only have to shrink if there's any unused capacity.
-			if (capacity() == size() || size() == 0) {
-				return;
-			}
-
-			// If we can use the object's memory again, we'll copy everything over.
-			if (size() <= N) {
-				copy(begin(), size(), reinterpret_cast<T*>(storage.data()));
-				_data = reinterpret_cast<T*>(storage.data());
-			} else {
-				// We have to use heap allocated memory.
-				auto* alloc = allocator.allocate(size());
-				for (std::size_t i = 0; i < size(); ++i) {
-					new(alloc + i) T((*this)[i]);
-				}
-
-				if (_data && !isUsingStack()) {
-					std::destroy(begin(), end());
-					allocator.deallocate(_data, _capacity);
-				}
-
-				_data = alloc;
-			}
-
-			_capacity = _size;
-		}
-
-		void assign(std::size_t count, const T& value) {
-			clear();
-			resize(count, value);
-		}
-
-		void assign(std::initializer_list<T> init) {
-			static_assert(std::is_trivially_copyable_v<T> || std::is_copy_constructible_v<T>, "T needs to be trivially copyable or be copy constructible");
-			clear();
-			reserve(init.size());
-			_size = init.size();
-
-			if constexpr (std::is_trivially_copyable_v<T>) {
-				std::memcpy(begin(), init.begin(), init.size() * sizeof(T));
-			} else if constexpr (std::is_copy_constructible_v<T>) {
-				for (auto it = init.begin(); it != init.end(); ++it) {
-					new (_data + std::distance(init.begin(), it)) T(*it);
+				*result++ = *first;
+				for (size_type i = 1; i < count; ++i) {
+					*result++ = *++first;
 				}
 			}
 		}
+	}
 
-		void clear() noexcept {
-			std::destroy(begin(), end());
+   public:
+	using reference = value_type&;
+	using const_reference = const value_type&;
+	using pointer = value_type*;
+	using const_pointer = const value_type*;
+	using iterator = pointer;
+	using const_iterator = const_pointer;
 
-			if (!isUsingStack() && size() != 0) {
-				allocator.deallocate(_data, _capacity);
-				_data = reinterpret_cast<T*>(storage.data());
-			}
+	explicit StaticVector(std::size_t size)
+		: _size(size), _array(std::make_unique_for_overwrite<array_t>(size)) {}
+	explicit StaticVector(std::size_t size, const T& initialValue)
+		: _size(size), _array(std::make_unique_for_overwrite<array_t>(size)) {
+		for (auto& value : *this) {
+			value = initialValue;
+		}
+	}
 
+	StaticVector(const StaticVector& other) {
+		if (other.size() == 0) {
+			_array.reset();
 			_size = 0;
+		} else {
+			_array.reset(new std::remove_extent_t<array_t>[other.size()]);
+			_size = other.size();
+			copy(other.begin(), _size, begin());
+		}
+	}
+
+	StaticVector(StaticVector&& other) noexcept {
+		_array = std::move(other._array);
+		_size = other.size();
+	}
+
+	StaticVector& operator=(StaticVector&& other) noexcept {
+		_array = std::move(other._array);
+		_size = other.size();
+		return *this;
+	}
+
+	/**
+	 * Copies the contents of the given vector into a new StaticVector.
+	 */
+	static auto fromVector(const std::vector<T>& vector) {
+		StaticVector staticVector(vector.size());
+		if constexpr (std::is_trivially_copyable_v<T>) {
+			std::memcpy(staticVector.data(), vector.data(), vector.size());
+		} else {
+			for (auto it = vector.begin(); it != vector.end(); ++it) {
+				staticVector[std::distance(vector.begin(), it)] = *it;
+			}
+		}
+		return staticVector;
+	}
+
+	[[nodiscard]] pointer data() noexcept { return &_array.get()[0]; }
+
+	[[nodiscard]] const_pointer data() const noexcept { return &_array.get()[0]; }
+
+	[[nodiscard]] size_type size() const noexcept { return _size; }
+
+	[[nodiscard]] size_type size_bytes() const noexcept { return _size * sizeof(value_type); }
+
+	[[nodiscard]] bool empty() const noexcept { return _size == 0; }
+
+	[[nodiscard]] iterator begin() noexcept { return data(); }
+	[[nodiscard]] const_iterator begin() const noexcept { return data(); }
+	[[nodiscard]] const_iterator cbegin() const noexcept { return data(); }
+	[[nodiscard]] iterator end() noexcept { return begin() + size(); }
+	[[nodiscard]] const_iterator end() const noexcept { return begin() + size(); }
+	[[nodiscard]] const_iterator cend() const noexcept { return begin() + size(); }
+
+	[[nodiscard]] T& operator[](std::size_t idx) {
+		assert(idx < size());
+		return begin()[idx];
+	}
+	[[nodiscard]] const T& operator[](std::size_t idx) const {
+		assert(idx < size());
+		return begin()[idx];
+	}
+
+	bool operator==(const StaticVector& other) const {
+		if (other.size() != size()) return false;
+		return std::memcmp(data(), other.data(), size_bytes()) == 0;
+	}
+
+	// This is mostly just here for compatibility and the tests
+	bool operator==(const std::vector<value_type>& other) const {
+		if (other.size() != size()) return false;
+		return std::memcmp(data(), other.data(), size_bytes()) == 0;
+	}
+};
+
+/*
+ * The amount of items that the SmallVector can initially store in the storage
+ * allocated within the object itself.
+ */
+static constexpr auto initialSmallVectorStorage = 8;
+
+/**
+ * A custom vector class for fastgltf, which can store up to N objects within itself.
+ * This is useful for cases where the vector is expected to only ever hold a tiny amount of small
+ * objects, such as a node's children. SmallVector is also mostly conformant to C++17's std::vector,
+ * and can therefore be used as a drop-in replacement.
+ * @note It is also available with polymorphic allocators in the fastgltf::pmr namespace.
+ */
+FASTGLTF_EXPORT template <typename T, std::size_t N = initialSmallVectorStorage,
+						  typename Allocator = std::allocator<T>>
+class SmallVector final {
+	static_assert(N != 0, "Cannot create a SmallVector with 0 initial capacity");
+
+	alignas(T) std::array<std::byte, N * sizeof(T)> storage = {};
+
+	Allocator allocator;
+
+	T* _data;
+	std::size_t _size = 0, _capacity = N;
+
+	void copy(const T* first, std::size_t count, T* result) {
+		if (count > 0) {
+			if constexpr (std::is_trivially_copyable_v<T>) {
+				std::memcpy(result, first, count * sizeof(T));
+			} else {
+				*result++ = *first;
+				for (std::size_t i = 1; i < count; ++i) {
+					*result++ = *++first;
+				}
+			}
+		}
+	}
+
+   public:
+	using iterator = T*;
+	using const_iterator = const T*;
+
+	SmallVector() : _data(reinterpret_cast<T*>(storage.data())) {}
+
+	explicit SmallVector(const Allocator& allocator) noexcept
+		: allocator(allocator), _data(reinterpret_cast<T*>(storage.data())) {}
+
+	explicit SmallVector(std::size_t size, const Allocator& allocator = Allocator())
+		: allocator(allocator), _data(reinterpret_cast<T*>(storage.data())) {
+		resize(size);
+	}
+
+	SmallVector(std::size_t size, const T& value, const Allocator& allocator = Allocator())
+		: allocator(allocator), _data(reinterpret_cast<T*>(storage.data())) {
+		assign(size, value);
+	}
+
+	SmallVector(std::initializer_list<T> init, const Allocator& allocator = Allocator())
+		: allocator(allocator), _data(reinterpret_cast<T*>(storage.data())) {
+		assign(init);
+	}
+
+	SmallVector(const SmallVector& other) noexcept : _data(reinterpret_cast<T*>(storage.data())) {
+		resize(other.size());
+		copy(other.begin(), other.size(), begin());
+	}
+
+	SmallVector(SmallVector&& other) noexcept : _data(reinterpret_cast<T*>(storage.data())) {
+		if (other.isUsingStack()) {
+			if (!other.empty()) {
+				resize(other.size());
+				copy(other.begin(), other.size(), begin());
+				other._data = reinterpret_cast<T*>(other.storage.data());  // Reset pointer
+				_size = std::exchange(other._size, 0);
+				_capacity = std::exchange(other._capacity, N);
+			}
+		} else {
+			_data = std::exchange(other._data, nullptr);
+			_size = std::exchange(other._size, 0);
+			_capacity = std::exchange(other._capacity, N);
+		}
+	}
+
+	SmallVector& operator=(const SmallVector& other) {
+		if (std::addressof(other) != this) {
+			if (!isUsingStack() && _data) {
+				std::destroy(begin(), end());
+				allocator.deallocate(_data, _capacity);
+				_data = reinterpret_cast<T*>(storage.data());
+				_size = _capacity = 0;
+			}
+
+			resize(other.size());
+			copy(other.begin(), other.size(), begin());
+		}
+		return *this;
+	}
+
+	SmallVector& operator=(SmallVector&& other) noexcept {
+		if (std::addressof(other) != this) {
+			if (other.isUsingStack()) {
+				if (!other.empty()) {
+					resize(other.size());
+					copy(other.begin(), other.size(), begin());
+					other._data = reinterpret_cast<T*>(other.storage.data());  // Reset pointer
+					_size = std::exchange(other._size, 0);
+					_capacity = std::exchange(other._capacity, N);
+				}
+			} else {
+				_data = std::exchange(other._data, nullptr);
+				_size = std::exchange(other._size, 0);
+				_capacity = std::exchange(other._capacity, N);
+			}
+		}
+		return *this;
+	}
+
+	~SmallVector() {
+		// As we use an array of std::byte for the stack storage, we have to destruct those manually
+		// too.
+		std::destroy(begin(), end());
+
+		if (!isUsingStack() && _data) {
+			// Not using the stack, we'll have to free.
+			allocator.deallocate(_data, _capacity);
+		}
+	}
+
+	[[nodiscard]] iterator begin() noexcept { return _data; }
+	[[nodiscard]] const_iterator begin() const noexcept { return _data; }
+	[[nodiscard]] const_iterator cbegin() const noexcept { return _data; }
+	[[nodiscard]] iterator end() noexcept { return begin() + size(); }
+	[[nodiscard]] const_iterator end() const noexcept { return begin() + size(); }
+	[[nodiscard]] const_iterator cend() const noexcept { return begin() + size(); }
+
+	[[nodiscard]] std::reverse_iterator<T*> rbegin() { return end(); }
+	[[nodiscard]] std::reverse_iterator<const T*> rbegin() const { return end(); }
+	[[nodiscard]] std::reverse_iterator<const T*> crbegin() const { return end(); }
+	[[nodiscard]] std::reverse_iterator<T*> rend() { return begin(); }
+	[[nodiscard]] std::reverse_iterator<const T*> rend() const { return begin(); }
+	[[nodiscard]] std::reverse_iterator<const T*> crend() const { return begin(); }
+
+	[[nodiscard]] T* data() noexcept { return _data; }
+	[[nodiscard]] const T* data() const noexcept { return _data; }
+	[[nodiscard]] std::size_t size() const noexcept { return _size; }
+	[[nodiscard]] std::size_t size_in_bytes() const noexcept { return _size * sizeof(T); }
+	[[nodiscard]] std::size_t capacity() const noexcept { return _capacity; }
+
+	[[nodiscard]] bool empty() const noexcept { return _size == 0; }
+	[[nodiscard]] bool isUsingStack() const noexcept {
+		return data() == reinterpret_cast<const T*>(storage.data());
+	}
+
+	void reserve(std::size_t newCapacity) {
+		static_assert(std::is_move_constructible_v<T> || std::is_copy_constructible_v<T>,
+					  "T needs to be copy constructible.");
+
+		// We don't want to reduce capacity with reserve, only with shrink_to_fit.
+		if (newCapacity <= capacity()) {
+			return;
 		}
 
-        template <typename... Args>
-        decltype(auto) emplace_back(Args&&... args) {
-            // We reserve enough capacity for the new element, and then just increment the size.
-			reserve(_size + 1);
-			++_size;
-            new (std::addressof(back())) T(std::forward<Args>(args)...);
-            return (back());
-        }
+		// If the new capacity is lower than what we can hold on the stack, we ignore this request.
+		if (newCapacity <= N && isUsingStack()) {
+			_capacity = newCapacity;
+			if (_size > _capacity) {
+				_size = _capacity;
+			}
+			return;
+		}
 
-        [[nodiscard]] T& at(std::size_t idx) {
-            if (idx >= size()) {
-                raise<std::out_of_range>("Index is out of range for SmallVector");
-            }
-            return begin()[idx];
-        }
-        [[nodiscard]] const T& at(std::size_t idx) const {
-            if (idx >= size()) {
-                raise<std::out_of_range>("Index is out of range for SmallVector");
-            }
-            return begin()[idx];
-        }
+		// We use geometric growth, similarly to std::vector.
+		newCapacity =
+			static_cast<std::size_t>(1)
+			<< (std::numeric_limits<decltype(newCapacity)>::digits - std::countl_zero(newCapacity));
 
-        [[nodiscard]] T& operator[](std::size_t idx) {
-            assert(idx < size());
-            return begin()[idx];
-        }
-        [[nodiscard]] const T& operator[](std::size_t idx) const {
-            assert(idx < size());
-            return begin()[idx];
-        }
+		T* alloc = allocator.allocate(newCapacity);
 
-        [[nodiscard]] T& front() {
-            assert(!empty());
-            return begin()[0];
-        }
-        [[nodiscard]] const T& front() const {
-            assert(!empty());
-            return begin()[0];
-        }
+		// Copy/Move the old data into the new memory
+		for (std::size_t i = 0; i < size(); ++i) {
+			auto& x = (*this)[i];
+			if constexpr (std::is_nothrow_move_constructible_v<T>) {
+				new (alloc + i) T(std::move(x));
+			} else if constexpr (std::is_copy_constructible_v<T>) {
+				new (alloc + i) T(x);
+			} else {
+				new (alloc + i) T(std::move(x));
+			}
+		}
 
-        [[nodiscard]] T& back() {
-            assert(!empty());
-            return end()[-1];
-        }
-        [[nodiscard]] const T& back() const {
-            assert(!empty());
-            return end()[-1];
-        }
-    };
+		// Destroy all objects in the old allocation
+		std::destroy(begin(), end());
+
+		if (!isUsingStack() && _data && size() != 0) {
+			allocator.deallocate(_data, _capacity);
+		}
+
+		_data = alloc;
+		_capacity = newCapacity;
+	}
+
+	void resize(std::size_t newSize) {
+		static_assert(std::is_constructible_v<T>, "T has to be constructible");
+		if (newSize == size()) {
+			return;
+		}
+
+		if (newSize < size()) {
+			// Just destroy the "overflowing" elements.
+			std::destroy(begin() + newSize, end());
+		} else {
+			// Reserve enough capacity and copy the new value over.
+			auto oldSize = _size;
+			reserve(newSize);
+			for (auto it = begin() + oldSize; it != begin() + newSize; ++it) {
+				new (it) T();
+			}
+		}
+
+		_size = newSize;
+	}
+
+	void resize(std::size_t newSize, const T& value) {
+		static_assert(std::is_copy_constructible_v<T>, "T needs to be copy constructible.");
+		if (newSize == size()) {
+			return;
+		}
+
+		if (newSize < size()) {
+			// Just destroy the "overflowing" elements.
+			std::destroy(begin() + newSize, end());
+		} else {
+			// Reserve enough capacity and copy the new value over.
+			auto oldSize = _size;
+			reserve(newSize);
+			for (auto it = begin() + oldSize; it != begin() + newSize; ++it) {
+				if (it == nullptr) break;
+
+				if constexpr (std::is_move_constructible_v<T>) {
+					new (it) T(std::move(value));
+				} else if constexpr (std::is_trivially_copyable_v<T>) {
+					std::memcpy(it, std::addressof(value), sizeof(T));
+				} else {
+					new (it) T(value);
+				}
+			}
+		}
+
+		_size = newSize;
+	}
+
+	void shrink_to_fit() {
+		// Only have to shrink if there's any unused capacity.
+		if (capacity() == size() || size() == 0) {
+			return;
+		}
+
+		// If we can use the object's memory again, we'll copy everything over.
+		if (size() <= N) {
+			copy(begin(), size(), reinterpret_cast<T*>(storage.data()));
+			_data = reinterpret_cast<T*>(storage.data());
+		} else {
+			// We have to use heap allocated memory.
+			auto* alloc = allocator.allocate(size());
+			for (std::size_t i = 0; i < size(); ++i) {
+				new (alloc + i) T((*this)[i]);
+			}
+
+			if (_data && !isUsingStack()) {
+				std::destroy(begin(), end());
+				allocator.deallocate(_data, _capacity);
+			}
+
+			_data = alloc;
+		}
+
+		_capacity = _size;
+	}
+
+	void assign(std::size_t count, const T& value) {
+		clear();
+		resize(count, value);
+	}
+
+	void assign(std::initializer_list<T> init) {
+		static_assert(std::is_trivially_copyable_v<T> || std::is_copy_constructible_v<T>,
+					  "T needs to be trivially copyable or be copy constructible");
+		clear();
+		reserve(init.size());
+		_size = init.size();
+
+		if constexpr (std::is_trivially_copyable_v<T>) {
+			std::memcpy(begin(), init.begin(), init.size() * sizeof(T));
+		} else if constexpr (std::is_copy_constructible_v<T>) {
+			for (auto it = init.begin(); it != init.end(); ++it) {
+				new (_data + std::distance(init.begin(), it)) T(*it);
+			}
+		}
+	}
+
+	void clear() noexcept {
+		std::destroy(begin(), end());
+
+		if (!isUsingStack() && size() != 0) {
+			allocator.deallocate(_data, _capacity);
+			_data = reinterpret_cast<T*>(storage.data());
+		}
+
+		_size = 0;
+	}
+
+	template <typename... Args>
+	decltype(auto) emplace_back(Args&&... args) {
+		// We reserve enough capacity for the new element, and then just increment the size.
+		reserve(_size + 1);
+		++_size;
+		new (std::addressof(back())) T(std::forward<Args>(args)...);
+		return (back());
+	}
+
+	[[nodiscard]] T& at(std::size_t idx) {
+		if (idx >= size()) {
+			raise<std::out_of_range>("Index is out of range for SmallVector");
+		}
+		return begin()[idx];
+	}
+	[[nodiscard]] const T& at(std::size_t idx) const {
+		if (idx >= size()) {
+			raise<std::out_of_range>("Index is out of range for SmallVector");
+		}
+		return begin()[idx];
+	}
+
+	[[nodiscard]] T& operator[](std::size_t idx) {
+		assert(idx < size());
+		return begin()[idx];
+	}
+	[[nodiscard]] const T& operator[](std::size_t idx) const {
+		assert(idx < size());
+		return begin()[idx];
+	}
+
+	[[nodiscard]] T& front() {
+		assert(!empty());
+		return begin()[0];
+	}
+	[[nodiscard]] const T& front() const {
+		assert(!empty());
+		return begin()[0];
+	}
+
+	[[nodiscard]] T& back() {
+		assert(!empty());
+		return end()[-1];
+	}
+	[[nodiscard]] const T& back() const {
+		assert(!empty());
+		return end()[-1];
+	}
+};
 
 #if !FASTGLTF_MISSING_MEMORY_RESOURCE
-	namespace pmr {
-		FASTGLTF_EXPORT template<typename T, std::size_t N>
-		using SmallVector = SmallVector<T, N, std::pmr::polymorphic_allocator<T>>;
-	} // namespace pmr
+namespace pmr {
+FASTGLTF_EXPORT template <typename T, std::size_t N>
+using SmallVector = SmallVector<T, N, std::pmr::polymorphic_allocator<T>>;
+}  // namespace pmr
 #endif
 
 #ifndef FASTGLTF_USE_CUSTOM_SMALLVECTOR
-#define FASTGLTF_USE_CUSTOM_SMALLVECTOR 0
+#	define FASTGLTF_USE_CUSTOM_SMALLVECTOR 0
 #endif
 
 #if FASTGLTF_USE_CUSTOM_SMALLVECTOR
-	FASTGLTF_EXPORT template <typename T, std::size_t N = initialSmallVectorStorage>
-	using MaybeSmallVector = SmallVector<T, N>;
+FASTGLTF_EXPORT template <typename T, std::size_t N = initialSmallVectorStorage>
+using MaybeSmallVector = SmallVector<T, N>;
 #else
-	FASTGLTF_EXPORT template <typename T, std::size_t N = 0>
-	using MaybeSmallVector = std::vector<T>;
+FASTGLTF_EXPORT template <typename T, std::size_t N = 0>
+using MaybeSmallVector = std::vector<T>;
 #endif
 
 #if !FASTGLTF_MISSING_MEMORY_RESOURCE
-	namespace pmr {
-#if FASTGLTF_USE_CUSTOM_SMALLVECTOR
-		FASTGLTF_EXPORT template <typename T, std::size_t N = initialSmallVectorStorage>
-		using MaybeSmallVector = pmr::SmallVector<T, N>;
-#else
-		FASTGLTF_EXPORT template <typename T, std::size_t N = 0>
-		using MaybeSmallVector = std::pmr::vector<T>;
+namespace pmr {
+#	if FASTGLTF_USE_CUSTOM_SMALLVECTOR
+FASTGLTF_EXPORT template <typename T, std::size_t N = initialSmallVectorStorage>
+using MaybeSmallVector = pmr::SmallVector<T, N>;
+#	else
+FASTGLTF_EXPORT template <typename T, std::size_t N = 0>
+using MaybeSmallVector = std::pmr::vector<T>;
+#	endif
+}  // namespace pmr
 #endif
-	} // namespace pmr
-#endif
 
-	FASTGLTF_EXPORT template<typename, typename = void>
-	struct OptionalFlagValue {
-		static constexpr std::nullopt_t missing_value = std::nullopt;
+FASTGLTF_EXPORT template <typename, typename = void>
+struct OptionalFlagValue {
+	static constexpr std::nullopt_t missing_value = std::nullopt;
+};
+
+template <>
+struct OptionalFlagValue<std::size_t> {
+	static constexpr auto missing_value = std::numeric_limits<std::size_t>::max();
+};
+
+template <>
+struct OptionalFlagValue<float, std::enable_if_t<std::numeric_limits<float>::is_iec559>> {
+	// This float is a quiet NaN with a specific bit pattern to be able to differentiate
+	// between this flag value and any result from FP operations.
+	static constexpr auto missing_value = std::bit_cast<float, std::uint32_t>(0x7fedb6db);
+};
+
+template <>
+struct OptionalFlagValue<double, std::enable_if_t<std::numeric_limits<double>::is_iec559>> {
+	static constexpr auto missing_value = std::bit_cast<double, std::uint64_t>(0x7ffdb6db6db6db6d);
+};
+
+template <>
+struct OptionalFlagValue<Filter> {
+	static constexpr auto missing_value =
+		static_cast<Filter>(std::numeric_limits<std::underlying_type_t<Filter>>::max());
+};
+
+template <>
+struct OptionalFlagValue<BufferTarget> {
+	static constexpr auto missing_value =
+		static_cast<BufferTarget>(std::numeric_limits<std::underlying_type_t<BufferTarget>>::max());
+};
+
+FASTGLTF_EXPORT template <typename T>
+class OptionalWithFlagValue;
+
+/**
+ * A type alias which checks if there is a specialization of OptionalFlagValue for T and "switches"
+ * between fastgltf::OptionalWithFlagValue and std::optional.
+ */
+FASTGLTF_EXPORT template <typename T>
+using Optional = std::conditional_t<
+	!std::is_same_v<std::nullopt_t,
+					std::remove_const_t<decltype(OptionalFlagValue<T>::missing_value)>>,
+	OptionalWithFlagValue<T>, std::optional<T>>;
+
+/**
+ * A custom optional class for fastgltf,
+ * which uses so-called "flag values" which are specific values of T that will never be present as
+ * an actual value. We can therefore use those values as flags for whether there is an actual value
+ * stored, instead of the additional bool used by std::optional.
+ *
+ * These flag values are obtained from the specializations of OptionalFlagValue.
+ * If no specialization for T of OptionalFlagValue is provided, a static assert will be triggered.
+ * In those cases, use std::optional or fastgltf::Optional instead.
+ */
+template <typename T>
+class OptionalWithFlagValue final {
+	static_assert(
+		!std::is_same_v<std::nullopt_t,
+						std::remove_const_t<decltype(OptionalFlagValue<T>::missing_value)>>,
+		"OptionalWithFlagValue can only be used when there is an appropriate specialization of "
+		"OptionalFlagValue<T>.");
+
+	struct NonTrivialDummy {
+		constexpr NonTrivialDummy() noexcept {}
 	};
 
-	template<>
-	struct OptionalFlagValue<std::size_t> {
-		static constexpr auto missing_value = std::numeric_limits<std::size_t>::max();
+	union {
+		NonTrivialDummy dummy;
+		std::remove_const_t<T> _value;
 	};
 
-	template<>
-	struct OptionalFlagValue<float, std::enable_if_t<std::numeric_limits<float>::is_iec559>> {
-		// This float is a quiet NaN with a specific bit pattern to be able to differentiate
-		// between this flag value and any result from FP operations.
-		static constexpr auto missing_value = std::bit_cast<float>(0x7fedb6db);
-	};
+   public:
+	OptionalWithFlagValue() noexcept { reset(); }
 
-	template<>
-	struct OptionalFlagValue<double, std::enable_if_t<std::numeric_limits<double>::is_iec559>> {
-		static constexpr auto missing_value = std::bit_cast<double>(0x7ffdb6db6db6db6d);
-	};
+	OptionalWithFlagValue(std::nullopt_t) noexcept { reset(); }
 
-	template<>
-	struct OptionalFlagValue<Filter> {
-		static constexpr auto missing_value = static_cast<Filter>(std::numeric_limits<std::underlying_type_t<Filter>>::max());
-	};
-
-	template<>
-	struct OptionalFlagValue<BufferTarget> {
-		static constexpr auto missing_value = static_cast<BufferTarget>(std::numeric_limits<std::underlying_type_t<BufferTarget>>::max());
-	};
-
-	FASTGLTF_EXPORT template<typename T>
-	class OptionalWithFlagValue;
-
-	/**
-	 * A type alias which checks if there is a specialization of OptionalFlagValue for T and "switches"
-	 * between fastgltf::OptionalWithFlagValue and std::optional.
-	 */
-	FASTGLTF_EXPORT template <typename T>
-	using Optional = std::conditional_t<
-		!std::is_same_v<std::nullopt_t, std::remove_const_t<decltype(OptionalFlagValue<T>::missing_value)>>,
-		OptionalWithFlagValue<T>,
-		std::optional<T>>;
-
-	/**
-	 * A custom optional class for fastgltf,
-	 * which uses so-called "flag values" which are specific values of T that will never be present as an actual value.
-	 * We can therefore use those values as flags for whether there is an actual value stored,
-	 * instead of the additional bool used by std::optional.
-	 *
-	 * These flag values are obtained from the specializations of OptionalFlagValue.
-	 * If no specialization for T of OptionalFlagValue is provided, a static assert will be triggered.
-	 * In those cases, use std::optional or fastgltf::Optional instead.
-	 */
-	template<typename T>
-	class OptionalWithFlagValue final {
-		static_assert(!std::is_same_v<std::nullopt_t, std::remove_const_t<decltype(OptionalFlagValue<T>::missing_value)>>,
-			"OptionalWithFlagValue can only be used when there is an appropriate specialization of OptionalFlagValue<T>.");
-
-		struct NonTrivialDummy {
-			constexpr NonTrivialDummy() noexcept {}
-		};
-
-		union {
-			NonTrivialDummy dummy;
-			std::remove_const_t<T> _value;
-		};
-
-	public:
-		OptionalWithFlagValue() noexcept {
+	template <typename U = T>
+	requires std::is_copy_constructible_v<T>
+	OptionalWithFlagValue(const OptionalWithFlagValue<U>& other) {
+		if (other.has_value()) {
+			new (std::addressof(_value)) T(*other);
+		} else {
 			reset();
 		}
+	}
 
-		OptionalWithFlagValue(std::nullopt_t) noexcept {
+	template <typename U = T>
+	requires std::is_move_constructible_v<T>
+	OptionalWithFlagValue(OptionalWithFlagValue<U>&& other) {
+		if (other.has_value()) {
+			new (std::addressof(_value)) T(std::move(*other));
+		} else {
 			reset();
 		}
+	}
 
-		template <typename U = T>
-		requires std::is_copy_constructible_v<T>
-		OptionalWithFlagValue(const OptionalWithFlagValue<U>& other) {
-			if (other.has_value()) {
-				new (std::addressof(_value)) T(*other);
-			} else {
-				reset();
-			}
-		}
+	template <typename... Args>
+	requires std::is_constructible_v<T, Args...>
+	explicit OptionalWithFlagValue(std::in_place_t, Args&&... args) noexcept(
+		std::is_nothrow_constructible_v<T, Args...>)
+		: _value(std::forward<Args>(args)...) {}
 
-		template <typename U = T>
-		requires std::is_move_constructible_v<T>
-		OptionalWithFlagValue(OptionalWithFlagValue<U>&& other) {
-			if (other.has_value()) {
-				new (std::addressof(_value)) T(std::move(*other));
-			} else {
-				reset();
-			}
-		}
+	template <typename U = T>
+	requires std::is_constructible_v<T, U&&>
+	OptionalWithFlagValue(U&& _new) noexcept(std::is_nothrow_assignable_v<T&, U> &&
+											 std::is_nothrow_constructible_v<T, U>) {
+		new (std::addressof(_value)) T(std::forward<U>(_new));
+	}
 
-		template<typename... Args>
-		requires std::is_constructible_v<T, Args...>
-		explicit OptionalWithFlagValue(std::in_place_t, Args&& ... args) noexcept(std::is_nothrow_constructible_v<T, Args...>)
-			: _value(std::forward<Args>(args)...) {}
+	~OptionalWithFlagValue() { reset(); }
 
-		template <typename U = T>
-		requires std::is_constructible_v<T, U&&>
-		OptionalWithFlagValue(U&& _new) noexcept(std::is_nothrow_assignable_v<T&, U> && std::is_nothrow_constructible_v<T, U>) {
+	OptionalWithFlagValue& operator=(std::nullopt_t) noexcept {
+		reset();
+		return *this;
+	}
+
+	template <typename U = T>
+	requires std::is_constructible_v<T, U&&>
+	OptionalWithFlagValue& operator=(U&& _new) noexcept(std::is_nothrow_assignable_v<T&, U> &&
+														std::is_nothrow_constructible_v<T, U>) {
+		if (has_value()) {
+			_value = std::forward<U>(_new);
+		} else {
 			new (std::addressof(_value)) T(std::forward<U>(_new));
 		}
+		return *this;
+	}
 
-		~OptionalWithFlagValue() {
-			reset();
-		}
-
-		OptionalWithFlagValue& operator=(std::nullopt_t) noexcept {
-			reset();
-			return *this;
-		}
-
-		template <typename U = T>
-		requires std::is_constructible_v<T, U&&>
-		OptionalWithFlagValue& operator=(U&& _new) noexcept(std::is_nothrow_assignable_v<T&, U> && std::is_nothrow_constructible_v<T, U>) {
+	template <typename U>
+	requires std::conjunction_v<std::is_constructible<T, const U&>,
+								std::is_assignable<T&, const U&>>
+	OptionalWithFlagValue& operator=(const OptionalWithFlagValue<U>& other) {
+		if (other.has_value()) {
 			if (has_value()) {
-				_value = std::forward<U>(_new);
+				_value = other._value;
 			} else {
-				new(std::addressof(_value)) T(std::forward<U>(_new));
+				new (std::addressof(_value)) T(other._value);
 			}
-			return *this;
+		} else {
+			reset();
 		}
+		return *this;
+	}
 
-		template <typename U>
-		requires std::conjunction_v<std::is_constructible<T, const U&>, std::is_assignable<T&, const U&>>
-		OptionalWithFlagValue& operator=(const OptionalWithFlagValue<U>& other) {
-			if (other.has_value()) {
-				if (has_value()) {
-					_value = other._value;
-				} else {
-					new(std::addressof(_value)) T(other._value);
-				}
-			} else {
-				reset();
-			}
-			return *this;
-		}
-
-		template <typename U>
-		requires std::conjunction_v<std::is_constructible<T, U>, std::is_assignable<T&, U>>
-		OptionalWithFlagValue& operator=(OptionalWithFlagValue<U>&& other) noexcept(std::is_nothrow_assignable_v<T&, T> && std::is_nothrow_constructible_v<T, T>) {
-			if (other.has_value()) {
-				if (has_value()) {
-					_value = std::move(other._value);
-				} else {
-					new(std::addressof(_value)) T(other._value);
-				}
-			} else {
-				reset();
-			}
-			return *this;
-		}
-
-		[[nodiscard]] bool has_value() const {
-			if constexpr (std::is_floating_point_v<T>) {
-				// NaNs are never equal to anything, not even themselves.
-				// Since the sentinels are special NaN values, we need to memcmp to check equality.
-				return std::memcmp(&_value, &OptionalFlagValue<T>::missing_value, sizeof(T)) != 0;
-			}
-			return this->_value != OptionalFlagValue<T>::missing_value;
-		}
-
-		[[nodiscard]] T& value()& {
-			if (!has_value()) {
-                raise<std::bad_optional_access>();
-			}
-			return _value;
-		}
-
-		[[nodiscard]] const T& value() const& {
-			if (!has_value()) {
-				raise<std::bad_optional_access>();
-			}
-			return _value;
-		}
-
-		[[nodiscard]] T&& value()&& {
-			if (!has_value()) {
-				raise<std::bad_optional_access>();
-			}
-			return std::move(_value);
-		}
-
-		[[nodiscard]] const T&& value() const&& {
-			if (!has_value()) {
-				raise<std::bad_optional_access>();
-			}
-			return std::move(_value);
-		}
-
-		template<typename U>
-		[[nodiscard]] T value_or(U&& default_value) const& {
-			return has_value() ? **this : static_cast<T>(std::forward<U>(default_value));
-		}
-
-		template<typename U>
-		[[nodiscard]] T value_or(U&& default_value)&& {
-			return has_value() ? std::move(**this) : static_cast<T>(std::forward<U>(default_value));
-		}
-
-		template <typename F>
-		[[nodiscard]] auto and_then(F&& func)& {
-			using U = std::remove_cvref_t<std::invoke_result_t<F, T&>>;
-			if (!has_value())
-				return U(std::nullopt);
-			return std::invoke(std::forward<F>(func), **this);
-		}
-
-		template <typename F>
-		[[nodiscard]] auto and_then(F&& func) const& {
-			using U = std::remove_cvref_t<std::invoke_result_t<F, const T&>>;
-			if (!has_value())
-				return U(std::nullopt);
-			return std::invoke(std::forward<F>(func), **this);
-		}
-
-		template <typename F>
-		[[nodiscard]] auto and_then(F&& func)&& {
-			using U = std::remove_cvref_t<std::invoke_result_t<F, T>>;
-			if (!has_value())
-				return U(std::nullopt);
-			return std::invoke(std::forward<F>(func), std::move(**this));
-		}
-
-		template <typename F>
-		[[nodiscard]] auto and_then(F&& func) const&& {
-			using U = std::remove_cvref_t<std::invoke_result_t<F, const T>>;
-			if (!has_value())
-				return U(std::nullopt);
-			return std::invoke(std::forward<F>(func), std::move(**this));
-		}
-
-		template <typename F>
-		[[nodiscard]] auto transform(F&& func)& {
-			using U = std::remove_cv_t<std::invoke_result_t<F, T&>>;
-			if (!has_value())
-				return Optional<U>(std::nullopt);
-			return Optional<U>(std::invoke(std::forward<F>(func), **this));
-		}
-
-		template <typename F>
-		[[nodiscard]] auto transform(F&& func) const& {
-			using U = std::remove_cv_t<std::invoke_result_t<F, const T&>>;
-			if (!has_value())
-				return Optional<U>(std::nullopt);
-			return Optional<U>(std::invoke(std::forward<F>(func), **this));
-		}
-
-		template <typename F>
-		[[nodiscard]] auto transform(F&& func)&& {
-			using U = std::remove_cv_t<std::invoke_result_t<F, T>>;
-			if (!has_value())
-				return Optional<U>(std::nullopt);
-			return Optional<U>(std::invoke(std::forward<F>(func), std::move(**this)));
-		}
-
-		template <typename F>
-		[[nodiscard]] auto transform(F&& func) const&& {
-			using U = std::remove_cv_t<std::invoke_result_t<F, const T>>;
-			if (!has_value())
-				return Optional<U>(std::nullopt);
-			return Optional<U>(std::invoke(std::forward<F>(func), std::move(**this)));
-		}
-
-		template <typename F>
-		[[nodiscard]] T or_else(F&& func) const& {
-			return *this ? *this : std::invoke(std::forward<F>(func));
-		}
-
-		template <typename F>
-		[[nodiscard]] T or_else(F&& func)&& {
-			return *this ? std::move(*this) : std::invoke(std::forward<F>(func));
-		}
-
-		void swap(OptionalWithFlagValue<T>& other) noexcept(std::is_nothrow_move_constructible_v<T> &&
-		                                                    std::is_nothrow_swappable_v<T>) {
-			static_assert(std::is_move_constructible_v<T>);
-			if (has_value() && other.has_value()) {
-				std::swap(_value, other._value);
-			} else if (has_value() && !other.has_value()) {
-				other._value = std::move(_value);
-			} else if (!has_value() && other.has_value()) {
+	template <typename U>
+	requires std::conjunction_v<std::is_constructible<T, U>, std::is_assignable<T&, U>>
+	OptionalWithFlagValue& operator=(OptionalWithFlagValue<U>&& other) noexcept(
+		std::is_nothrow_assignable_v<T&, T> && std::is_nothrow_constructible_v<T, T>) {
+		if (other.has_value()) {
+			if (has_value()) {
 				_value = std::move(other._value);
+			} else {
+				new (std::addressof(_value)) T(other._value);
 			}
+		} else {
+			reset();
 		}
-
-		void reset() noexcept {
-			this->_value = OptionalFlagValue<T>::missing_value;
-		}
-
-		template <typename... Args>
-		T& emplace(Args&&... args) {
-			new (std::addressof(_value)) T(std::forward<Args>(args)...);
-			return _value;
-		}
-
-		template <typename U, typename... Args>
-		T& emplace(std::initializer_list<U> list, Args&&... args) {
-			static_assert(std::is_constructible_v<T, std::initializer_list<U>&, Args&&...>);
-			new (std::addressof(_value)) T(list, std::forward<Args>(args)...);
-			return _value;
-		}
-
-		explicit operator bool() const noexcept {
-			return has_value();
-		}
-
-		T* operator->() noexcept {
-			return std::addressof(_value);
-		}
-
-		const T* operator->() const noexcept {
-			return std::addressof(_value);
-		}
-
-		T& operator*()& noexcept {
-			return _value;
-		}
-
-		const T& operator*() const& noexcept {
-			return _value;
-		}
-
-		T&& operator*()&& noexcept {
-			return std::move(_value);
-		}
-
-		const T&& operator*() const&& noexcept {
-			return std::move(_value);
-		}
-
-		operator std::optional<T>() const noexcept {
-			return has_value() ? std::optional<T>(_value) : std::nullopt;
-		}
-
-		operator std::optional<T>&&()&& noexcept {
-			return has_value() ? std::optional<T>(std::move(_value)) : std::nullopt;
-		}
-	};
-
-	FASTGLTF_EXPORT template <typename T, typename U>
-	bool operator==(const OptionalWithFlagValue<T>& lhs, const OptionalWithFlagValue<U>& rhs) {
-		return static_cast<bool>(lhs) == static_cast<bool>(rhs) &&
-			(!static_cast<bool>(lhs) || *lhs == *rhs);
+		return *this;
 	}
 
-	FASTGLTF_EXPORT template <typename T, typename U>
-	bool operator!=(const OptionalWithFlagValue<T>& lhs, const OptionalWithFlagValue<U>& rhs) {
-		return !(lhs == rhs);
+	[[nodiscard]] bool has_value() const {
+		if constexpr (std::is_floating_point_v<T>) {
+			// NaNs are never equal to anything, not even themselves.
+			// Since the sentinels are special NaN values, we need to memcmp to check equality.
+			return std::memcmp(&_value, &OptionalFlagValue<T>::missing_value, sizeof(T)) != 0;
+		}
+		return this->_value != OptionalFlagValue<T>::missing_value;
 	}
 
-	FASTGLTF_EXPORT template <typename T, typename U>
-	bool operator==(const OptionalWithFlagValue<T>& opt, const U& value) {
-		return opt.has_value() && (*opt) == value;
+	[[nodiscard]] T& value() & {
+		if (!has_value()) {
+			raise<std::bad_optional_access>();
+		}
+		return _value;
 	}
 
-	FASTGLTF_EXPORT template <typename T, typename U>
-	bool operator!=(const OptionalWithFlagValue<T>& opt, const U& value) {
-		return !(opt == value);
+	[[nodiscard]] const T& value() const& {
+		if (!has_value()) {
+			raise<std::bad_optional_access>();
+		}
+		return _value;
 	}
 
-	FASTGLTF_EXPORT template <typename T, typename U>
-	bool operator<(const OptionalWithFlagValue<T>& opt, const U& value) {
-		return opt.has_value() && *opt < value;
+	[[nodiscard]] T&& value() && {
+		if (!has_value()) {
+			raise<std::bad_optional_access>();
+		}
+		return std::move(_value);
 	}
 
-	FASTGLTF_EXPORT template <typename T, typename U>
-	bool operator<=(const OptionalWithFlagValue<T>& opt, const U& value) {
-		return opt.has_value() && *opt <= value;
+	[[nodiscard]] const T&& value() const&& {
+		if (!has_value()) {
+			raise<std::bad_optional_access>();
+		}
+		return std::move(_value);
 	}
 
-	FASTGLTF_EXPORT template <typename T, typename U>
-	bool operator>(const OptionalWithFlagValue<T>& opt, const U& value) {
-		return opt.has_value() && *opt > value;
+	template <typename U>
+	[[nodiscard]] T value_or(U&& default_value) const& {
+		return has_value() ? **this : static_cast<T>(std::forward<U>(default_value));
 	}
 
-	FASTGLTF_EXPORT template <typename T, typename U>
-	bool operator>=(const OptionalWithFlagValue<T>& opt, const U& value) {
-		return opt.has_value() && *opt >= value;
+	template <typename U>
+	[[nodiscard]] T value_or(U&& default_value) && {
+		return has_value() ? std::move(**this) : static_cast<T>(std::forward<U>(default_value));
 	}
+
+	template <typename F>
+	[[nodiscard]] auto and_then(F&& func) & {
+		using U = std::remove_cvref_t<std::invoke_result_t<F, T&>>;
+		if (!has_value()) return U(std::nullopt);
+		return std::invoke(std::forward<F>(func), **this);
+	}
+
+	template <typename F>
+	[[nodiscard]] auto and_then(F&& func) const& {
+		using U = std::remove_cvref_t<std::invoke_result_t<F, const T&>>;
+		if (!has_value()) return U(std::nullopt);
+		return std::invoke(std::forward<F>(func), **this);
+	}
+
+	template <typename F>
+	[[nodiscard]] auto and_then(F&& func) && {
+		using U = std::remove_cvref_t<std::invoke_result_t<F, T>>;
+		if (!has_value()) return U(std::nullopt);
+		return std::invoke(std::forward<F>(func), std::move(**this));
+	}
+
+	template <typename F>
+	[[nodiscard]] auto and_then(F&& func) const&& {
+		using U = std::remove_cvref_t<std::invoke_result_t<F, const T>>;
+		if (!has_value()) return U(std::nullopt);
+		return std::invoke(std::forward<F>(func), std::move(**this));
+	}
+
+	template <typename F>
+	[[nodiscard]] auto transform(F&& func) & {
+		using U = std::remove_cv_t<std::invoke_result_t<F, T&>>;
+		if (!has_value()) return Optional<U>(std::nullopt);
+		return Optional<U>(std::invoke(std::forward<F>(func), **this));
+	}
+
+	template <typename F>
+	[[nodiscard]] auto transform(F&& func) const& {
+		using U = std::remove_cv_t<std::invoke_result_t<F, const T&>>;
+		if (!has_value()) return Optional<U>(std::nullopt);
+		return Optional<U>(std::invoke(std::forward<F>(func), **this));
+	}
+
+	template <typename F>
+	[[nodiscard]] auto transform(F&& func) && {
+		using U = std::remove_cv_t<std::invoke_result_t<F, T>>;
+		if (!has_value()) return Optional<U>(std::nullopt);
+		return Optional<U>(std::invoke(std::forward<F>(func), std::move(**this)));
+	}
+
+	template <typename F>
+	[[nodiscard]] auto transform(F&& func) const&& {
+		using U = std::remove_cv_t<std::invoke_result_t<F, const T>>;
+		if (!has_value()) return Optional<U>(std::nullopt);
+		return Optional<U>(std::invoke(std::forward<F>(func), std::move(**this)));
+	}
+
+	template <typename F>
+	[[nodiscard]] T or_else(F&& func) const& {
+		return *this ? *this : std::invoke(std::forward<F>(func));
+	}
+
+	template <typename F>
+	[[nodiscard]] T or_else(F&& func) && {
+		return *this ? std::move(*this) : std::invoke(std::forward<F>(func));
+	}
+
+	void swap(OptionalWithFlagValue<T>& other) noexcept(std::is_nothrow_move_constructible_v<T> &&
+														std::is_nothrow_swappable_v<T>) {
+		static_assert(std::is_move_constructible_v<T>);
+		if (has_value() && other.has_value()) {
+			std::swap(_value, other._value);
+		} else if (has_value() && !other.has_value()) {
+			other._value = std::move(_value);
+		} else if (!has_value() && other.has_value()) {
+			_value = std::move(other._value);
+		}
+	}
+
+	void reset() noexcept { this->_value = OptionalFlagValue<T>::missing_value; }
+
+	template <typename... Args>
+	T& emplace(Args&&... args) {
+		new (std::addressof(_value)) T(std::forward<Args>(args)...);
+		return _value;
+	}
+
+	template <typename U, typename... Args>
+	T& emplace(std::initializer_list<U> list, Args&&... args) {
+		static_assert(std::is_constructible_v<T, std::initializer_list<U>&, Args&&...>);
+		new (std::addressof(_value)) T(list, std::forward<Args>(args)...);
+		return _value;
+	}
+
+	explicit operator bool() const noexcept { return has_value(); }
+
+	T* operator->() noexcept { return std::addressof(_value); }
+
+	const T* operator->() const noexcept { return std::addressof(_value); }
+
+	T& operator*() & noexcept { return _value; }
+
+	const T& operator*() const& noexcept { return _value; }
+
+	T&& operator*() && noexcept { return std::move(_value); }
+
+	const T&& operator*() const&& noexcept { return std::move(_value); }
+
+	operator std::optional<T>() const noexcept {
+		return has_value() ? std::optional<T>(_value) : std::nullopt;
+	}
+
+	operator std::optional<T>&&() && noexcept {
+		return has_value() ? std::optional<T>(std::move(_value)) : std::nullopt;
+	}
+};
+
+FASTGLTF_EXPORT template <typename T, typename U>
+bool operator==(const OptionalWithFlagValue<T>& lhs, const OptionalWithFlagValue<U>& rhs) {
+	return static_cast<bool>(lhs) == static_cast<bool>(rhs) &&
+		   (!static_cast<bool>(lhs) || *lhs == *rhs);
+}
+
+FASTGLTF_EXPORT template <typename T, typename U>
+bool operator!=(const OptionalWithFlagValue<T>& lhs, const OptionalWithFlagValue<U>& rhs) {
+	return !(lhs == rhs);
+}
+
+FASTGLTF_EXPORT template <typename T, typename U>
+bool operator==(const OptionalWithFlagValue<T>& opt, const U& value) {
+	return opt.has_value() && (*opt) == value;
+}
+
+FASTGLTF_EXPORT template <typename T, typename U>
+bool operator!=(const OptionalWithFlagValue<T>& opt, const U& value) {
+	return !(opt == value);
+}
+
+FASTGLTF_EXPORT template <typename T, typename U>
+bool operator<(const OptionalWithFlagValue<T>& opt, const U& value) {
+	return opt.has_value() && *opt < value;
+}
+
+FASTGLTF_EXPORT template <typename T, typename U>
+bool operator<=(const OptionalWithFlagValue<T>& opt, const U& value) {
+	return opt.has_value() && *opt <= value;
+}
+
+FASTGLTF_EXPORT template <typename T, typename U>
+bool operator>(const OptionalWithFlagValue<T>& opt, const U& value) {
+	return opt.has_value() && *opt > value;
+}
+
+FASTGLTF_EXPORT template <typename T, typename U>
+bool operator>=(const OptionalWithFlagValue<T>& opt, const U& value) {
+	return opt.has_value() && *opt >= value;
+}
 
 #pragma endregion
 
 #pragma region Structs
-	FASTGLTF_EXPORT class URI;
+FASTGLTF_EXPORT class URI;
 
-	/**
-	 * Custom URI class for fastgltf's needs. glTF 2.0 only allows two types of URIs:
-	 *  (1) Data URIs as specified in RFC 2397.
-	 *  (2) Relative paths as specified in RFC 3986.
-	 *
-	 * See https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#uris for details.
-	 * However, the glTF spec allows more broader URIs in client implementations. Therefore,
-	 * this supports all types of URIs as defined in RFC 3986.
-	 *
-	 * This class, unlike fastgltf::URI, only holds a std::string_view to the URI and therefore
-	 * doesn't own the allocation.
-	 */
-	FASTGLTF_EXPORT class URIView {
-		friend class URI;
+/**
+ * Custom URI class for fastgltf's needs. glTF 2.0 only allows two types of URIs:
+ *  (1) Data URIs as specified in RFC 2397.
+ *  (2) Relative paths as specified in RFC 3986.
+ *
+ * See https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#uris for details.
+ * However, the glTF spec allows more broader URIs in client implementations. Therefore,
+ * this supports all types of URIs as defined in RFC 3986.
+ *
+ * This class, unlike fastgltf::URI, only holds a std::string_view to the URI and therefore
+ * doesn't own the allocation.
+ */
+FASTGLTF_EXPORT class URIView {
+	friend class URI;
 
-		std::string_view view;
+	std::string_view view;
 
-		std::string_view _scheme;
-		std::string_view _path;
+	std::string_view _scheme;
+	std::string_view _path;
 
-		std::string_view _userinfo;
-		std::string_view _host;
-		std::string_view _port;
+	std::string_view _userinfo;
+	std::string_view _host;
+	std::string_view _port;
 
-		std::string_view _query;
-		std::string_view _fragment;
+	std::string_view _query;
+	std::string_view _fragment;
 
-		bool _valid = true;
+	bool _valid = true;
 
-		void parse();
+	void parse();
 
-		[[nodiscard]] auto data() const noexcept -> const char*;
+	[[nodiscard]] auto data() const noexcept -> const char*;
 
-	public:
-		explicit URIView() noexcept;
-		explicit URIView(std::string_view uri) noexcept;
-		URIView(const URIView& other) noexcept;
+   public:
+	explicit URIView() noexcept;
+	explicit URIView(std::string_view uri) noexcept;
+	URIView(const URIView& other) noexcept;
 
-		URIView& operator=(const URIView& other);
-		URIView& operator=(std::string_view other);
+	URIView& operator=(const URIView& other);
+	URIView& operator=(std::string_view other);
 
-		[[nodiscard]] auto string() const noexcept -> std::string_view;
+	[[nodiscard]] auto string() const noexcept -> std::string_view;
 
-		[[nodiscard]] auto scheme() const noexcept -> std::string_view;
-		[[nodiscard]] auto userinfo() const noexcept -> std::string_view;
-		[[nodiscard]] auto host() const noexcept -> std::string_view;
-		[[nodiscard]] auto port() const noexcept -> std::string_view;
-		[[nodiscard]] auto path() const noexcept -> std::string_view;
-		[[nodiscard]] auto query() const noexcept -> std::string_view;
-		[[nodiscard]] auto fragment() const noexcept -> std::string_view;
+	[[nodiscard]] auto scheme() const noexcept -> std::string_view;
+	[[nodiscard]] auto userinfo() const noexcept -> std::string_view;
+	[[nodiscard]] auto host() const noexcept -> std::string_view;
+	[[nodiscard]] auto port() const noexcept -> std::string_view;
+	[[nodiscard]] auto path() const noexcept -> std::string_view;
+	[[nodiscard]] auto query() const noexcept -> std::string_view;
+	[[nodiscard]] auto fragment() const noexcept -> std::string_view;
 
-		[[nodiscard]] auto fspath() const -> std::filesystem::path;
-		[[nodiscard]] bool valid() const noexcept;
-		[[nodiscard]] bool isLocalPath() const noexcept;
-		[[nodiscard]] bool isDataUri() const noexcept;
+	[[nodiscard]] auto fspath() const -> std::filesystem::path;
+	[[nodiscard]] bool valid() const noexcept;
+	[[nodiscard]] bool isLocalPath() const noexcept;
+	[[nodiscard]] bool isDataUri() const noexcept;
+};
+
+/**
+ * Custom URI class for fastgltf's needs. glTF 2.0 only allows two types of URIs:
+ *  (1) Data URIs as specified in RFC 2397.
+ *  (2) Relative paths as specified in RFC 3986.
+ *
+ * See https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#uris for details.
+ * However, the glTF spec allows more broader URIs in client implementations. Therefore,
+ * this supports all types of URIs as defined in RFC 3986.
+ *
+ * This class, unlike fastgltf::URIView, holds a std::string which contains the URI. It
+ * also decodes any percent-encoded characters.
+ */
+class URI {
+	std::string uri;
+	URIView view;
+
+	void readjustViews(const URIView& other);
+
+   public:
+	explicit URI() noexcept;
+
+	explicit URI(std::string uri) noexcept;
+	explicit URI(std::string_view uri) noexcept;
+	explicit URI(const URIView& view) noexcept;
+
+	URI(const URI& other);
+	URI(URI&& other) noexcept;
+
+	URI& operator=(const URI& other);
+	URI& operator=(const URIView& other);
+	URI& operator=(URI&& other) noexcept;
+
+	operator URIView() const noexcept;
+
+	static void decodePercents(std::string& x) noexcept;
+
+	[[nodiscard]] auto string() const noexcept -> std::string_view;
+	[[nodiscard]] auto c_str() const noexcept -> const char*;
+
+	[[nodiscard]] auto scheme() const noexcept -> std::string_view;
+	[[nodiscard]] auto userinfo() const noexcept -> std::string_view;
+	[[nodiscard]] auto host() const noexcept -> std::string_view;
+	[[nodiscard]] auto port() const noexcept -> std::string_view;
+	[[nodiscard]] auto path() const noexcept -> std::string_view;
+	[[nodiscard]] auto query() const noexcept -> std::string_view;
+	[[nodiscard]] auto fragment() const noexcept -> std::string_view;
+
+	[[nodiscard]] auto fspath() const -> std::filesystem::path;
+	[[nodiscard]] bool valid() const noexcept;
+	[[nodiscard]] bool isLocalPath() const noexcept;
+	[[nodiscard]] bool isDataUri() const noexcept;
+};
+
+/**
+ * Represents the minimum and maximum bounds for glTF accessors in a better interface to avoid
+ * heavy usage of std::variant, which can pollute the user's code needlessly.
+ */
+FASTGLTF_EXPORT class AccessorBoundsArray {
+   public:
+	enum class BoundsType {
+		int64,
+		float64,
+	};
+
+	template <typename T>
+	using is_valid_type = is_any_of<T, std::int64_t, double>;
+	template <typename T>
+	static constexpr auto is_valid_type_v = is_valid_type<T>::value;
+
+   private:
+	std::size_t len;
+	BoundsType dataType;
+	union {
+		std::unique_ptr<std::int64_t[]> int64_buffer;
+		std::unique_ptr<double[]> float64_buffer;
+	};
+
+   public:
+	explicit AccessorBoundsArray(const std::size_t len, const BoundsType type)
+		: len(len), dataType(type) {
+		switch (dataType) {
+			case BoundsType::int64:
+				new (&int64_buffer) std::unique_ptr<std::int64_t[]>(new std::int64_t[len]());
+				break;
+			case BoundsType::float64:
+				new (&float64_buffer) std::unique_ptr<double[]>(new double[len]());
+				break;
+			default: FASTGLTF_UNREACHABLE
+		}
+	}
+
+	template <typename T>
+	requires is_valid_type_v<T>
+	static AccessorBoundsArray ForType(const std::size_t len) {
+		if constexpr (std::is_same_v<T, std::int64_t>) {
+			return AccessorBoundsArray(len, BoundsType::int64);
+		} else if constexpr (std::is_same_v<T, double>) {
+			return AccessorBoundsArray(len, BoundsType::float64);
+		}
+		FASTGLTF_UNREACHABLE
+	}
+
+	~AccessorBoundsArray() {
+		switch (dataType) {
+			case BoundsType::int64:   std::destroy_at(&int64_buffer); break;
+			case BoundsType::float64: std::destroy_at(&float64_buffer); break;
+			default:                  FASTGLTF_UNREACHABLE
+		}
+	}
+
+	AccessorBoundsArray(const AccessorBoundsArray& other) = delete;
+	AccessorBoundsArray(AccessorBoundsArray&& other) noexcept
+		: len(other.len), dataType(other.dataType) {
+		switch (other.dataType) {
+			case BoundsType::int64:
+				new (&int64_buffer) std::unique_ptr(std::move(other.int64_buffer));
+				break;
+			case BoundsType::float64:
+				new (&float64_buffer) std::unique_ptr(std::move(other.float64_buffer));
+				break;
+			default: FASTGLTF_UNREACHABLE
+		}
+	}
+
+	auto& operator=(const AccessorBoundsArray& other) = delete;
+	auto& operator=(AccessorBoundsArray&& other) noexcept {
+		len = other.len;
+		dataType = other.dataType;
+		switch (dataType) {
+			case BoundsType::int64:   std::destroy_at(&int64_buffer); break;
+			case BoundsType::float64: std::destroy_at(&float64_buffer); break;
+			default:                  FASTGLTF_UNREACHABLE
+		}
+		switch (other.dataType) {
+			case BoundsType::int64:
+				new (&int64_buffer) std::unique_ptr(std::move(other.int64_buffer));
+				break;
+			case BoundsType::float64:
+				new (&float64_buffer) std::unique_ptr(std::move(other.float64_buffer));
+				break;
+			default: FASTGLTF_UNREACHABLE
+		}
+		return *this;
+	}
+
+	[[nodiscard]] BoundsType type() const noexcept { return dataType; }
+
+	template <typename T>
+	requires is_valid_type_v<T>
+	[[nodiscard]] bool isType() const noexcept {
+		switch (dataType) {
+			case BoundsType::int64:   return std::is_same_v<T, std::int64_t>;
+			case BoundsType::float64: return std::is_same_v<T, double>;
+			default:                  return false;
+		}
+	}
+
+	[[nodiscard]] std::size_t size() const noexcept { return len; }
+
+	template <typename T>
+	requires is_valid_type_v<T>
+	[[nodiscard]] auto* data() noexcept {
+		assert(isType<T>());
+		if constexpr (std::is_same_v<T, std::int64_t>) {
+			return int64_buffer.get();
+		} else if constexpr (std::is_same_v<T, double>) {
+			return float64_buffer.get();
+		}
+		FASTGLTF_UNREACHABLE
+	}
+
+	template <typename T>
+	requires is_valid_type_v<T>
+	[[nodiscard]] const auto* data() const noexcept {
+		assert(isType<T>());
+		if constexpr (std::is_same_v<T, std::int64_t>) {
+			return int64_buffer.get();
+		} else if constexpr (std::is_same_v<T, double>) {
+			return float64_buffer.get();
+		}
+		FASTGLTF_UNREACHABLE
+	}
+
+	template <typename T>
+	requires is_valid_type_v<T>
+	[[nodiscard]] T get(const std::size_t pos) const {
+		assert(pos < len && isType<T>());
+		return data<T>()[pos];
+	}
+
+	template <typename T>
+	requires is_valid_type_v<T>
+	void set(const std::size_t pos, const T value) {
+		assert(pos < len && isType<T>());
+		data<T>()[pos] = value;
+	}
+};
+
+FASTGLTF_EXPORT inline constexpr std::size_t dynamic_extent =
+	std::numeric_limits<std::size_t>::max();
+
+FASTGLTF_EXPORT using CustomBufferId = std::uint64_t;
+
+/**
+ * Namespace for structs that describe individual sources of data for images and/or buffers.
+ */
+namespace sources {
+FASTGLTF_EXPORT struct BufferView {
+	std::size_t bufferViewIndex;
+	MimeType mimeType = MimeType::None;
+};
+
+FASTGLTF_EXPORT struct URI {
+	std::size_t fileByteOffset;
+	fastgltf::URI uri;
+	MimeType mimeType = MimeType::None;
+};
+
+FASTGLTF_EXPORT struct Array {
+	StaticVector<std::byte> bytes;
+	MimeType mimeType = MimeType::None;
+};
+
+/** @note This type is not used by the fastgltf parser and is only used for exporting. Use
+ * sources::Array instead when importing intead. */
+FASTGLTF_EXPORT struct Vector {
+	std::vector<std::byte> bytes;
+	MimeType mimeType = MimeType::None;
+};
+
+FASTGLTF_EXPORT struct CustomBuffer {
+	CustomBufferId id;
+	MimeType mimeType = MimeType::None;
+};
+
+FASTGLTF_EXPORT struct ByteView {
+	std::span<const std::byte> bytes;
+	MimeType mimeType = MimeType::None;
+};
+
+FASTGLTF_EXPORT struct Fallback {};
+}  // namespace sources
+
+/**
+ * Represents the data source of a buffer or image. These could be a buffer view, a file path
+ * (including offsets), a StaticVector (if #Options::LoadExternalBuffers or #Options::LoadGLBBuffers
+ * was specified), or the ID of a custom buffer.
+ *
+ * @note As a user, you should never encounter this variant holding the std::monostate, as that
+ * would be an ill-formed glTF, which fastgltf already checks for while parsing.
+ *
+ * @note For buffers, this variant will never hold a sources::BufferView, as only images are able to
+ * reference buffer views as a source.
+ */
+FASTGLTF_EXPORT using DataSource =
+	std::variant<std::monostate, sources::BufferView, sources::URI, sources::Array, sources::Vector,
+				 sources::CustomBuffer, sources::ByteView, sources::Fallback>;
+
+FASTGLTF_EXPORT struct AnimationChannel {
+	std::size_t samplerIndex;
+	Optional<std::size_t> nodeIndex;
+	AnimationPath path;
+};
+
+FASTGLTF_EXPORT struct AnimationSampler {
+	std::size_t inputAccessor;
+	std::size_t outputAccessor;
+	AnimationInterpolation interpolation = AnimationInterpolation::Linear;
+};
+
+FASTGLTF_EXPORT struct Animation {
+	FASTGLTF_FG_PMR_NS::MaybeSmallVector<AnimationChannel> channels;
+	FASTGLTF_FG_PMR_NS::MaybeSmallVector<AnimationSampler> samplers;
+
+	FASTGLTF_STD_PMR_NS::string name;
+};
+
+FASTGLTF_EXPORT struct AssetInfo {
+	FASTGLTF_STD_PMR_NS::string gltfVersion;
+	FASTGLTF_STD_PMR_NS::string copyright;
+	FASTGLTF_STD_PMR_NS::string generator;
+};
+
+FASTGLTF_EXPORT struct Camera {
+	struct Orthographic {
+		num xmag;
+		num ymag;
+		num zfar;
+		num znear;
+	};
+	struct Perspective {
+		Optional<num> aspectRatio;
+		num yfov;
+		// If omitted, use an infinite projection matrix.
+		Optional<num> zfar;
+		num znear;
 	};
 
 	/**
-	 * Custom URI class for fastgltf's needs. glTF 2.0 only allows two types of URIs:
-	 *  (1) Data URIs as specified in RFC 2397.
-	 *  (2) Relative paths as specified in RFC 3986.
-	 *
-	 * See https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#uris for details.
-	 * However, the glTF spec allows more broader URIs in client implementations. Therefore,
-	 * this supports all types of URIs as defined in RFC 3986.
-	 *
-	 * This class, unlike fastgltf::URIView, holds a std::string which contains the URI. It
-	 * also decodes any percent-encoded characters.
+	 * Variant holding either a perspective or a orthographic camera. Use std::holds_alternative
+	 * and/or std::get_if to figure out which camera type is being used.
 	 */
-	class URI {
-		std::string uri;
-		URIView view;
+	std::variant<Perspective, Orthographic> camera;
+	FASTGLTF_STD_PMR_NS::string name;
+};
 
-		void readjustViews(const URIView& other);
+FASTGLTF_EXPORT struct Skin {
+	Optional<std::size_t> inverseBindMatrices;
+	Optional<std::size_t> skeleton;
+	FASTGLTF_FG_PMR_NS::MaybeSmallVector<std::size_t> joints;
 
-	public:
-		explicit URI() noexcept;
+	FASTGLTF_STD_PMR_NS::string name;
+};
 
-		explicit URI(std::string uri) noexcept;
-		explicit URI(std::string_view uri) noexcept;
-		explicit URI(const URIView& view) noexcept;
+FASTGLTF_EXPORT struct Sampler {
+	Optional<Filter> magFilter;
+	Optional<Filter> minFilter;
+	Wrap wrapS = Wrap::Repeat;
+	Wrap wrapT = Wrap::Repeat;
 
-		URI(const URI& other);
-		URI(URI&& other) noexcept;
+	FASTGLTF_STD_PMR_NS::string name;
+};
 
-		URI& operator=(const URI& other);
-		URI& operator=(const URIView& other);
-		URI& operator=(URI&& other) noexcept;
+FASTGLTF_EXPORT struct Scene {
+	FASTGLTF_FG_PMR_NS::MaybeSmallVector<std::size_t> nodeIndices;
 
-		operator URIView() const noexcept;
+	FASTGLTF_STD_PMR_NS::string name;
+};
 
-		static void decodePercents(std::string& x) noexcept;
+FASTGLTF_EXPORT struct TRS {
+	math::fvec3 translation = math::fvec3(0.f);
+	math::fquat rotation = math::fquat(0.f, 0.f, 0.f, 1.f);
+	math::fvec3 scale = math::fvec3(1.f);
+};
 
-		[[nodiscard]] auto string() const noexcept -> std::string_view;
-		[[nodiscard]] auto c_str() const noexcept -> const char*;
-
-		[[nodiscard]] auto scheme() const noexcept -> std::string_view;
-		[[nodiscard]] auto userinfo() const noexcept -> std::string_view;
-		[[nodiscard]] auto host() const noexcept -> std::string_view;
-		[[nodiscard]] auto port() const noexcept -> std::string_view;
-		[[nodiscard]] auto path() const noexcept -> std::string_view;
-		[[nodiscard]] auto query() const noexcept -> std::string_view;
-		[[nodiscard]] auto fragment() const noexcept -> std::string_view;
-
-		[[nodiscard]] auto fspath() const -> std::filesystem::path;
-		[[nodiscard]] bool valid() const noexcept;
-		[[nodiscard]] bool isLocalPath() const noexcept;
-		[[nodiscard]] bool isDataUri() const noexcept;
-	};
-
-	/**
-	 * Represents the minimum and maximum bounds for glTF accessors in a better interface to avoid
-	 * heavy usage of std::variant, which can pollute the user's code needlessly.
-	 */
-	FASTGLTF_EXPORT class AccessorBoundsArray {
-	public:
-		enum class BoundsType {
-			int64,
-			float64,
-		};
-
-		template <typename T>
-		using is_valid_type = is_any_of<T, std::int64_t, double>;
-		template <typename T>
-		static constexpr auto is_valid_type_v = is_valid_type<T>::value;
-
-	private:
-		std::size_t len;
-		BoundsType dataType;
-		union {
-			std::unique_ptr<std::int64_t[]> int64_buffer;
-			std::unique_ptr<double[]> float64_buffer;
-		};
-
-	public:
-		explicit AccessorBoundsArray(const std::size_t len, const BoundsType type) : len(len), dataType(type) {
-			switch (dataType) {
-				case BoundsType::int64:
-					new (&int64_buffer) std::unique_ptr<std::int64_t[]>(new std::int64_t[len]());
-					break;
-				case BoundsType::float64:
-					new (&float64_buffer) std::unique_ptr<double[]>(new double[len]());
-					break;
-				default:
-					FASTGLTF_UNREACHABLE
-			}
-		}
-
-		template <typename T>
-		requires is_valid_type_v<T>
-		static AccessorBoundsArray ForType(const std::size_t len) {
-			if constexpr (std::is_same_v<T, std::int64_t>) {
-				return AccessorBoundsArray(len, BoundsType::int64);
-			} else if constexpr(std::is_same_v<T, double>) {
-				return AccessorBoundsArray(len, BoundsType::float64);
-			}
-			FASTGLTF_UNREACHABLE
-		}
-
-		~AccessorBoundsArray() {
-			switch (dataType) {
-				case BoundsType::int64:
-					std::destroy_at(&int64_buffer);
-					break;
-				case BoundsType::float64:
-					std::destroy_at(&float64_buffer);
-					break;
-				default:
-					FASTGLTF_UNREACHABLE
-			}
-		}
-
-		AccessorBoundsArray(const AccessorBoundsArray& other) = delete;
-		AccessorBoundsArray(AccessorBoundsArray&& other) noexcept
-			: len(other.len), dataType(other.dataType) {
-			switch (other.dataType) {
-				case BoundsType::int64:
-					new (&int64_buffer) std::unique_ptr(std::move(other.int64_buffer));
-					break;
-				case BoundsType::float64:
-					new (&float64_buffer) std::unique_ptr(std::move(other.float64_buffer));
-					break;
-				default:
-					FASTGLTF_UNREACHABLE
-			}
-		}
-
-		auto& operator=(const AccessorBoundsArray& other) = delete;
-		auto& operator=(AccessorBoundsArray&& other) noexcept {
-			len = other.len;
-			dataType = other.dataType;
-			switch (dataType) {
-				case BoundsType::int64:
-					std::destroy_at(&int64_buffer);
-					break;
-				case BoundsType::float64:
-					std::destroy_at(&float64_buffer);
-					break;
-				default:
-					FASTGLTF_UNREACHABLE
-			}
-			switch (other.dataType) {
-				case BoundsType::int64:
-					new (&int64_buffer) std::unique_ptr(std::move(other.int64_buffer));
-					break;
-				case BoundsType::float64:
-					new (&float64_buffer) std::unique_ptr(std::move(other.float64_buffer));
-					break;
-				default:
-					FASTGLTF_UNREACHABLE
-			}
-			return *this;
-		}
-
-		[[nodiscard]] BoundsType type() const noexcept {
-			return dataType;
-		}
-
-		template <typename T>
-		requires is_valid_type_v<T>
-		[[nodiscard]] bool isType() const noexcept {
-			switch (dataType) {
-				case BoundsType::int64:
-					return std::is_same_v<T, std::int64_t>;
-				case BoundsType::float64:
-					return std::is_same_v<T, double>;
-				default:
-					return false;
-			}
-		}
-
-		[[nodiscard]] std::size_t size() const noexcept {
-			return len;
-		}
-
-		template <typename T>
-		requires is_valid_type_v<T>
-		[[nodiscard]] auto* data() noexcept {
-			assert(isType<T>());
-			if constexpr (std::is_same_v<T, std::int64_t>) {
-				return int64_buffer.get();
-			} else if constexpr (std::is_same_v<T, double>) {
-				return float64_buffer.get();
-			}
-			FASTGLTF_UNREACHABLE
-		}
-
-		template <typename T>
-		requires is_valid_type_v<T>
-		[[nodiscard]] const auto* data() const noexcept {
-			assert(isType<T>());
-			if constexpr (std::is_same_v<T, std::int64_t>) {
-				return int64_buffer.get();
-			} else if constexpr (std::is_same_v<T, double>) {
-				return float64_buffer.get();
-			}
-			FASTGLTF_UNREACHABLE
-		}
-
-		template <typename T>
-		requires is_valid_type_v<T>
-		[[nodiscard]] T get(const std::size_t pos) const {
-			assert(pos < len && isType<T>());
-			return data<T>()[pos];
-		}
-
-		template <typename T>
-		requires is_valid_type_v<T>
-		void set(const std::size_t pos, const T value) {
-			assert(pos < len && isType<T>());
-			data<T>()[pos] = value;
-		}
-	};
-
-	FASTGLTF_EXPORT inline constexpr std::size_t dynamic_extent = std::numeric_limits<std::size_t>::max();
-
-    FASTGLTF_EXPORT using CustomBufferId = std::uint64_t;
-
-    /**
-     * Namespace for structs that describe individual sources of data for images and/or buffers.
-     */
-    namespace sources {
-        FASTGLTF_EXPORT struct BufferView {
-            std::size_t bufferViewIndex;
-            MimeType mimeType = MimeType::None;
-        };
-
-        FASTGLTF_EXPORT struct URI {
-            std::size_t fileByteOffset;
-            fastgltf::URI uri;
-            MimeType mimeType = MimeType::None;
-        };
-
-        FASTGLTF_EXPORT struct Array {
-            StaticVector<std::byte> bytes;
-            MimeType mimeType = MimeType::None;
-        };
-
-		/** @note This type is not used by the fastgltf parser and is only used for exporting. Use sources::Array instead when importing intead. */
-		FASTGLTF_EXPORT struct Vector {
-			std::vector<std::byte> bytes;
-			MimeType mimeType = MimeType::None;
-		};
-
-        FASTGLTF_EXPORT struct CustomBuffer {
-            CustomBufferId id;
-            MimeType mimeType = MimeType::None;
-        };
-
-        FASTGLTF_EXPORT struct ByteView {
-            std::span<const std::byte> bytes;
-            MimeType mimeType = MimeType::None;
-        };
-
-		FASTGLTF_EXPORT struct Fallback {};
-    } // namespace sources
-
-    /**
-     * Represents the data source of a buffer or image. These could be a buffer view, a file path
-     * (including offsets), a StaticVector (if #Options::LoadExternalBuffers or #Options::LoadGLBBuffers
-     * was specified), or the ID of a custom buffer.
-     *
-     * @note As a user, you should never encounter this variant holding the std::monostate, as that would be an ill-formed glTF,
-     * which fastgltf already checks for while parsing.
-     *
-     * @note For buffers, this variant will never hold a sources::BufferView, as only images are able to reference buffer views as a source.
-     */
-    FASTGLTF_EXPORT using DataSource = std::variant<std::monostate, sources::BufferView, sources::URI, sources::Array, sources::Vector, sources::CustomBuffer, sources::ByteView, sources::Fallback>;
-
-    FASTGLTF_EXPORT struct AnimationChannel {
-        std::size_t samplerIndex;
-        Optional<std::size_t> nodeIndex;
-        AnimationPath path;
-    };
-
-    FASTGLTF_EXPORT struct AnimationSampler {
-        std::size_t inputAccessor;
-        std::size_t outputAccessor;
-        AnimationInterpolation interpolation = AnimationInterpolation::Linear;
-    };
-
-    FASTGLTF_EXPORT struct Animation {
-	    FASTGLTF_FG_PMR_NS::MaybeSmallVector<AnimationChannel> channels;
-	    FASTGLTF_FG_PMR_NS::MaybeSmallVector<AnimationSampler> samplers;
-
-        FASTGLTF_STD_PMR_NS::string name;
-    };
-
-    FASTGLTF_EXPORT struct AssetInfo {
-        FASTGLTF_STD_PMR_NS::string gltfVersion;
-        FASTGLTF_STD_PMR_NS::string copyright;
-        FASTGLTF_STD_PMR_NS::string generator;
-    };
-
-    FASTGLTF_EXPORT struct Camera {
-        struct Orthographic {
-            num xmag;
-            num ymag;
-            num zfar;
-            num znear;
-        };
-        struct Perspective {
-            Optional<num> aspectRatio;
-            num yfov;
-            // If omitted, use an infinite projection matrix.
-            Optional<num> zfar;
-            num znear;
-        };
-
-        /**
-         * Variant holding either a perspective or a orthographic camera. Use std::holds_alternative
-         * and/or std::get_if to figure out which camera type is being used.
-         */
-        std::variant<Perspective, Orthographic> camera;
-        FASTGLTF_STD_PMR_NS::string name;
-    };
-
-    FASTGLTF_EXPORT struct Skin {
-	    Optional<std::size_t> inverseBindMatrices;
-        Optional<std::size_t> skeleton;
-        FASTGLTF_FG_PMR_NS::MaybeSmallVector<std::size_t> joints;
-
-        FASTGLTF_STD_PMR_NS::string name;
-    };
-
-    FASTGLTF_EXPORT struct Sampler {
-	    Optional<Filter> magFilter;
-	    Optional<Filter> minFilter;
-        Wrap wrapS = Wrap::Repeat;
-        Wrap wrapT = Wrap::Repeat;
-
-        FASTGLTF_STD_PMR_NS::string name;
-    };
-
-    FASTGLTF_EXPORT struct Scene {
-	    FASTGLTF_FG_PMR_NS::MaybeSmallVector<std::size_t> nodeIndices;
-
-        FASTGLTF_STD_PMR_NS::string name;
-    };
-
-	FASTGLTF_EXPORT struct TRS {
-		math::fvec3 translation = math::fvec3(0.f);
-		math::fquat rotation = math::fquat(0.f, 0.f, 0.f, 1.f);
-		math::fvec3 scale = math::fvec3(1.f);
-	};
-
-	FASTGLTF_EXPORT struct Attribute {
-		FASTGLTF_STD_PMR_NS::string name;
-		std::size_t accessorIndex;
-	};
+FASTGLTF_EXPORT struct Attribute {
+	FASTGLTF_STD_PMR_NS::string name;
+	std::size_t accessorIndex;
+};
 
 #if FASTGLTF_ENABLE_KHR_IMPLICIT_SHAPES
-	FASTGLTF_EXPORT struct SphereShape {
-		num radius = 0.5;
-	};
+FASTGLTF_EXPORT struct SphereShape {
+	num radius = 0.5;
+};
 
-	FASTGLTF_EXPORT struct BoxShape {
-		math::fvec3 size = { 1, 1, 1 };
-	};
+FASTGLTF_EXPORT struct BoxShape {
+	math::fvec3 size = {1, 1, 1};
+};
 
-	FASTGLTF_EXPORT struct CapsuleShape {
-		num height = 0.5;
+FASTGLTF_EXPORT struct CapsuleShape {
+	num height = 0.5;
 
-		num radiusBottom = 0.25;
+	num radiusBottom = 0.25;
 
-		num radiusTop = 0.25;
-	};
+	num radiusTop = 0.25;
+};
 
-	FASTGLTF_EXPORT struct CylinderShape {
-		num height = 0.5;
+FASTGLTF_EXPORT struct CylinderShape {
+	num height = 0.5;
 
-		num radiusBottom = 0.25;
+	num radiusBottom = 0.25;
 
-		num radiusTop = 0.25;
-	};
+	num radiusTop = 0.25;
+};
 
-	using Shape = std::variant<SphereShape, BoxShape, CapsuleShape, CylinderShape>;
+using Shape = std::variant<SphereShape, BoxShape, CapsuleShape, CylinderShape>;
 #endif
 
 #if FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES
-    FASTGLTF_EXPORT struct Motion {
-        /**
-         * When true, treat the rigid body as having infinite mass. Its velocity will be constant during simulation
-         */
-        bool isKinematic = false;
-
-        /**
-         * The mass of the rigid body. Larger values imply the rigid body is harder to move
-         */
-        Optional<num> mass;
-
-		/**
-		 * Center of mass of the rigid body in node space
-		 */
-		math::fvec3 centerOfMass = { 0, 0, 0 };
-
-		/**
-		 * The principal moments of inertia. Larger values imply the rigid body is harder to rotate
-		 */
-		Optional<math::fvec3> inertialDiagonal;
-
-        /**
-         * The quaternion rotating from inertia major axis space to node space
-         */
-        Optional<math::fvec4> inertialOrientation;
-
-        /**
-         * Initial linear velocity of the rigid body in node space
-         */
-        math::fvec3 linearVelocity = {0, 0, 0};
-
-        /**
-         * Initial angular velocity of the rigid body in node space
-         */
-        math::fvec3 angularVelocity = {0, 0, 0};
-
-        /**
-         * A multiplier applied to the acceleration due to gravity
-         */
-        num gravityFactor = 1;
-	};
-
-	FASTGLTF_EXPORT struct Geometry {
-        /**
-         * The index of a top-level `KHR_implicit_shapes.shape`, providing an implicit representation of the geometry
-         */
-        Optional<size_t> shape;
-
-        /**
-         * The index of a glTF `node` which provides a mesh representation of the geometry
-         */
-        Optional<size_t> node;
-
-        /**
-         * Flag to indicate that the geometry should be a convex hull.
-         */
-        bool convexHull;
-	};
-
-	FASTGLTF_EXPORT struct PhysicsMaterial {
-		num staticFriction = 0.6f;
-
-		num dynamicFriction = 0.6f;
-
-		num restitution = 0.0f;
-
-		CombineMode frictionCombine;
-
-		CombineMode restitutionCombine;
-	};
-
-	FASTGLTF_EXPORT struct CollisionFilter {
-        /**
-         * An array of arbitrary strings indicating the "system" a node is a member of
-         */
-        FASTGLTF_FG_PMR_NS::MaybeSmallVector<FASTGLTF_STD_PMR_NS::string> collisionSystems;
-
-        /**
-         * An array of strings representing the systems which this node can _not_ collide with
-         */
-        FASTGLTF_FG_PMR_NS::MaybeSmallVector<FASTGLTF_STD_PMR_NS::string> notCollideWithSystems;
-
-        /**
-         * An array of strings representing the systems which this node can collide with
-         */
-        FASTGLTF_FG_PMR_NS::MaybeSmallVector<FASTGLTF_STD_PMR_NS::string> collideWithSystems;
-	};
-
-	FASTGLTF_EXPORT struct Collider {
-        /**
-         * An object describing the geometrical representation of this collider
-         */
-        Geometry geometry;
-
-        /**
-         * Indexes into the top-level `physicsMaterials` and describes how the collider should respond to collisions
-         */
-        Optional<std::size_t> physicsMaterial;
-
-        /**
-         * Indexes into the top-level `collisionFilters` and describes a filter which determines if this collider should perform collision detection against another collider
-         */
-        Optional<std::size_t> collisionFilter;
-	};
-
-	FASTGLTF_EXPORT struct GeometryTrigger {
-		/**
-		 * An object describing the geometrical representation of this collider
-		 */
-		Geometry geometry;
-
-		/**
-		 * Indexes into the top-level `collisionFilters` and describes a filter which determines if this collider should perform collision detection against another collider
-		 */
-		Optional<std::size_t> collisionFilter;
-	};
-
-	FASTGLTF_EXPORT struct NodeTrigger {
-
-		/**
-		 * For compound triggers, the set of descendant glTF nodes with a trigger property that make up this compound trigger
-		 */
-		FASTGLTF_FG_PMR_NS::MaybeSmallVector<std::size_t> nodes;
-	};
-
-	FASTGLTF_EXPORT struct JointLimit {
-		/**
-		 * The linear axes to constrain (0=X, 1=Y, 2=Z)
-		 */
-		FASTGLTF_FG_PMR_NS::SmallVector<uint8_t, 3> linearAxes;
-
-		/**
-		 * The angular axes to constrain (0=X, 1=Y, 2=Z)
-		 */
-		FASTGLTF_FG_PMR_NS::SmallVector<uint8_t, 3> angularAxes;
-
-		/**
-		 * The minimum allowed relative distance/angle
-		 */
-		Optional<num> min;
-
-		/**
-		 * The maximum allowed relative distance/angle
-		 */
-		Optional<num> max;
-
-		/**
-		 * Optional softness of the limits when beyond the limits
-		 */
-		Optional<num> stiffness;
-
-		/**
-		 * Optional spring damping applied when beyond the limits
-		 */
-		num damping = 0;
-	};
-
-	FASTGLTF_EXPORT struct JointDrive {
-        /**
-         * Determines if the drive affects is a `linear` or `angular` drive
-         */
-        DriveType type;
-
-        /**
-         * Determines if the drive is operating in `force` or `acceleration` mode
-         */
-        DriveMode mode;
-
-        /**
-         * The index of the axis which this drive affects
-         */
-        uint8_t axis;
-
-        /**
-         * The maximum force that the drive can apply
-         */
-        num maxForce;
-
-        /**
-         * The desired relative target between the pivot axes
-         */
-        num positionTarget;
-
-        /**
-         * The desired relative velocity of the pivot axes
-         */
-        num velocityTarget;
-
-        /**
-         * The drive's stiffness, used to achieve the position target
-         */
-        num stiffness = 0;
-
-        /**
-         * The damping factor applied to reach the velocity target
-         */
-        num damping = 0;
-	};
-
-	FASTGLTF_EXPORT struct PhysicsJoint {
-		FASTGLTF_FG_PMR_NS::MaybeSmallVector<JointLimit> limits;
-
-        /**
-         * Each drive specifies a force to apply along a single axis
-         */
-        FASTGLTF_FG_PMR_NS::MaybeSmallVector<JointDrive> drives;
-	};
-
-	FASTGLTF_EXPORT struct Joint {
-	    std::size_t connectedNode;
-
-		std::size_t joint;
-
-		bool enableCollision = false;
-	};
-
-    FASTGLTF_EXPORT struct PhysicsRigidBody {
-		Optional<Motion> motion;
-
-		Optional<Collider> collider;
-
-		Optional<std::variant<GeometryTrigger, NodeTrigger>> trigger;
-
-		Optional<Joint> joint;
-	};
-#endif
-
-    FASTGLTF_EXPORT struct Node {
-        Optional<std::size_t> meshIndex;
-	    Optional<std::size_t> skinIndex;
-	    Optional<std::size_t> cameraIndex;
-
-        /**
-         * Only ever non-empty when KHR_lights_punctual is enabled and used by the asset.
-         */
-        Optional<std::size_t> lightIndex;
-
-	    FASTGLTF_FG_PMR_NS::MaybeSmallVector<std::size_t> children;
-	    FASTGLTF_FG_PMR_NS::MaybeSmallVector<num> weights;
-
-        /**
-         * Variant holding either the three TRS components; transform, rotation, and scale, or a
-         * transformation matrix, which cannot skew or shear. The latter can be decomposed into
-         * the TRS components by specifying Options::DecomposeNodeMatrices.
-         */
-        std::variant<TRS, math::fmat4x4> transform;
-
-        /**
-         * Only ever non-empty when EXT_mesh_gpu_instancing is enabled and used by the asset.
-         */
-        FASTGLTF_STD_PMR_NS::vector<Attribute> instancingAttributes;
-
-        FASTGLTF_STD_PMR_NS::string name;
-
-#if FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES
-		std::unique_ptr<PhysicsRigidBody> physicsRigidBody;
-#endif
-
-        [[nodiscard]] auto findInstancingAttribute(const std::string_view attributeName) noexcept {
-            for (auto it = instancingAttributes.begin(); it != instancingAttributes.end(); ++it) {
-                if (it->name == attributeName)
-                    return it;
-            }
-            return instancingAttributes.end();
-        }
-
-        [[nodiscard]] auto findInstancingAttribute(const std::string_view attributeName) const noexcept {
-            for (auto it = instancingAttributes.cbegin(); it != instancingAttributes.cend(); ++it) {
-                if (it->name == attributeName)
-                    return it;
-            }
-            return instancingAttributes.cend();
-        }
-    };
-
-	struct DracoCompressedPrimitive {
-		std::size_t bufferView;
-		FASTGLTF_FG_PMR_NS::SmallVector<Attribute, 4> attributes;
-
-		[[nodiscard]] auto findAttribute(const std::string_view name) noexcept {
-			for (auto* it = attributes.begin(); it != attributes.end(); ++it) {
-				if (it->name == name)
-					return it;
-			}
-			return attributes.end();
-		}
-
-		[[nodiscard]] auto findAttribute(const std::string_view name) const noexcept {
-			for (const auto* it = attributes.cbegin(); it != attributes.cend(); ++it) {
-				if (it->name == name)
-					return it;
-			}
-			return attributes.cend();
-		}
-	};
-
-    FASTGLTF_EXPORT struct Primitive {
-		// Instead of a map, we have a list of attributes here. Each pair contains
-		// the name of the attribute and the corresponding accessor index.
-		FASTGLTF_FG_PMR_NS::SmallVector<Attribute, 4> attributes;
-        PrimitiveType type = PrimitiveType::Triangles;
-
-        FASTGLTF_STD_PMR_NS::vector<FASTGLTF_FG_PMR_NS::SmallVector<Attribute, 4>> targets;
-
-        Optional<std::size_t> indicesAccessor;
-        Optional<std::size_t> materialIndex;
-
-		/**
-		 * Represents the mappings data from KHR_material_variants.
-		 * Use the variant index to index into this array to get the corresponding material index to use.
-		 * If this vector is empty, the normal materialIndex should be used as a fallback.
-		 */
-		std::vector<Optional<std::size_t>> mappings;
-
-		std::unique_ptr<DracoCompressedPrimitive> dracoCompression;
-
-		[[nodiscard]] auto findAttribute(std::string_view name) noexcept {
-			for (auto* it = attributes.begin(); it != attributes.end(); ++it) {
-				if (it->name == name)
-					return it;
-			}
-			return attributes.end();
-		}
-
-		[[nodiscard]] auto findAttribute(std::string_view name) const noexcept {
-			for (const auto* it = attributes.cbegin(); it != attributes.cend(); ++it) {
-				if (it->name == name)
-					return it;
-			}
-			return attributes.cend();
-		}
-
-		[[nodiscard]] auto findTargetAttribute(std::size_t targetIndex, std::string_view name) noexcept {
-			auto& targetAttributes = targets[targetIndex];
-			for (auto* it = targetAttributes.begin(); it != targetAttributes.end(); ++it) {
-				if (it->name == name)
-					return it;
-			}
-			return targetAttributes.end();
-		}
-
-		[[nodiscard]] auto findTargetAttribute(std::size_t targetIndex, std::string_view name) const noexcept {
-			const auto& targetAttributes = targets[targetIndex];
-			for (const auto* it = targetAttributes.cbegin(); it != targetAttributes.cend(); ++it) {
-				if (it->name == name)
-					return it;
-			}
-			return targetAttributes.cend();
-		}
-	};
-
-    FASTGLTF_EXPORT struct Mesh {
-		FASTGLTF_FG_PMR_NS::MaybeSmallVector<Primitive, 2> primitives;
-	    FASTGLTF_FG_PMR_NS::MaybeSmallVector<num> weights;
-
-        FASTGLTF_STD_PMR_NS::string name;
-    };
-
-    /**
-     * Texture transform information as per KHR_texture_transform.
-     */
-    FASTGLTF_EXPORT struct TextureTransform {
-        /**
-         * Rotate the UVs by this many radians counter-clockwise around the origin. This is equivalent to a similar rotation of the image clockwise.
-         */
-        num rotation;
-
-		/**
-		 * The offset of the UV coordinate origin as a factor of the texture dimensions.
-		 */
-		math::nvec2 uvOffset = math::nvec2(0);
-
-		/**
-		 * The scale factor applied to the components of the UV coordinates.
-		 */
-		math::nvec2 uvScale = math::nvec2(1);
-
-        /**
-         * Overrides the textureInfo texCoord value if supplied.
-         */
-        Optional<std::size_t> texCoordIndex;
-    };
-
-    FASTGLTF_EXPORT struct TextureInfo {
-        std::size_t textureIndex;
-        std::size_t texCoordIndex = 0;
-
-        /**
-         * Data from KHR_texture_transform, and nullptr if the extension wasn't enabled or used.
-         */
-        std::unique_ptr<TextureTransform> transform;
-    };
-
-	FASTGLTF_EXPORT struct NormalTextureInfo : TextureInfo {
-		num scale = 1.f;
-	};
-
-	FASTGLTF_EXPORT struct OcclusionTextureInfo : TextureInfo {
-		num strength = 1.f;
-	};
-
-    FASTGLTF_EXPORT struct PBRData {
-		/**
-		 * The factors for the base color of then material.
-		 */
-		math::nvec4 baseColorFactor = math::nvec4(1);
-
-        /**
-         * The factor for the metalness of the material.
-         */
-        num metallicFactor = 1.0f;
-
-        /**
-         * The factor for the roughness of the material.
-         */
-        num roughnessFactor = 1.0f;
-
-        Optional<TextureInfo> baseColorTexture;
-        Optional<TextureInfo> metallicRoughnessTexture;
-    };
-
-	FASTGLTF_EXPORT struct MaterialAnisotropy {
-		num anisotropyStrength = 0.0f;
-		num anisotropyRotation = 0.0f;
-		Optional<TextureInfo> anisotropyTexture;
-	};
+FASTGLTF_EXPORT struct Motion {
+	/**
+	 * When true, treat the rigid body as having infinite mass. Its velocity will be constant during
+	 * simulation
+	 */
+	bool isKinematic = false;
 
 	/**
-	 * Diffuse transmission information from KHR_materials_diffuse_transmission
+	 * The mass of the rigid body. Larger values imply the rigid body is harder to move
 	 */
-	FASTGLTF_EXPORT struct MaterialDiffuseTransmission {
-		num diffuseTransmissionFactor = 0.0f;
-		Optional<TextureInfo> diffuseTransmissionTexture;
-		math::nvec3 diffuseTransmissionColorFactor = math::nvec3(1);
-		Optional<TextureInfo> diffuseTransmissionColorTexture;
-	};
+	Optional<num> mass;
 
-    /**
-     * Specular information from KHR_materials_specular.
-     */
-    FASTGLTF_EXPORT struct MaterialSpecular {
-        num specularFactor = 1.0f;
-        Optional<TextureInfo> specularTexture;
-		math::nvec3 specularColorFactor = math::nvec3(1);
-        Optional<TextureInfo> specularColorTexture;
-    };
+	/**
+	 * Center of mass of the rigid body in node space
+	 */
+	math::fvec3 centerOfMass = {0, 0, 0};
 
-    /**
-     * Iridescence information from KHR_materials_iridescence
-     */
-    FASTGLTF_EXPORT struct MaterialIridescence {
-        num iridescenceFactor = 0.0f;
-        Optional<TextureInfo> iridescenceTexture;
-        num iridescenceIor = 1.3f;
-        num iridescenceThicknessMinimum = 100.0f;
-        num iridescenceThicknessMaximum = 400.0f;
-        Optional<TextureInfo> iridescenceThicknessTexture;
-    };
+	/**
+	 * The principal moments of inertia. Larger values imply the rigid body is harder to rotate
+	 */
+	Optional<math::fvec3> inertialDiagonal;
 
-    /**
-     * Volume information from KHR_materials_volume
-     */
-    FASTGLTF_EXPORT struct MaterialVolume {
-        num thicknessFactor = 0.0f;
-        Optional<TextureInfo> thicknessTexture;
-        num attenuationDistance = std::numeric_limits<num>::infinity();
-		math::nvec3 attenuationColor = math::nvec3(1);
-    };
+	/**
+	 * The quaternion rotating from inertia major axis space to node space
+	 */
+	Optional<math::fvec4> inertialOrientation;
 
-    FASTGLTF_EXPORT struct MaterialTransmission {
-        num transmissionFactor = 0.0f;
-        Optional<TextureInfo> transmissionTexture;
-    };
+	/**
+	 * Initial linear velocity of the rigid body in node space
+	 */
+	math::fvec3 linearVelocity = {0, 0, 0};
 
-    FASTGLTF_EXPORT struct MaterialClearcoat {
-        num clearcoatFactor = 0.0f;
-        Optional<TextureInfo> clearcoatTexture;
-        num clearcoatRoughnessFactor = 0.0f;
-        Optional<TextureInfo> clearcoatRoughnessTexture;
-        Optional<NormalTextureInfo> clearcoatNormalTexture;
-    };
+	/**
+	 * Initial angular velocity of the rigid body in node space
+	 */
+	math::fvec3 angularVelocity = {0, 0, 0};
 
-    FASTGLTF_EXPORT struct MaterialSheen {
-		math::nvec3 sheenColorFactor = math::nvec3(0);
-        Optional<TextureInfo> sheenColorTexture;
-        num sheenRoughnessFactor = 0.0f;
-        Optional<TextureInfo> sheenRoughnessTexture;
-    };
+	/**
+	 * A multiplier applied to the acceleration due to gravity
+	 */
+	num gravityFactor = 1;
+};
+
+FASTGLTF_EXPORT struct Geometry {
+	/**
+	 * The index of a top-level `KHR_implicit_shapes.shape`, providing an implicit representation of
+	 * the geometry
+	 */
+	Optional<size_t> shape;
+
+	/**
+	 * The index of a glTF `node` which provides a mesh representation of the geometry
+	 */
+	Optional<size_t> node;
+
+	/**
+	 * Flag to indicate that the geometry should be a convex hull.
+	 */
+	bool convexHull;
+};
+
+FASTGLTF_EXPORT struct PhysicsMaterial {
+	num staticFriction = 0.6f;
+
+	num dynamicFriction = 0.6f;
+
+	num restitution = 0.0f;
+
+	CombineMode frictionCombine;
+
+	CombineMode restitutionCombine;
+};
+
+FASTGLTF_EXPORT struct CollisionFilter {
+	/**
+	 * An array of arbitrary strings indicating the "system" a node is a member of
+	 */
+	FASTGLTF_FG_PMR_NS::MaybeSmallVector<FASTGLTF_STD_PMR_NS::string> collisionSystems;
+
+	/**
+	 * An array of strings representing the systems which this node can _not_ collide with
+	 */
+	FASTGLTF_FG_PMR_NS::MaybeSmallVector<FASTGLTF_STD_PMR_NS::string> notCollideWithSystems;
+
+	/**
+	 * An array of strings representing the systems which this node can collide with
+	 */
+	FASTGLTF_FG_PMR_NS::MaybeSmallVector<FASTGLTF_STD_PMR_NS::string> collideWithSystems;
+};
+
+FASTGLTF_EXPORT struct Collider {
+	/**
+	 * An object describing the geometrical representation of this collider
+	 */
+	Geometry geometry;
+
+	/**
+	 * Indexes into the top-level `physicsMaterials` and describes how the collider should respond
+	 * to collisions
+	 */
+	Optional<std::size_t> physicsMaterial;
+
+	/**
+	 * Indexes into the top-level `collisionFilters` and describes a filter which determines if this
+	 * collider should perform collision detection against another collider
+	 */
+	Optional<std::size_t> collisionFilter;
+};
+
+FASTGLTF_EXPORT struct GeometryTrigger {
+	/**
+	 * An object describing the geometrical representation of this collider
+	 */
+	Geometry geometry;
+
+	/**
+	 * Indexes into the top-level `collisionFilters` and describes a filter which determines if this
+	 * collider should perform collision detection against another collider
+	 */
+	Optional<std::size_t> collisionFilter;
+};
+
+FASTGLTF_EXPORT struct NodeTrigger {
+	/**
+	 * For compound triggers, the set of descendant glTF nodes with a trigger property that make up
+	 * this compound trigger
+	 */
+	FASTGLTF_FG_PMR_NS::MaybeSmallVector<std::size_t> nodes;
+};
+
+FASTGLTF_EXPORT struct JointLimit {
+	/**
+	 * The linear axes to constrain (0=X, 1=Y, 2=Z)
+	 */
+	FASTGLTF_FG_PMR_NS::SmallVector<uint8_t, 3> linearAxes;
+
+	/**
+	 * The angular axes to constrain (0=X, 1=Y, 2=Z)
+	 */
+	FASTGLTF_FG_PMR_NS::SmallVector<uint8_t, 3> angularAxes;
+
+	/**
+	 * The minimum allowed relative distance/angle
+	 */
+	Optional<num> min;
+
+	/**
+	 * The maximum allowed relative distance/angle
+	 */
+	Optional<num> max;
+
+	/**
+	 * Optional softness of the limits when beyond the limits
+	 */
+	Optional<num> stiffness;
+
+	/**
+	 * Optional spring damping applied when beyond the limits
+	 */
+	num damping = 0;
+};
+
+FASTGLTF_EXPORT struct JointDrive {
+	/**
+	 * Determines if the drive affects is a `linear` or `angular` drive
+	 */
+	DriveType type;
+
+	/**
+	 * Determines if the drive is operating in `force` or `acceleration` mode
+	 */
+	DriveMode mode;
+
+	/**
+	 * The index of the axis which this drive affects
+	 */
+	uint8_t axis;
+
+	/**
+	 * The maximum force that the drive can apply
+	 */
+	num maxForce;
+
+	/**
+	 * The desired relative target between the pivot axes
+	 */
+	num positionTarget;
+
+	/**
+	 * The desired relative velocity of the pivot axes
+	 */
+	num velocityTarget;
+
+	/**
+	 * The drive's stiffness, used to achieve the position target
+	 */
+	num stiffness = 0;
+
+	/**
+	 * The damping factor applied to reach the velocity target
+	 */
+	num damping = 0;
+};
+
+FASTGLTF_EXPORT struct PhysicsJoint {
+	FASTGLTF_FG_PMR_NS::MaybeSmallVector<JointLimit> limits;
+
+	/**
+	 * Each drive specifies a force to apply along a single axis
+	 */
+	FASTGLTF_FG_PMR_NS::MaybeSmallVector<JointDrive> drives;
+};
+
+FASTGLTF_EXPORT struct Joint {
+	std::size_t connectedNode;
+
+	std::size_t joint;
+
+	bool enableCollision = false;
+};
+
+FASTGLTF_EXPORT struct PhysicsRigidBody {
+	Optional<Motion> motion;
+
+	Optional<Collider> collider;
+
+	Optional<std::variant<GeometryTrigger, NodeTrigger>> trigger;
+
+	Optional<Joint> joint;
+};
+#endif
+
+FASTGLTF_EXPORT struct Node {
+	Optional<std::size_t> meshIndex;
+	Optional<std::size_t> skinIndex;
+	Optional<std::size_t> cameraIndex;
+
+	/**
+	 * Only ever non-empty when KHR_lights_punctual is enabled and used by the asset.
+	 */
+	Optional<std::size_t> lightIndex;
+
+	FASTGLTF_FG_PMR_NS::MaybeSmallVector<std::size_t> children;
+	FASTGLTF_FG_PMR_NS::MaybeSmallVector<num> weights;
+
+	/**
+	 * Variant holding either the three TRS components; transform, rotation, and scale, or a
+	 * transformation matrix, which cannot skew or shear. The latter can be decomposed into
+	 * the TRS components by specifying Options::DecomposeNodeMatrices.
+	 */
+	std::variant<TRS, math::fmat4x4> transform;
+
+	/**
+	 * Only ever non-empty when EXT_mesh_gpu_instancing is enabled and used by the asset.
+	 */
+	FASTGLTF_STD_PMR_NS::vector<Attribute> instancingAttributes;
+
+	FASTGLTF_STD_PMR_NS::string name;
+
+#if FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES
+	std::unique_ptr<PhysicsRigidBody> physicsRigidBody;
+#endif
+
+	[[nodiscard]] auto findInstancingAttribute(const std::string_view attributeName) noexcept {
+		for (auto it = instancingAttributes.begin(); it != instancingAttributes.end(); ++it) {
+			if (it->name == attributeName) return it;
+		}
+		return instancingAttributes.end();
+	}
+
+	[[nodiscard]] auto findInstancingAttribute(
+		const std::string_view attributeName) const noexcept {
+		for (auto it = instancingAttributes.cbegin(); it != instancingAttributes.cend(); ++it) {
+			if (it->name == attributeName) return it;
+		}
+		return instancingAttributes.cend();
+	}
+};
+
+struct DracoCompressedPrimitive {
+	std::size_t bufferView;
+	FASTGLTF_FG_PMR_NS::SmallVector<Attribute, 4> attributes;
+
+	[[nodiscard]] auto findAttribute(const std::string_view name) noexcept {
+		for (auto* it = attributes.begin(); it != attributes.end(); ++it) {
+			if (it->name == name) return it;
+		}
+		return attributes.end();
+	}
+
+	[[nodiscard]] auto findAttribute(const std::string_view name) const noexcept {
+		for (const auto* it = attributes.cbegin(); it != attributes.cend(); ++it) {
+			if (it->name == name) return it;
+		}
+		return attributes.cend();
+	}
+};
+
+FASTGLTF_EXPORT struct Primitive {
+	// Instead of a map, we have a list of attributes here. Each pair contains
+	// the name of the attribute and the corresponding accessor index.
+	FASTGLTF_FG_PMR_NS::SmallVector<Attribute, 4> attributes;
+	PrimitiveType type = PrimitiveType::Triangles;
+
+	FASTGLTF_STD_PMR_NS::vector<FASTGLTF_FG_PMR_NS::SmallVector<Attribute, 4>> targets;
+
+	Optional<std::size_t> indicesAccessor;
+	Optional<std::size_t> materialIndex;
+
+	/**
+	 * Represents the mappings data from KHR_material_variants.
+	 * Use the variant index to index into this array to get the corresponding material index to
+	 * use. If this vector is empty, the normal materialIndex should be used as a fallback.
+	 */
+	std::vector<Optional<std::size_t>> mappings;
+
+	std::unique_ptr<DracoCompressedPrimitive> dracoCompression;
+
+	[[nodiscard]] auto findAttribute(std::string_view name) noexcept {
+		for (auto* it = attributes.begin(); it != attributes.end(); ++it) {
+			if (it->name == name) return it;
+		}
+		return attributes.end();
+	}
+
+	[[nodiscard]] auto findAttribute(std::string_view name) const noexcept {
+		for (const auto* it = attributes.cbegin(); it != attributes.cend(); ++it) {
+			if (it->name == name) return it;
+		}
+		return attributes.cend();
+	}
+
+	[[nodiscard]] auto findTargetAttribute(std::size_t targetIndex,
+										   std::string_view name) noexcept {
+		auto& targetAttributes = targets[targetIndex];
+		for (auto* it = targetAttributes.begin(); it != targetAttributes.end(); ++it) {
+			if (it->name == name) return it;
+		}
+		return targetAttributes.end();
+	}
+
+	[[nodiscard]] auto findTargetAttribute(std::size_t targetIndex,
+										   std::string_view name) const noexcept {
+		const auto& targetAttributes = targets[targetIndex];
+		for (const auto* it = targetAttributes.cbegin(); it != targetAttributes.cend(); ++it) {
+			if (it->name == name) return it;
+		}
+		return targetAttributes.cend();
+	}
+};
+
+FASTGLTF_EXPORT struct Mesh {
+	FASTGLTF_FG_PMR_NS::MaybeSmallVector<Primitive, 2> primitives;
+	FASTGLTF_FG_PMR_NS::MaybeSmallVector<num> weights;
+
+	FASTGLTF_STD_PMR_NS::string name;
+};
+
+/**
+ * Texture transform information as per KHR_texture_transform.
+ */
+FASTGLTF_EXPORT struct TextureTransform {
+	/**
+	 * Rotate the UVs by this many radians counter-clockwise around the origin. This is equivalent
+	 * to a similar rotation of the image clockwise.
+	 */
+	num rotation;
+
+	/**
+	 * The offset of the UV coordinate origin as a factor of the texture dimensions.
+	 */
+	math::nvec2 uvOffset = math::nvec2(0);
+
+	/**
+	 * The scale factor applied to the components of the UV coordinates.
+	 */
+	math::nvec2 uvScale = math::nvec2(1);
+
+	/**
+	 * Overrides the textureInfo texCoord value if supplied.
+	 */
+	Optional<std::size_t> texCoordIndex;
+};
+
+FASTGLTF_EXPORT struct TextureInfo {
+	std::size_t textureIndex;
+	std::size_t texCoordIndex = 0;
+
+	/**
+	 * Data from KHR_texture_transform, and nullptr if the extension wasn't enabled or used.
+	 */
+	std::unique_ptr<TextureTransform> transform;
+};
+
+FASTGLTF_EXPORT struct NormalTextureInfo : TextureInfo {
+	num scale = 1.f;
+};
+
+FASTGLTF_EXPORT struct OcclusionTextureInfo : TextureInfo {
+	num strength = 1.f;
+};
+
+FASTGLTF_EXPORT struct PBRData {
+	/**
+	 * The factors for the base color of then material.
+	 */
+	math::nvec4 baseColorFactor = math::nvec4(1);
+
+	/**
+	 * The factor for the metalness of the material.
+	 */
+	num metallicFactor = 1.0f;
+
+	/**
+	 * The factor for the roughness of the material.
+	 */
+	num roughnessFactor = 1.0f;
+
+	Optional<TextureInfo> baseColorTexture;
+	Optional<TextureInfo> metallicRoughnessTexture;
+};
+
+FASTGLTF_EXPORT struct MaterialAnisotropy {
+	num anisotropyStrength = 0.0f;
+	num anisotropyRotation = 0.0f;
+	Optional<TextureInfo> anisotropyTexture;
+};
+
+/**
+ * Diffuse transmission information from KHR_materials_diffuse_transmission
+ */
+FASTGLTF_EXPORT struct MaterialDiffuseTransmission {
+	num diffuseTransmissionFactor = 0.0f;
+	Optional<TextureInfo> diffuseTransmissionTexture;
+	math::nvec3 diffuseTransmissionColorFactor = math::nvec3(1);
+	Optional<TextureInfo> diffuseTransmissionColorTexture;
+};
+
+/**
+ * Specular information from KHR_materials_specular.
+ */
+FASTGLTF_EXPORT struct MaterialSpecular {
+	num specularFactor = 1.0f;
+	Optional<TextureInfo> specularTexture;
+	math::nvec3 specularColorFactor = math::nvec3(1);
+	Optional<TextureInfo> specularColorTexture;
+};
+
+/**
+ * Iridescence information from KHR_materials_iridescence
+ */
+FASTGLTF_EXPORT struct MaterialIridescence {
+	num iridescenceFactor = 0.0f;
+	Optional<TextureInfo> iridescenceTexture;
+	num iridescenceIor = 1.3f;
+	num iridescenceThicknessMinimum = 100.0f;
+	num iridescenceThicknessMaximum = 400.0f;
+	Optional<TextureInfo> iridescenceThicknessTexture;
+};
+
+/**
+ * Volume information from KHR_materials_volume
+ */
+FASTGLTF_EXPORT struct MaterialVolume {
+	num thicknessFactor = 0.0f;
+	Optional<TextureInfo> thicknessTexture;
+	num attenuationDistance = std::numeric_limits<num>::infinity();
+	math::nvec3 attenuationColor = math::nvec3(1);
+};
+
+FASTGLTF_EXPORT struct MaterialTransmission {
+	num transmissionFactor = 0.0f;
+	Optional<TextureInfo> transmissionTexture;
+};
+
+FASTGLTF_EXPORT struct MaterialClearcoat {
+	num clearcoatFactor = 0.0f;
+	Optional<TextureInfo> clearcoatTexture;
+	num clearcoatRoughnessFactor = 0.0f;
+	Optional<TextureInfo> clearcoatRoughnessTexture;
+	Optional<NormalTextureInfo> clearcoatNormalTexture;
+};
+
+FASTGLTF_EXPORT struct MaterialSheen {
+	math::nvec3 sheenColorFactor = math::nvec3(0);
+	Optional<TextureInfo> sheenColorTexture;
+	num sheenRoughnessFactor = 0.0f;
+	Optional<TextureInfo> sheenRoughnessTexture;
+};
 
 #if FASTGLTF_ENABLE_DEPRECATED_EXT
-    /**
-     * Specular/Glossiness information from KHR_materials_pbrSpecularGlossiness.
-     */
-    FASTGLTF_EXPORT struct MaterialSpecularGlossiness {
-		math::nvec4 diffuseFactor = math::nvec4(1);
-        Optional<TextureInfo> diffuseTexture;
-		math::nvec3 specularFactor = math::nvec3(1);
-        num glossinessFactor = 1.0f;
-        Optional<TextureInfo> specularGlossinessTexture;
-    };
+/**
+ * Specular/Glossiness information from KHR_materials_pbrSpecularGlossiness.
+ */
+FASTGLTF_EXPORT struct MaterialSpecularGlossiness {
+	math::nvec4 diffuseFactor = math::nvec4(1);
+	Optional<TextureInfo> diffuseTexture;
+	math::nvec3 specularFactor = math::nvec3(1);
+	num glossinessFactor = 1.0f;
+	Optional<TextureInfo> specularGlossinessTexture;
+};
 #endif
 
-	FASTGLTF_EXPORT struct MaterialPackedTextures {
-		Optional<TextureInfo> occlusionRoughnessMetallicTexture;
-		Optional<TextureInfo> roughnessMetallicOcclusionTexture;
-		Optional<TextureInfo> normalTexture;
-	};
+FASTGLTF_EXPORT struct MaterialPackedTextures {
+	Optional<TextureInfo> occlusionRoughnessMetallicTexture;
+	Optional<TextureInfo> roughnessMetallicOcclusionTexture;
+	Optional<TextureInfo> normalTexture;
+};
 
-    FASTGLTF_EXPORT struct Material {
-        /**
-         * A set of parameter values that are used to define the metallic-roughness material model
-         * from Physically Based Rendering (PBR) methodology.
-         */
-        PBRData pbrData;
+FASTGLTF_EXPORT struct Material {
+	/**
+	 * A set of parameter values that are used to define the metallic-roughness material model
+	 * from Physically Based Rendering (PBR) methodology.
+	 */
+	PBRData pbrData;
 
-        /**
-         * The tangent space normal texture.
-         */
-        Optional<NormalTextureInfo> normalTexture;
-        Optional<OcclusionTextureInfo> occlusionTexture;
-        Optional<TextureInfo> emissiveTexture;
+	/**
+	 * The tangent space normal texture.
+	 */
+	Optional<NormalTextureInfo> normalTexture;
+	Optional<OcclusionTextureInfo> occlusionTexture;
+	Optional<TextureInfo> emissiveTexture;
 
-		/**
-		 * The factors for the emissive color of the material.
-		 */
-		math::nvec3 emissiveFactor = math::nvec3(0);
+	/**
+	 * The factors for the emissive color of the material.
+	 */
+	math::nvec3 emissiveFactor = math::nvec3(0);
 
-        /**
-         * The values used to determine the transparency of the material.
-         */
-        AlphaMode alphaMode = AlphaMode::Opaque;
+	/**
+	 * The values used to determine the transparency of the material.
+	 */
+	AlphaMode alphaMode = AlphaMode::Opaque;
 
-		/**
-		 * Determines whether back-face culling should be disabled when using this material.
-		 */
-		bool doubleSided = false;
+	/**
+	 * Determines whether back-face culling should be disabled when using this material.
+	 */
+	bool doubleSided = false;
 
-		/**
-		 * Only true when KHR_materials_unlit is enabled and specified for this material.
-		 */
-		bool unlit = false;
+	/**
+	 * Only true when KHR_materials_unlit is enabled and specified for this material.
+	 */
+	bool unlit = false;
 
-		/**
-		 * The alpha value that determines the upper limit for fragments that
-		 * should be discarded for transparency.
-		 */
-        num alphaCutoff = 0.5f;
+	/**
+	 * The alpha value that determines the upper limit for fragments that
+	 * should be discarded for transparency.
+	 */
+	num alphaCutoff = 0.5f;
 
-		/**
-		 * The emissive strength from the KHR_materials_emissive_strength extension.
-		 */
-		num emissiveStrength = 1.0f;
+	/**
+	 * The emissive strength from the KHR_materials_emissive_strength extension.
+	 */
+	num emissiveStrength = 1.0f;
 
-		/**
-		 * The index of refraction as specified through KHR_materials_ior.
-		 */
-		num ior = 1.5f;
+	/**
+	 * The index of refraction as specified through KHR_materials_ior.
+	 */
+	num ior = 1.5f;
 
-		/**
-		 * The dispersion factor from KHR_materials_dispersion, specifies as 20/Abbe number (20/V).
-		 */
-		num dispersion = 0.0f;
+	/**
+	 * The dispersion factor from KHR_materials_dispersion, specifies as 20/Abbe number (20/V).
+	 */
+	num dispersion = 0.0f;
 
-		std::unique_ptr<MaterialAnisotropy> anisotropy;
+	std::unique_ptr<MaterialAnisotropy> anisotropy;
 
-        std::unique_ptr<MaterialClearcoat> clearcoat;
+	std::unique_ptr<MaterialClearcoat> clearcoat;
 
-		/**
-		 * Diffuse transmission information from KHR_materials_diffuse_transmission.
-		 */
-		std::unique_ptr<MaterialDiffuseTransmission> diffuseTransmission;
+	/**
+	 * Diffuse transmission information from KHR_materials_diffuse_transmission.
+	 */
+	std::unique_ptr<MaterialDiffuseTransmission> diffuseTransmission;
 
-        /**
-         * Iridescence information from KHR_materials_iridescence.
-         */
-        std::unique_ptr<MaterialIridescence> iridescence;
+	/**
+	 * Iridescence information from KHR_materials_iridescence.
+	 */
+	std::unique_ptr<MaterialIridescence> iridescence;
 
-        std::unique_ptr<MaterialSheen> sheen;
+	std::unique_ptr<MaterialSheen> sheen;
 
-        /**
-         * Specular information from KHR_materials_specular.
-         */
-        std::unique_ptr<MaterialSpecular> specular;
+	/**
+	 * Specular information from KHR_materials_specular.
+	 */
+	std::unique_ptr<MaterialSpecular> specular;
 
 #if FASTGLTF_ENABLE_DEPRECATED_EXT
-        /**
-         * Specular/Glossiness information from KHR_materials_pbrSpecularGlossiness.
-         */
-        std::unique_ptr<MaterialSpecularGlossiness> specularGlossiness;
+	/**
+	 * Specular/Glossiness information from KHR_materials_pbrSpecularGlossiness.
+	 */
+	std::unique_ptr<MaterialSpecularGlossiness> specularGlossiness;
 #endif
 
-        /**
-         * Specular information from KHR_materials_transmission.
-         */
-        std::unique_ptr<MaterialTransmission> transmission;
+	/**
+	 * Specular information from KHR_materials_transmission.
+	 */
+	std::unique_ptr<MaterialTransmission> transmission;
 
-        /**
-         * Volume information from KHR_materials_volume
-         */
-        std::unique_ptr<MaterialVolume> volume;
+	/**
+	 * Volume information from KHR_materials_volume
+	 */
+	std::unique_ptr<MaterialVolume> volume;
 
-		/**
-		 * The index of a packed texture from the MSFT_packing_normalRoughnessMetallic extension,
-		 * providing normal, roughness and metallic data.
-		 */
-		Optional<TextureInfo> packedNormalMetallicRoughnessTexture;
+	/**
+	 * The index of a packed texture from the MSFT_packing_normalRoughnessMetallic extension,
+	 * providing normal, roughness and metallic data.
+	 */
+	Optional<TextureInfo> packedNormalMetallicRoughnessTexture;
 
-		std::unique_ptr<MaterialPackedTextures> packedOcclusionRoughnessMetallicTextures;
+	std::unique_ptr<MaterialPackedTextures> packedOcclusionRoughnessMetallicTextures;
 
-        FASTGLTF_STD_PMR_NS::string name;
-    };
+	FASTGLTF_STD_PMR_NS::string name;
+};
 
-    FASTGLTF_EXPORT struct Texture {
-		/**
-		 * If no sampler is specified, use a default sampler with repeat wrap and auto filter.
-		 */
-		Optional<std::size_t> samplerIndex;
+FASTGLTF_EXPORT struct Texture {
+	/**
+	 * If no sampler is specified, use a default sampler with repeat wrap and auto filter.
+	 */
+	Optional<std::size_t> samplerIndex;
 
-		/**
-		 * The index of the image used by this texture. Either this will have a value,
-		 * or one of the following extensions will define a texture index. If no extensions
-		 * were enabled while parsing, this will always have a value.
-		 */
-		Optional<std::size_t> imageIndex;
+	/**
+	 * The index of the image used by this texture. Either this will have a value,
+	 * or one of the following extensions will define a texture index. If no extensions
+	 * were enabled while parsing, this will always have a value.
+	 */
+	Optional<std::size_t> imageIndex;
 
-		/**
-		 * An optional texture index from the KHR_texture_basisu extension.
-		 */
-		Optional<std::size_t> basisuImageIndex;
+	/**
+	 * An optional texture index from the KHR_texture_basisu extension.
+	 */
+	Optional<std::size_t> basisuImageIndex;
 
-		/**
-		 * An optional texture index from the MSFT_texture_dds extension.
-		 */
-		Optional<std::size_t> ddsImageIndex;
+	/**
+	 * An optional texture index from the MSFT_texture_dds extension.
+	 */
+	Optional<std::size_t> ddsImageIndex;
 
-		/**
-		 * An optional texture index from the EXT_texture_webp extension.
-		 */
-		Optional<std::size_t> webpImageIndex;
+	/**
+	 * An optional texture index from the EXT_texture_webp extension.
+	 */
+	Optional<std::size_t> webpImageIndex;
 
-        FASTGLTF_STD_PMR_NS::string name;
-    };
+	FASTGLTF_STD_PMR_NS::string name;
+};
 
-    FASTGLTF_EXPORT struct Image {
-        DataSource data;
+FASTGLTF_EXPORT struct Image {
+	DataSource data;
 
-        FASTGLTF_STD_PMR_NS::string name;
-    };
+	FASTGLTF_STD_PMR_NS::string name;
+};
 
-    FASTGLTF_EXPORT struct SparseAccessor {
-        std::size_t count;
-        std::size_t indicesBufferView;
-        std::size_t indicesByteOffset = 0;
-        std::size_t valuesBufferView;
-        std::size_t valuesByteOffset = 0;
-        ComponentType indexComponentType;
-    };
+FASTGLTF_EXPORT struct SparseAccessor {
+	std::size_t count;
+	std::size_t indicesBufferView;
+	std::size_t indicesByteOffset = 0;
+	std::size_t valuesBufferView;
+	std::size_t valuesByteOffset = 0;
+	ComponentType indexComponentType;
+};
 
-	FASTGLTF_EXPORT struct Accessor {
-		std::size_t byteOffset = 0;
-		std::size_t count;
-		AccessorType type;
-		ComponentType componentType;
-		bool normalized = false;
+FASTGLTF_EXPORT struct Accessor {
+	std::size_t byteOffset = 0;
+	std::size_t count;
+	AccessorType type;
+	ComponentType componentType;
+	bool normalized = false;
 
-		std::optional<AccessorBoundsArray> max;
-		std::optional<AccessorBoundsArray> min;
+	std::optional<AccessorBoundsArray> max;
+	std::optional<AccessorBoundsArray> min;
 
-		// Could have no value for sparse morph targets
-		Optional<std::size_t> bufferViewIndex;
+	// Could have no value for sparse morph targets
+	Optional<std::size_t> bufferViewIndex;
 
-		Optional<SparseAccessor> sparse;
+	Optional<SparseAccessor> sparse;
 
-		FASTGLTF_STD_PMR_NS::string name;
+	FASTGLTF_STD_PMR_NS::string name;
 
-		/**
-		 * Helper function that updates the max/min variables dynamically.
-		 */
-		template <typename T>
-		requires AccessorBoundsArray::is_valid_type_v<T>
-		void updateBoundsToInclude(T value) {
-			if (!max)
-				max = AccessorBoundsArray::ForType<T>(1);
-			if (!min)
-				min = AccessorBoundsArray::ForType<T>(1);
+	/**
+	 * Helper function that updates the max/min variables dynamically.
+	 */
+	template <typename T>
+	requires AccessorBoundsArray::is_valid_type_v<T>
+	void updateBoundsToInclude(T value) {
+		if (!max) max = AccessorBoundsArray::ForType<T>(1);
+		if (!min) min = AccessorBoundsArray::ForType<T>(1);
 
-			assert(max->isType<T>() && min->isType<T>());
-			assert(max->size() == 1 && min->size() == 1);
+		assert(max->isType<T>() && min->isType<T>());
+		assert(max->size() == 1 && min->size() == 1);
 
-			const auto cur_max = max->get<T>(0);
-			const auto cur_min = min->get<T>(0);
-			if (value > cur_max)
-				max->set<T>(0, value);
-			if (value < cur_min)
-				min->set<T>(0, value);
+		const auto cur_max = max->get<T>(0);
+		const auto cur_min = min->get<T>(0);
+		if (value > cur_max) max->set<T>(0, value);
+		if (value < cur_min) min->set<T>(0, value);
+	}
+
+	/**
+	 * Helper function that updates the max/min variables dynamically. Note that the value passed in
+	 * needs to be a vector with the same size as max/min
+	 */
+	template <typename T, std::size_t N>
+	requires AccessorBoundsArray::is_valid_type_v<T>
+	void updateBoundsToInclude(math::vec<T, N> value) {
+		if (!max) max = AccessorBoundsArray::ForType<T>(value.size());
+		if (!min) min = AccessorBoundsArray::ForType<T>(value.size());
+
+		assert(max->isType<T>() && min->isType<T>());
+		assert(max->size() == value.size() && min->size() == value.size());
+
+		for (std::size_t i = 0; i < value.size(); ++i) {
+			const auto cur_max = max->get<T>(i);
+			const auto cur_min = min->get<T>(i);
+			if (value[i] > cur_max) max->set<T>(i, value[i]);
+			if (value[i] < cur_min) min->set<T>(i, value[i]);
 		}
+	}
+};
 
-		/**
-		 * Helper function that updates the max/min variables dynamically. Note that the value passed in
-		 * needs to be a vector with the same size as max/min
-		 */
-		template <typename T, std::size_t N>
-		requires AccessorBoundsArray::is_valid_type_v<T>
-		void updateBoundsToInclude(math::vec<T, N> value) {
-			if (!max)
-				max = AccessorBoundsArray::ForType<T>(value.size());
-			if (!min)
-				min = AccessorBoundsArray::ForType<T>(value.size());
+FASTGLTF_EXPORT struct CompressedBufferView {
+	std::size_t bufferIndex;
+	std::size_t byteOffset;
+	std::size_t byteLength;
+	std::size_t count;
+	MeshoptCompressionMode mode;
+	MeshoptCompressionFilter filter;
 
-			assert(max->isType<T>() && min->isType<T>());
-			assert(max->size() == value.size() && min->size() == value.size());
+	std::size_t byteStride;
+};
 
-			for (std::size_t i = 0; i < value.size(); ++i) {
-				const auto cur_max = max->get<T>(i);
-				const auto cur_min = min->get<T>(i);
-				if (value[i] > cur_max)
-					max->set<T>(i, value[i]);
-				if (value[i] < cur_min)
-					min->set<T>(i, value[i]);
-			}
-		}
-	};
+FASTGLTF_EXPORT struct BufferView {
+	std::size_t bufferIndex;
+	std::size_t byteOffset = 0;
+	std::size_t byteLength;
 
-    FASTGLTF_EXPORT struct CompressedBufferView {
-        std::size_t bufferIndex;
-        std::size_t byteOffset;
-        std::size_t byteLength;
-        std::size_t count;
-        MeshoptCompressionMode mode;
-        MeshoptCompressionFilter filter;
+	Optional<std::size_t> byteStride;
+	Optional<BufferTarget> target;
 
-        std::size_t byteStride;
-    };
+	/**
+	 * Data from EXT_meshopt_compression, and nullptr if the extension was not enabled or used.
+	 */
+	std::unique_ptr<CompressedBufferView> meshoptCompression;
 
-    FASTGLTF_EXPORT struct BufferView {
-        std::size_t bufferIndex;
-        std::size_t byteOffset = 0;
-        std::size_t byteLength;
+	FASTGLTF_STD_PMR_NS::string name;
+};
 
-        Optional<std::size_t> byteStride;
-        Optional<BufferTarget> target;
+FASTGLTF_EXPORT struct Buffer {
+	std::size_t byteLength;
 
-        /**
-         * Data from EXT_meshopt_compression, and nullptr if the extension was not enabled or used.
-         */
-        std::unique_ptr<CompressedBufferView> meshoptCompression;
+	DataSource data;
 
-        FASTGLTF_STD_PMR_NS::string name;
-    };
+	FASTGLTF_STD_PMR_NS::string name;
+};
 
-    FASTGLTF_EXPORT struct Buffer {
-        std::size_t byteLength;
+FASTGLTF_EXPORT struct Light {
+	LightType type;
+	/** RGB light color in linear space. */
+	math::nvec3 color;
 
-        DataSource data;
+	/** Point and spot lights use candela (lm/sr) while directional use lux (lm/m^2) */
+	num intensity;
+	/** Range for point and spot lights. If not present, range is infinite. */
+	Optional<num> range;
 
-        FASTGLTF_STD_PMR_NS::string name;
-    };
+	/** The inner and outer cone angles only apply to spot lights */
+	Optional<num> innerConeAngle;
+	Optional<num> outerConeAngle;
 
-    FASTGLTF_EXPORT struct Light {
-        LightType type;
-        /** RGB light color in linear space. */
-        math::nvec3 color;
+	FASTGLTF_STD_PMR_NS::string name;
+};
 
-        /** Point and spot lights use candela (lm/sr) while directional use lux (lm/m^2) */
-        num intensity;
-        /** Range for point and spot lights. If not present, range is infinite. */
-        Optional<num> range;
+class ChunkMemoryResource;
+FASTGLTF_EXPORT class Parser;
 
-		/** The inner and outer cone angles only apply to spot lights */
-        Optional<num> innerConeAngle;
-        Optional<num> outerConeAngle;
-
-        FASTGLTF_STD_PMR_NS::string name;
-    };
-
-	class ChunkMemoryResource;
-	FASTGLTF_EXPORT class Parser;
-
-	FASTGLTF_EXPORT class Asset {
-		friend class Parser;
+FASTGLTF_EXPORT class Asset {
+	friend class Parser;
 
 #if !FASTGLTF_DISABLE_CUSTOM_MEMORY_POOL
-		// This has to be first in this struct so that it gets destroyed last, leaving all allocations
-		// alive until the end.
-		std::shared_ptr<std::pmr::monotonic_buffer_resource> memoryResource;
+	// This has to be first in this struct so that it gets destroyed last, leaving all allocations
+	// alive until the end.
+	std::shared_ptr<std::pmr::monotonic_buffer_resource> memoryResource;
 #endif
 
-	public:
-        /**
-         * This will only ever have no value if #Options::DontRequireValidAssetMember was specified.
-         */
-        Optional<AssetInfo> assetInfo;
-		FASTGLTF_STD_PMR_NS::vector<FASTGLTF_STD_PMR_NS::string> extensionsUsed;
-		FASTGLTF_STD_PMR_NS::vector<FASTGLTF_STD_PMR_NS::string> extensionsRequired;
+   public:
+	/**
+	 * This will only ever have no value if #Options::DontRequireValidAssetMember was specified.
+	 */
+	Optional<AssetInfo> assetInfo;
+	FASTGLTF_STD_PMR_NS::vector<FASTGLTF_STD_PMR_NS::string> extensionsUsed;
+	FASTGLTF_STD_PMR_NS::vector<FASTGLTF_STD_PMR_NS::string> extensionsRequired;
 
-        Optional<std::size_t> defaultScene;
-        std::vector<Accessor> accessors;
-        std::vector<Animation> animations;
-        std::vector<Buffer> buffers;
-        std::vector<BufferView> bufferViews;
-        std::vector<Camera> cameras;
-        std::vector<Image> images;
-        std::vector<Light> lights;
-        std::vector<Material> materials;
-        std::vector<Mesh> meshes;
-        std::vector<Node> nodes;
-        std::vector<Sampler> samplers;
-        std::vector<Scene> scenes;
-        std::vector<Skin> skins;
-        std::vector<Texture> textures;
+	Optional<std::size_t> defaultScene;
+	std::vector<Accessor> accessors;
+	std::vector<Animation> animations;
+	std::vector<Buffer> buffers;
+	std::vector<BufferView> bufferViews;
+	std::vector<Camera> cameras;
+	std::vector<Image> images;
+	std::vector<Light> lights;
+	std::vector<Material> materials;
+	std::vector<Mesh> meshes;
+	std::vector<Node> nodes;
+	std::vector<Sampler> samplers;
+	std::vector<Scene> scenes;
+	std::vector<Skin> skins;
+	std::vector<Texture> textures;
 
-		std::vector<std::string> materialVariants;
+	std::vector<std::string> materialVariants;
 
 #if FASTGLTF_ENABLE_KHR_IMPLICIT_SHAPES
-		std::vector<Shape> shapes;
+	std::vector<Shape> shapes;
 #endif
 
 #if FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES
-		std::vector<PhysicsMaterial> physicsMaterials;
-	    std::vector<PhysicsJoint> physicsJoints;
-		std::vector<CollisionFilter> collisionFilters;
+	std::vector<PhysicsMaterial> physicsMaterials;
+	std::vector<PhysicsJoint> physicsJoints;
+	std::vector<CollisionFilter> collisionFilters;
 #endif
 
-        // Keeps tracked of categories that were actually parsed.
-        Category availableCategories = Category::None;
+	// Keeps tracked of categories that were actually parsed.
+	Category availableCategories = Category::None;
 
-        explicit Asset() = default;
-        explicit Asset(const Asset& other) = delete;
-        Asset(Asset&& other) noexcept :
+	explicit Asset() = default;
+	explicit Asset(const Asset& other) = delete;
+	Asset(Asset&& other) noexcept
+		:
 #if !FASTGLTF_DISABLE_CUSTOM_MEMORY_POOL
-				memoryResource(std::move(other.memoryResource)),
+		  memoryResource(std::move(other.memoryResource)),
 #endif
-				assetInfo(std::move(other.assetInfo)),
-				extensionsUsed(std::move(other.extensionsUsed)),
-				extensionsRequired(std::move(other.extensionsRequired)),
-				defaultScene(other.defaultScene),
-				accessors(std::move(other.accessors)),
-				animations(std::move(other.animations)),
-				buffers(std::move(other.buffers)),
-				bufferViews(std::move(other.bufferViews)),
-				cameras(std::move(other.cameras)),
-				images(std::move(other.images)),
-				lights(std::move(other.lights)),
-				materials(std::move(other.materials)),
-				meshes(std::move(other.meshes)),
-				nodes(std::move(other.nodes)),
-				samplers(std::move(other.samplers)),
-				scenes(std::move(other.scenes)),
-				skins(std::move(other.skins)),
-				textures(std::move(other.textures)),
-				materialVariants(std::move(other.materialVariants)),
+		  assetInfo(std::move(other.assetInfo)),
+		  extensionsUsed(std::move(other.extensionsUsed)),
+		  extensionsRequired(std::move(other.extensionsRequired)),
+		  defaultScene(other.defaultScene),
+		  accessors(std::move(other.accessors)),
+		  animations(std::move(other.animations)),
+		  buffers(std::move(other.buffers)),
+		  bufferViews(std::move(other.bufferViews)),
+		  cameras(std::move(other.cameras)),
+		  images(std::move(other.images)),
+		  lights(std::move(other.lights)),
+		  materials(std::move(other.materials)),
+		  meshes(std::move(other.meshes)),
+		  nodes(std::move(other.nodes)),
+		  samplers(std::move(other.samplers)),
+		  scenes(std::move(other.scenes)),
+		  skins(std::move(other.skins)),
+		  textures(std::move(other.textures)),
+		  materialVariants(std::move(other.materialVariants)),
 #if FASTGLTF_ENABLE_KHR_IMPLICIT_SHAPES
-			    shapes(std::move(other.shapes)),
+		  shapes(std::move(other.shapes)),
 #endif
 #if FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES
-			    physicsMaterials(std::move(other.physicsMaterials)),
-			    physicsJoints(std::move(other.physicsJoints)),
-			    collisionFilters(std::move(other.collisionFilters)),
+		  physicsMaterials(std::move(other.physicsMaterials)),
+		  physicsJoints(std::move(other.physicsJoints)),
+		  collisionFilters(std::move(other.collisionFilters)),
 #endif
-	            availableCategories(other.availableCategories) {}
+		  availableCategories(other.availableCategories) {
+	}
 
-		Asset& operator=(const Asset& other) = delete;
-		Asset& operator=(Asset&& other) noexcept {
-			assetInfo = std::move(other.assetInfo);
-			extensionsUsed = std::move(other.extensionsUsed);
-			extensionsRequired = std::move(other.extensionsRequired);
-			defaultScene = other.defaultScene;
-			accessors = std::move(other.accessors);
-			animations = std::move(other.animations);
-			buffers = std::move(other.buffers);
-			bufferViews = std::move(other.bufferViews);
-			cameras = std::move(other.cameras);
-			images = std::move(other.images);
-			lights = std::move(other.lights);
-			materials = std::move(other.materials);
-			meshes = std::move(other.meshes);
-			nodes = std::move(other.nodes);
-			samplers = std::move(other.samplers);
-			scenes = std::move(other.scenes);
-			skins = std::move(other.skins);
-			textures = std::move(other.textures);
-			materialVariants = std::move(other.materialVariants);
+	Asset& operator=(const Asset& other) = delete;
+	Asset& operator=(Asset&& other) noexcept {
+		assetInfo = std::move(other.assetInfo);
+		extensionsUsed = std::move(other.extensionsUsed);
+		extensionsRequired = std::move(other.extensionsRequired);
+		defaultScene = other.defaultScene;
+		accessors = std::move(other.accessors);
+		animations = std::move(other.animations);
+		buffers = std::move(other.buffers);
+		bufferViews = std::move(other.bufferViews);
+		cameras = std::move(other.cameras);
+		images = std::move(other.images);
+		lights = std::move(other.lights);
+		materials = std::move(other.materials);
+		meshes = std::move(other.meshes);
+		nodes = std::move(other.nodes);
+		samplers = std::move(other.samplers);
+		scenes = std::move(other.scenes);
+		skins = std::move(other.skins);
+		textures = std::move(other.textures);
+		materialVariants = std::move(other.materialVariants);
 #if FASTGLTF_ENABLE_KHR_IMPLICIT_SHAPES
-			shapes = std::move(other.shapes);
+		shapes = std::move(other.shapes);
 #endif
 #if FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES
-			physicsMaterials = std::move(other.physicsMaterials);
-			physicsJoints = std::move(other.physicsJoints);
-			collisionFilters = std::move(other.collisionFilters);
+		physicsMaterials = std::move(other.physicsMaterials);
+		physicsJoints = std::move(other.physicsJoints);
+		collisionFilters = std::move(other.collisionFilters);
 #endif
-			availableCategories = other.availableCategories;
+		availableCategories = other.availableCategories;
 #if !FASTGLTF_DISABLE_CUSTOM_MEMORY_POOL
-			// This needs to be last to not destroy the old memoryResource for the current data.
-			memoryResource = std::move(other.memoryResource);
+		// This needs to be last to not destroy the old memoryResource for the current data.
+		memoryResource = std::move(other.memoryResource);
 #endif
-			return *this;
-		}
-    };
+		return *this;
+	}
+};
 #pragma endregion
-} // namespace fastgltf
+}  // namespace fastgltf
 
 #ifdef _MSC_VER
-#pragma warning(pop)
+#	pragma warning(pop)
 #endif
 
 #endif

--- a/include/fastgltf/types.hpp
+++ b/include/fastgltf/types.hpp
@@ -1158,7 +1158,8 @@ namespace fastgltf {
 			reset();
 		}
 
-		template <typename U = T, std::enable_if_t<std::is_copy_constructible_v<T>, int> = 0>
+		template <typename U = T>
+		requires std::is_copy_constructible_v<T>
 		OptionalWithFlagValue(const OptionalWithFlagValue<U>& other) {
 			if (other.has_value()) {
 				new (std::addressof(_value)) T(*other);
@@ -1167,7 +1168,8 @@ namespace fastgltf {
 			}
 		}
 
-		template <typename U = T, std::enable_if_t<std::is_move_constructible_v<T>, int> = 0>
+		template <typename U = T>
+		requires std::is_move_constructible_v<T>
 		OptionalWithFlagValue(OptionalWithFlagValue<U>&& other) {
 			if (other.has_value()) {
 				new (std::addressof(_value)) T(std::move(*other));
@@ -1176,11 +1178,13 @@ namespace fastgltf {
 			}
 		}
 
-		template<typename... Args, std::enable_if_t<std::is_constructible_v<T, Args...>, int> = 0>
+		template<typename... Args>
+		requires std::is_constructible_v<T, Args...>
 		explicit OptionalWithFlagValue(std::in_place_t, Args&& ... args) noexcept(std::is_nothrow_constructible_v<T, Args...>)
 			: _value(std::forward<Args>(args)...) {}
 
-		template <typename U = T, std::enable_if_t<std::is_constructible_v<T, U&&>, int> = 0>
+		template <typename U = T>
+		requires std::is_constructible_v<T, U&&>
 		OptionalWithFlagValue(U&& _new) noexcept(std::is_nothrow_assignable_v<T&, U> && std::is_nothrow_constructible_v<T, U>) {
 			new (std::addressof(_value)) T(std::forward<U>(_new));
 		}
@@ -1194,7 +1198,8 @@ namespace fastgltf {
 			return *this;
 		}
 
-		template<typename U = T, std::enable_if_t<std::is_constructible_v<T, U&&>, int> = 0>
+		template <typename U = T>
+		requires std::is_constructible_v<T, U&&>
 		OptionalWithFlagValue& operator=(U&& _new) noexcept(std::is_nothrow_assignable_v<T&, U> && std::is_nothrow_constructible_v<T, U>) {
 			if (has_value()) {
 				_value = std::forward<U>(_new);
@@ -1204,7 +1209,8 @@ namespace fastgltf {
 			return *this;
 		}
 
-		template <typename U, std::enable_if_t<std::conjunction_v<std::is_constructible<T, const U&>, std::is_assignable<T&, const U&>>, int> = 0>
+		template <typename U>
+		requires std::conjunction_v<std::is_constructible<T, const U&>, std::is_assignable<T&, const U&>>
 		OptionalWithFlagValue& operator=(const OptionalWithFlagValue<U>& other) {
 			if (other.has_value()) {
 				if (has_value()) {
@@ -1218,7 +1224,8 @@ namespace fastgltf {
 			return *this;
 		}
 
-		template <typename U, std::enable_if_t<std::conjunction_v<std::is_constructible<T, U>, std::is_assignable<T&, U>>, int> = 0>
+		template <typename U>
+		requires std::conjunction_v<std::is_constructible<T, U>, std::is_assignable<T&, U>>
 		OptionalWithFlagValue& operator=(OptionalWithFlagValue<U>&& other) noexcept(std::is_nothrow_assignable_v<T&, T> && std::is_nothrow_constructible_v<T, T>) {
 			if (other.has_value()) {
 				if (has_value()) {
@@ -1613,7 +1620,8 @@ namespace fastgltf {
 			}
 		}
 
-		template <typename T, std::enable_if_t<is_valid_type_v<T>, bool> = true>
+		template <typename T>
+		requires is_valid_type_v<T>
 		static AccessorBoundsArray ForType(const std::size_t len) {
 			if constexpr (std::is_same_v<T, std::int64_t>) {
 				return AccessorBoundsArray(len, BoundsType::int64);
@@ -1682,7 +1690,8 @@ namespace fastgltf {
 			return dataType;
 		}
 
-		template <typename T, std::enable_if_t<is_valid_type_v<T>, bool> = true>
+		template <typename T>
+		requires is_valid_type_v<T>
 		[[nodiscard]] bool isType() const noexcept {
 			switch (dataType) {
 				case BoundsType::int64:
@@ -1698,7 +1707,8 @@ namespace fastgltf {
 			return len;
 		}
 
-		template <typename T, std::enable_if_t<is_valid_type_v<T>, bool> = true>
+		template <typename T>
+		requires is_valid_type_v<T>
 		[[nodiscard]] auto* data() noexcept {
 			assert(isType<T>());
 			if constexpr (std::is_same_v<T, std::int64_t>) {
@@ -1709,7 +1719,8 @@ namespace fastgltf {
 			FASTGLTF_UNREACHABLE
 		}
 
-		template <typename T, std::enable_if_t<is_valid_type_v<T>, bool> = true>
+		template <typename T>
+		requires is_valid_type_v<T>
 		[[nodiscard]] const auto* data() const noexcept {
 			assert(isType<T>());
 			if constexpr (std::is_same_v<T, std::int64_t>) {
@@ -1720,13 +1731,15 @@ namespace fastgltf {
 			FASTGLTF_UNREACHABLE
 		}
 
-		template <typename T, std::enable_if_t<is_valid_type_v<T>, bool> = true>
+		template <typename T>
+		requires is_valid_type_v<T>
 		[[nodiscard]] T get(const std::size_t pos) const {
 			assert(pos < len && isType<T>());
 			return data<T>()[pos];
 		}
 
-		template <typename T, std::enable_if_t<is_valid_type_v<T>, bool> = true>
+		template <typename T>
+		requires is_valid_type_v<T>
 		void set(const std::size_t pos, const T value) {
 			assert(pos < len && isType<T>());
 			data<T>()[pos] = value;
@@ -2577,7 +2590,8 @@ namespace fastgltf {
 		/**
 		 * Helper function that updates the max/min variables dynamically.
 		 */
-		template <typename T, std::enable_if_t<AccessorBoundsArray::is_valid_type_v<T>, bool> = true>
+		template <typename T>
+		requires AccessorBoundsArray::is_valid_type_v<T>
 		void updateBoundsToInclude(T value) {
 			if (!max)
 				max = AccessorBoundsArray::ForType<T>(1);
@@ -2599,7 +2613,8 @@ namespace fastgltf {
 		 * Helper function that updates the max/min variables dynamically. Note that the value passed in
 		 * needs to be a vector with the same size as max/min
 		 */
-		template <typename T, std::size_t N, std::enable_if_t<AccessorBoundsArray::is_valid_type_v<T>, bool> = true>
+		template <typename T, std::size_t N>
+		requires AccessorBoundsArray::is_valid_type_v<T>
 		void updateBoundsToInclude(math::vec<T, N> value) {
 			if (!max)
 				max = AccessorBoundsArray::ForType<T>(value.size());

--- a/include/fastgltf/util.hpp
+++ b/include/fastgltf/util.hpp
@@ -83,15 +83,6 @@
 #define FASTGLTF_IS_A64 1
 #endif
 
-#if FASTGLTF_CPP_20 || (defined(__clang__) && __clang_major__ >= 12) || (defined(__GNUC__) && __GNUC__ >= 9)
-// These attributes were introduced with C++20, but Clang 12 already supports them since C++11.
-#define FASTGLTF_LIKELY [[likely]]
-#define FASTGLTF_UNLIKELY [[unlikely]]
-#else
-#define FASTGLTF_LIKELY
-#define FASTGLTF_UNLIKELY
-#endif
-
 #if (_MSC_VER && !defined(__clang__)) || __has_cpp_attribute(msvc::intrinsic)
 #define FASTGLTF_INTRINSIC [[msvc::intrinsic]]
 #else

--- a/include/fastgltf/util.hpp
+++ b/include/fastgltf/util.hpp
@@ -28,302 +28,309 @@
 #define FASTGLTF_UTIL_HPP
 
 #if !defined(FASTGLTF_USE_STD_MODULE) || !FASTGLTF_USE_STD_MODULE
-#include <array>
-#include <bit>
-#include <cmath>
-#include <concepts>
-#include <cstddef>
-#include <cstdint>
-#include <cstring>
-#include <limits>
-#include <memory>
-#include <string_view>
-#include <type_traits>
-#include <variant>
+#	include <array>
+#	include <bit>
+#	include <cmath>
+#	include <concepts>
+#	include <cstddef>
+#	include <cstdint>
+#	include <cstring>
+#	include <limits>
+#	include <memory>
+#	include <string_view>
+#	include <type_traits>
+#	include <variant>
 #endif
 
 #ifndef FASTGLTF_EXPORT
-#define FASTGLTF_EXPORT
+#	define FASTGLTF_EXPORT
 #endif
 
 // Macros to determine C++ standard version
-#if (!defined(_MSVC_LANG) && __cplusplus >= 202002L) || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)
-#define FASTGLTF_CPP_20 1
-#include <version>
+#if (!defined(_MSVC_LANG) && __cplusplus >= 202002L) || \
+	(defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)
+#	define FASTGLTF_CPP_20 1
+#	include <version>
 #else
-#error "fastgltf requires C++20"
+#	error "fastgltf requires C++20"
 #endif
 
-#if (!defined(_MSVC_LANG) && __cplusplus >= 202302L) || (defined(_MSVC_LANG) && _MSVC_LANG >= 202302L)
-#define FASTGLTF_CPP_23 1
+#if (!defined(_MSVC_LANG) && __cplusplus >= 202302L) || \
+	(defined(_MSVC_LANG) && _MSVC_LANG >= 202302L)
+#	define FASTGLTF_CPP_23 1
 #else
-#define FASTGLTF_CPP_23 0
+#	define FASTGLTF_CPP_23 0
 #endif
 
 #if FASTGLTF_CPP_23
-#define FASTGLTF_UNREACHABLE std::unreachable();
+#	define FASTGLTF_UNREACHABLE std::unreachable();
 #elif defined(__GNUC__) || defined(__clang__)
-#define FASTGLTF_UNREACHABLE __builtin_unreachable();
+#	define FASTGLTF_UNREACHABLE __builtin_unreachable();
 #elif defined(_MSC_VER)
-#define FASTGLTF_UNREACHABLE __assume(false);
+#	define FASTGLTF_UNREACHABLE __assume(false);
 #else
-#define FASTGLTF_UNREACHABLE assert(0);
+#	define FASTGLTF_UNREACHABLE assert(0);
 #endif
 
 #if defined(__has_builtin)
-#define FASTGLTF_HAS_BUILTIN(x) __has_builtin(x)
+#	define FASTGLTF_HAS_BUILTIN(x) __has_builtin(x)
 #else
-#define FASTGLTF_HAS_BUILTIN(x) 0
+#	define FASTGLTF_HAS_BUILTIN(x) 0
 #endif
 
 #if defined(__x86_64__) || defined(_M_AMD64) || defined(_M_IX86)
-#define FASTGLTF_IS_X86 1
+#	define FASTGLTF_IS_X86 1
 #elif defined(_M_ARM64) || defined(__aarch64__)
-// __ARM_NEON is only for general Neon availability. It does not guarantee the full A64 instruction set.
-#define FASTGLTF_IS_A64 1
+// __ARM_NEON is only for general Neon availability. It does not guarantee the full A64 instruction
+// set.
+#	define FASTGLTF_IS_A64 1
 #endif
 
 #if (_MSC_VER && !defined(__clang__)) || __has_cpp_attribute(msvc::intrinsic)
-#define FASTGLTF_INTRINSIC [[msvc::intrinsic]]
+#	define FASTGLTF_INTRINSIC [[msvc::intrinsic]]
 #else
-#define FASTGLTF_INTRINSIC
+#	define FASTGLTF_INTRINSIC
 #endif
 
 #if defined(_MSC_VER)
-#define FASTGLTF_FORCEINLINE __forceinline
+#	define FASTGLTF_FORCEINLINE __forceinline
 #elif defined(__GNUC__) || defined(__clang__)
-#define FASTGLTF_FORCEINLINE [[gnu::always_inline]] inline
+#	define FASTGLTF_FORCEINLINE [[gnu::always_inline]] inline
 #else
 // On other compilers we need the inline specifier, so that the functions in this compilation unit
 // can be properly inlined without the "function body can be overwritten at link time" error.
-#define FASTGLTF_FORCEINLINE inline
+#	define FASTGLTF_FORCEINLINE inline
 #endif
 
 #ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 5030) // attribute 'x' is not recognized
-#pragma warning(disable : 4514) // unreferenced inline function has been removed
+#	pragma warning(push)
+#	pragma warning(disable : 5030)  // attribute 'x' is not recognized
+#	pragma warning(disable : 4514)  // unreferenced inline function has been removed
 #endif
 
 namespace fastgltf {
-	FASTGLTF_EXPORT template<typename T>
-	requires std::is_enum_v<T>
-	[[nodiscard]] FASTGLTF_INTRINSIC constexpr std::underlying_type_t<T> to_underlying(T t) noexcept {
-		return static_cast<std::underlying_type_t<T>>(t);
-	}
+FASTGLTF_EXPORT template <typename T>
+requires std::is_enum_v<T>
+[[nodiscard]] FASTGLTF_INTRINSIC constexpr std::underlying_type_t<T> to_underlying(T t) noexcept {
+	return static_cast<std::underlying_type_t<T>>(t);
+}
 
-	FASTGLTF_EXPORT template <typename T, typename U>
-	requires ((std::is_enum_v<T> && std::integral<std::underlying_type_t<T>>) || std::integral<T>) && requires (T t, U u) {
-		{ t & u } -> std::same_as<U>;
-	}
-	[[nodiscard]] constexpr bool hasBit(T flags, U bit) {
-		return (flags & bit) == bit;
-	}
+FASTGLTF_EXPORT template <typename T, typename U>
+requires((std::is_enum_v<T> && std::integral<std::underlying_type_t<T>>) || std::integral<T>) &&
+		requires(T t, U u) {
+			{ t & u } -> std::same_as<U>;
+		}
+[[nodiscard]] constexpr bool hasBit(T flags, U bit) {
+	return (flags & bit) == bit;
+}
 
-	template <typename T, typename U>
-	[[nodiscard]] constexpr T alignUp(T base, U alignment) {
-		static_assert(std::is_signed_v<U>, "alignUp requires type U to be signed.");
-		return (base + alignment - 1) & -alignment;
-	}
+template <typename T, typename U>
+[[nodiscard]] constexpr T alignUp(T base, U alignment) {
+	static_assert(std::is_signed_v<U>, "alignUp requires type U to be signed.");
+	return (base + alignment - 1) & -alignment;
+}
 
-	template <typename T>
-	[[nodiscard]] constexpr T alignDown(T base, T alignment) {
-		return base - (base % alignment);
-	}
+template <typename T>
+[[nodiscard]] constexpr T alignDown(T base, T alignment) {
+	return base - (base % alignment);
+}
 
-	FASTGLTF_EXPORT template <typename T>
-	requires requires (T t) {
-		{ t > t } -> std::same_as<bool>;
-	}
-	[[nodiscard]] constexpr const T& max(const T& a, const T& b) noexcept {
-		return (a > b) ? a : b;
-	}
+FASTGLTF_EXPORT template <typename T>
+requires requires(T t) {
+	{ t > t } -> std::same_as<bool>;
+}
+[[nodiscard]] constexpr const T& max(const T& a, const T& b) noexcept {
+	return (a > b) ? a : b;
+}
 
-	FASTGLTF_EXPORT template <typename T>
-	requires requires (T t) {
-		{ t < t } -> std::same_as<bool>;
-	}
-	[[nodiscard]] constexpr const T& min(const T& a, const T& b) noexcept {
-		return (a < b) ? a : b;
-	}
+FASTGLTF_EXPORT template <typename T>
+requires requires(T t) {
+	{ t < t } -> std::same_as<bool>;
+}
+[[nodiscard]] constexpr const T& min(const T& a, const T& b) noexcept {
+	return (a < b) ? a : b;
+}
 
-	template<typename T, typename... A>
-	[[noreturn]] constexpr void raise(A&&... args) {
+template <typename T, typename... A>
+[[noreturn]] constexpr void raise(A&&... args) {
 #ifdef __cpp_exceptions
-		throw T(std::forward<A>(args)...);
+	throw T(std::forward<A>(args)...);
 #else
-		std::abort();
+	std::abort();
 #endif
-	}
+}
 
-	/**
-	 * Constants generated using 0x82f63b79u CRC poly.
-	 */
-	static constexpr std::array<std::uint32_t, 256> crcHashTable = {{
-		0x00000000, 0xf26b8303, 0xe13b70f7, 0x1350f3f4, 0xc79a971f, 0x35f1141c, 0x26a1e7e8, 0xd4ca64eb,
-		0x8ad958cf, 0x78b2dbcc, 0x6be22838, 0x9989ab3b, 0x4d43cfd0, 0xbf284cd3, 0xac78bf27, 0x5e133c24,
-		0x105ec76f, 0xe235446c, 0xf165b798, 0x030e349b, 0xd7c45070, 0x25afd373, 0x36ff2087, 0xc494a384,
-		0x9a879fa0, 0x68ec1ca3, 0x7bbcef57, 0x89d76c54, 0x5d1d08bf, 0xaf768bbc, 0xbc267848, 0x4e4dfb4b,
-		0x20bd8ede, 0xd2d60ddd, 0xc186fe29, 0x33ed7d2a, 0xe72719c1, 0x154c9ac2, 0x061c6936, 0xf477ea35,
-		0xaa64d611, 0x580f5512, 0x4b5fa6e6, 0xb93425e5, 0x6dfe410e, 0x9f95c20d, 0x8cc531f9, 0x7eaeb2fa,
-		0x30e349b1, 0xc288cab2, 0xd1d83946, 0x23b3ba45, 0xf779deae, 0x05125dad, 0x1642ae59, 0xe4292d5a,
-		0xba3a117e, 0x4851927d, 0x5b016189, 0xa96ae28a, 0x7da08661, 0x8fcb0562, 0x9c9bf696, 0x6ef07595,
-		0x417b1dbc, 0xb3109ebf, 0xa0406d4b, 0x522bee48, 0x86e18aa3, 0x748a09a0, 0x67dafa54, 0x95b17957,
-		0xcba24573, 0x39c9c670, 0x2a993584, 0xd8f2b687, 0x0c38d26c, 0xfe53516f, 0xed03a29b, 0x1f682198,
-		0x5125dad3, 0xa34e59d0, 0xb01eaa24, 0x42752927, 0x96bf4dcc, 0x64d4cecf, 0x77843d3b, 0x85efbe38,
-		0xdbfc821c, 0x2997011f, 0x3ac7f2eb, 0xc8ac71e8, 0x1c661503, 0xee0d9600, 0xfd5d65f4, 0x0f36e6f7,
-		0x61c69362, 0x93ad1061, 0x80fde395, 0x72966096, 0xa65c047d, 0x5437877e, 0x4767748a, 0xb50cf789,
-		0xeb1fcbad, 0x197448ae, 0x0a24bb5a, 0xf84f3859, 0x2c855cb2, 0xdeeedfb1, 0xcdbe2c45, 0x3fd5af46,
-		0x7198540d, 0x83f3d70e, 0x90a324fa, 0x62c8a7f9, 0xb602c312, 0x44694011, 0x5739b3e5, 0xa55230e6,
-		0xfb410cc2, 0x092a8fc1, 0x1a7a7c35, 0xe811ff36, 0x3cdb9bdd, 0xceb018de, 0xdde0eb2a, 0x2f8b6829,
-		0x82f63b78, 0x709db87b, 0x63cd4b8f, 0x91a6c88c, 0x456cac67, 0xb7072f64, 0xa457dc90, 0x563c5f93,
-		0x082f63b7, 0xfa44e0b4, 0xe9141340, 0x1b7f9043, 0xcfb5f4a8, 0x3dde77ab, 0x2e8e845f, 0xdce5075c,
-		0x92a8fc17, 0x60c37f14, 0x73938ce0, 0x81f80fe3, 0x55326b08, 0xa759e80b, 0xb4091bff, 0x466298fc,
-		0x1871a4d8, 0xea1a27db, 0xf94ad42f, 0x0b21572c, 0xdfeb33c7, 0x2d80b0c4, 0x3ed04330, 0xccbbc033,
-		0xa24bb5a6, 0x502036a5, 0x4370c551, 0xb11b4652, 0x65d122b9, 0x97baa1ba, 0x84ea524e, 0x7681d14d,
-		0x2892ed69, 0xdaf96e6a, 0xc9a99d9e, 0x3bc21e9d, 0xef087a76, 0x1d63f975, 0x0e330a81, 0xfc588982,
-		0xb21572c9, 0x407ef1ca, 0x532e023e, 0xa145813d, 0x758fe5d6, 0x87e466d5, 0x94b49521, 0x66df1622,
-		0x38cc2a06, 0xcaa7a905, 0xd9f75af1, 0x2b9cd9f2, 0xff56bd19, 0x0d3d3e1a, 0x1e6dcdee, 0xec064eed,
-		0xc38d26c4, 0x31e6a5c7, 0x22b65633, 0xd0ddd530, 0x0417b1db, 0xf67c32d8, 0xe52cc12c, 0x1747422f,
-		0x49547e0b, 0xbb3ffd08, 0xa86f0efc, 0x5a048dff, 0x8ecee914, 0x7ca56a17, 0x6ff599e3, 0x9d9e1ae0,
-		0xd3d3e1ab, 0x21b862a8, 0x32e8915c, 0xc083125f, 0x144976b4, 0xe622f5b7, 0xf5720643, 0x07198540,
-		0x590ab964, 0xab613a67, 0xb831c993, 0x4a5a4a90, 0x9e902e7b, 0x6cfbad78, 0x7fab5e8c, 0x8dc0dd8f,
-		0xe330a81a, 0x115b2b19, 0x020bd8ed, 0xf0605bee, 0x24aa3f05, 0xd6c1bc06, 0xc5914ff2, 0x37faccf1,
-		0x69e9f0d5, 0x9b8273d6, 0x88d28022, 0x7ab90321, 0xae7367ca, 0x5c18e4c9, 0x4f48173d, 0xbd23943e,
-		0xf36e6f75, 0x0105ec76, 0x12551f82, 0xe03e9c81, 0x34f4f86a, 0xc69f7b69, 0xd5cf889d, 0x27a40b9e,
-		0x79b737ba, 0x8bdcb4b9, 0x988c474d, 0x6ae7c44e, 0xbe2da0a5, 0x4c4623a6, 0x5f16d052, 0xad7d5351,
-	}};
+/**
+ * Constants generated using 0x82f63b79u CRC poly.
+ */
+static constexpr std::array<std::uint32_t, 256> crcHashTable = {{
+	0x00000000, 0xf26b8303, 0xe13b70f7, 0x1350f3f4, 0xc79a971f, 0x35f1141c, 0x26a1e7e8, 0xd4ca64eb,
+	0x8ad958cf, 0x78b2dbcc, 0x6be22838, 0x9989ab3b, 0x4d43cfd0, 0xbf284cd3, 0xac78bf27, 0x5e133c24,
+	0x105ec76f, 0xe235446c, 0xf165b798, 0x030e349b, 0xd7c45070, 0x25afd373, 0x36ff2087, 0xc494a384,
+	0x9a879fa0, 0x68ec1ca3, 0x7bbcef57, 0x89d76c54, 0x5d1d08bf, 0xaf768bbc, 0xbc267848, 0x4e4dfb4b,
+	0x20bd8ede, 0xd2d60ddd, 0xc186fe29, 0x33ed7d2a, 0xe72719c1, 0x154c9ac2, 0x061c6936, 0xf477ea35,
+	0xaa64d611, 0x580f5512, 0x4b5fa6e6, 0xb93425e5, 0x6dfe410e, 0x9f95c20d, 0x8cc531f9, 0x7eaeb2fa,
+	0x30e349b1, 0xc288cab2, 0xd1d83946, 0x23b3ba45, 0xf779deae, 0x05125dad, 0x1642ae59, 0xe4292d5a,
+	0xba3a117e, 0x4851927d, 0x5b016189, 0xa96ae28a, 0x7da08661, 0x8fcb0562, 0x9c9bf696, 0x6ef07595,
+	0x417b1dbc, 0xb3109ebf, 0xa0406d4b, 0x522bee48, 0x86e18aa3, 0x748a09a0, 0x67dafa54, 0x95b17957,
+	0xcba24573, 0x39c9c670, 0x2a993584, 0xd8f2b687, 0x0c38d26c, 0xfe53516f, 0xed03a29b, 0x1f682198,
+	0x5125dad3, 0xa34e59d0, 0xb01eaa24, 0x42752927, 0x96bf4dcc, 0x64d4cecf, 0x77843d3b, 0x85efbe38,
+	0xdbfc821c, 0x2997011f, 0x3ac7f2eb, 0xc8ac71e8, 0x1c661503, 0xee0d9600, 0xfd5d65f4, 0x0f36e6f7,
+	0x61c69362, 0x93ad1061, 0x80fde395, 0x72966096, 0xa65c047d, 0x5437877e, 0x4767748a, 0xb50cf789,
+	0xeb1fcbad, 0x197448ae, 0x0a24bb5a, 0xf84f3859, 0x2c855cb2, 0xdeeedfb1, 0xcdbe2c45, 0x3fd5af46,
+	0x7198540d, 0x83f3d70e, 0x90a324fa, 0x62c8a7f9, 0xb602c312, 0x44694011, 0x5739b3e5, 0xa55230e6,
+	0xfb410cc2, 0x092a8fc1, 0x1a7a7c35, 0xe811ff36, 0x3cdb9bdd, 0xceb018de, 0xdde0eb2a, 0x2f8b6829,
+	0x82f63b78, 0x709db87b, 0x63cd4b8f, 0x91a6c88c, 0x456cac67, 0xb7072f64, 0xa457dc90, 0x563c5f93,
+	0x082f63b7, 0xfa44e0b4, 0xe9141340, 0x1b7f9043, 0xcfb5f4a8, 0x3dde77ab, 0x2e8e845f, 0xdce5075c,
+	0x92a8fc17, 0x60c37f14, 0x73938ce0, 0x81f80fe3, 0x55326b08, 0xa759e80b, 0xb4091bff, 0x466298fc,
+	0x1871a4d8, 0xea1a27db, 0xf94ad42f, 0x0b21572c, 0xdfeb33c7, 0x2d80b0c4, 0x3ed04330, 0xccbbc033,
+	0xa24bb5a6, 0x502036a5, 0x4370c551, 0xb11b4652, 0x65d122b9, 0x97baa1ba, 0x84ea524e, 0x7681d14d,
+	0x2892ed69, 0xdaf96e6a, 0xc9a99d9e, 0x3bc21e9d, 0xef087a76, 0x1d63f975, 0x0e330a81, 0xfc588982,
+	0xb21572c9, 0x407ef1ca, 0x532e023e, 0xa145813d, 0x758fe5d6, 0x87e466d5, 0x94b49521, 0x66df1622,
+	0x38cc2a06, 0xcaa7a905, 0xd9f75af1, 0x2b9cd9f2, 0xff56bd19, 0x0d3d3e1a, 0x1e6dcdee, 0xec064eed,
+	0xc38d26c4, 0x31e6a5c7, 0x22b65633, 0xd0ddd530, 0x0417b1db, 0xf67c32d8, 0xe52cc12c, 0x1747422f,
+	0x49547e0b, 0xbb3ffd08, 0xa86f0efc, 0x5a048dff, 0x8ecee914, 0x7ca56a17, 0x6ff599e3, 0x9d9e1ae0,
+	0xd3d3e1ab, 0x21b862a8, 0x32e8915c, 0xc083125f, 0x144976b4, 0xe622f5b7, 0xf5720643, 0x07198540,
+	0x590ab964, 0xab613a67, 0xb831c993, 0x4a5a4a90, 0x9e902e7b, 0x6cfbad78, 0x7fab5e8c, 0x8dc0dd8f,
+	0xe330a81a, 0x115b2b19, 0x020bd8ed, 0xf0605bee, 0x24aa3f05, 0xd6c1bc06, 0xc5914ff2, 0x37faccf1,
+	0x69e9f0d5, 0x9b8273d6, 0x88d28022, 0x7ab90321, 0xae7367ca, 0x5c18e4c9, 0x4f48173d, 0xbd23943e,
+	0xf36e6f75, 0x0105ec76, 0x12551f82, 0xe03e9c81, 0x34f4f86a, 0xc69f7b69, 0xd5cf889d, 0x27a40b9e,
+	0x79b737ba, 0x8bdcb4b9, 0x988c474d, 0x6ae7c44e, 0xbe2da0a5, 0x4c4623a6, 0x5f16d052, 0xad7d5351,
+}};
 
-	[[gnu::hot, gnu::const]] constexpr std::uint32_t crc32c(std::string_view str) noexcept {
-		std::uint32_t crc = 0;
-		for (auto c : str)
-			crc = (crc >> 8) ^ crcHashTable[(crc ^ static_cast<std::uint8_t>(c)) & 0xff];
-		return crc;
-	}
+[[gnu::hot, gnu::const]] constexpr std::uint32_t crc32c(std::string_view str) noexcept {
+	std::uint32_t crc = 0;
+	for (auto c : str) crc = (crc >> 8) ^ crcHashTable[(crc ^ static_cast<std::uint8_t>(c)) & 0xff];
+	return crc;
+}
 
-	[[gnu::hot, gnu::const]] constexpr std::uint32_t crc32c(const std::uint8_t* d, std::size_t len) noexcept {
-		std::uint32_t crc = 0;
-		for (std::size_t i = 0; i < len; ++i)
-			crc = (crc >> 8) ^ crcHashTable[(crc ^ d[i]) & 0xff];
-		return crc;
-	}
+[[gnu::hot, gnu::const]] constexpr std::uint32_t crc32c(const std::uint8_t* d,
+														std::size_t len) noexcept {
+	std::uint32_t crc = 0;
+	for (std::size_t i = 0; i < len; ++i) crc = (crc >> 8) ^ crcHashTable[(crc ^ d[i]) & 0xff];
+	return crc;
+}
 
 #if defined(FASTGLTF_IS_X86)
-	/**
-	 * Variant of crc32 that uses SSE4.2 instructions to increase performance. Note that this does not
-	 * check for availability of said instructions.
-	 */
-	[[gnu::hot, gnu::const]] std::uint32_t sse_crc32c(std::string_view str) noexcept;
-	[[gnu::hot, gnu::const]] std::uint32_t sse_crc32c(const std::uint8_t* d, std::size_t len) noexcept;
+/**
+ * Variant of crc32 that uses SSE4.2 instructions to increase performance. Note that this does not
+ * check for availability of said instructions.
+ */
+[[gnu::hot, gnu::const]] std::uint32_t sse_crc32c(std::string_view str) noexcept;
+[[gnu::hot, gnu::const]] std::uint32_t sse_crc32c(const std::uint8_t* d, std::size_t len) noexcept;
 #elif defined(FASTGLTF_IS_A64) && !defined(_MSC_VER) && !defined(__ANDROID__)
-	// Both MSVC stdlib and Android NDK don't include the arm intrinsics. TODO: Find a workaround?
-#define FASTGLTF_ENABLE_ARMV8_CRC 1
-	[[gnu::hot, gnu::const]] std::uint32_t armv8_crc32c(std::string_view str) noexcept;
-	[[gnu::hot, gnu::const]] std::uint32_t armv8_crc32c(const std::uint8_t* d, std::size_t len) noexcept;
+// Both MSVC stdlib and Android NDK don't include the arm intrinsics. TODO: Find a workaround?
+#	define FASTGLTF_ENABLE_ARMV8_CRC 1
+[[gnu::hot, gnu::const]] std::uint32_t armv8_crc32c(std::string_view str) noexcept;
+[[gnu::hot, gnu::const]] std::uint32_t armv8_crc32c(const std::uint8_t* d,
+													std::size_t len) noexcept;
 #endif
 
-	/**
-	 * Helper to force evaluation of constexpr functions at compile-time in C++17. One example of
-	 * this is with crc32: force_consteval<crc32("string")>. No matter the context, this will
-	 * always be evaluated to a constant.
-	 */
-	template <auto V>
-	static constexpr auto force_consteval = V;
+/**
+ * Helper to force evaluation of constexpr functions at compile-time in C++17. One example of
+ * this is with crc32: force_consteval<crc32("string")>. No matter the context, this will
+ * always be evaluated to a constant.
+ */
+template <auto V>
+static constexpr auto force_consteval = V;
 
-	/**
-	 * Essentially the same as std::same<T, U> but it accepts multiple different types for U,
-	 * checking if T is any of U...
-	 */
-	template <typename T, typename... Ts>
-	using is_any_of = std::disjunction<std::is_same<T, Ts>...>;
+/**
+ * Essentially the same as std::same<T, U> but it accepts multiple different types for U,
+ * checking if T is any of U...
+ */
+template <typename T, typename... Ts>
+using is_any_of = std::disjunction<std::is_same<T, Ts>...>;
 
-	template <typename T, typename... Ts>
-	constexpr bool is_any_of_v = is_any_of<T, Ts...>::value;
+template <typename T, typename... Ts>
+constexpr bool is_any_of_v = is_any_of<T, Ts...>::value;
 
-	/**
-	 * Helper type in order to allow building a visitor out of multiple lambdas within a call to
-	 * std::visit
-	 */
-	FASTGLTF_EXPORT template<class... Ts>
-	struct visitor : Ts... {
-		using Ts::operator()...;
-	};
+/**
+ * Helper type in order to allow building a visitor out of multiple lambdas within a call to
+ * std::visit
+ */
+FASTGLTF_EXPORT template <class... Ts>
+struct visitor : Ts... {
+	using Ts::operator()...;
+};
 
-	FASTGLTF_EXPORT template<class... Ts> visitor(Ts...) -> visitor<Ts...>;
+FASTGLTF_EXPORT template <class... Ts>
+visitor(Ts...) -> visitor<Ts...>;
 
-	template <typename Visitor, typename Variant, std::size_t... i>
-	constexpr bool is_exhaustive_visitor(std::integer_sequence<std::size_t, i...>) noexcept {
-		return std::conjunction_v<std::is_invocable<Visitor, std::variant_alternative_t<i, std::remove_cvref_t<Variant>>>...>;
+template <typename Visitor, typename Variant, std::size_t... i>
+constexpr bool is_exhaustive_visitor(std::integer_sequence<std::size_t, i...>) noexcept {
+	return std::conjunction_v<
+		std::is_invocable<Visitor, std::variant_alternative_t<i, std::remove_cvref_t<Variant>>>...>;
+}
+
+/**
+ * Simple wrapper around std::visit for a single variant that checks at compile-time if the given
+ * visitor contains overloads for *all* required alternatives. This is meant to guarantee
+ * correctness, since using something like fastgltf::visitor could fail unexpectedly due to
+ * const-issues without any compile-time errors or warnings.
+ * @note This currently does not support auto parameters.
+ */
+FASTGLTF_EXPORT template <typename Visitor, typename Variant>
+constexpr decltype(auto) visit_exhaustive(Visitor&& visitor, Variant&& variant) {
+	static_assert(
+		is_exhaustive_visitor<Visitor, Variant>(
+			std::make_index_sequence<std::variant_size_v<std::remove_cvref_t<Variant>>>()),
+		"The visitor does not include all necessary overloads for the given variant");
+	return std::visit(std::forward<Visitor>(visitor), std::forward<Variant>(variant));
+}
+
+template <auto callback>
+struct UniqueDeleter {
+	template <typename T>
+	constexpr void operator()(T* t) const {
+		callback(t);
 	}
+};
 
-	/**
-	 * Simple wrapper around std::visit for a single variant that checks at compile-time if the given visitor contains
-	 * overloads for *all* required alternatives. This is meant to guarantee correctness, since using something like
-	 * fastgltf::visitor could fail unexpectedly due to const-issues without any compile-time errors or warnings.
-	 * @note This currently does not support auto parameters.
-	 */
-	FASTGLTF_EXPORT template<typename Visitor, typename Variant>
-	constexpr decltype(auto) visit_exhaustive(Visitor&& visitor, Variant&& variant) {
-		static_assert(is_exhaustive_visitor<Visitor, Variant>(std::make_index_sequence<std::variant_size_v<std::remove_cvref_t<Variant>>>()),
-			"The visitor does not include all necessary overloads for the given variant");
-		return std::visit(std::forward<Visitor>(visitor), std::forward<Variant>(variant));
-	}
-
-	template <auto callback>
-	struct UniqueDeleter {
-		template <typename T>
-		constexpr void operator()(T* t) const {
-			callback(t);
-		}
-	};
-
-	// For simple ops like &, |, +, - taking a left and right operand.
-#define FASTGLTF_ARITHMETIC_OP_TEMPLATE_MACRO(T1, T2, op) \
+// For simple ops like &, |, +, - taking a left and right operand.
+#define FASTGLTF_ARITHMETIC_OP_TEMPLATE_MACRO(T1, T2, op)                         \
 	FASTGLTF_EXPORT constexpr T1 operator op(const T1& a, const T2& b) noexcept { \
-		static_assert(std::is_enum_v<T1> && std::is_enum_v<T2>); \
-		return static_cast<T1>(to_underlying(a) op to_underlying(b)); \
+		static_assert(std::is_enum_v<T1> && std::is_enum_v<T2>);                  \
+		return static_cast<T1>(to_underlying(a) op to_underlying(b));             \
 	}
 
-	// For any ops like |=, &=, +=, -=
-#define FASTGLTF_ASSIGNMENT_OP_TEMPLATE_MACRO(T1, T2, op) \
-	FASTGLTF_EXPORT constexpr T1& operator op##=(T1& a, const T2& b) noexcept { \
-		static_assert(std::is_enum_v<T1> && std::is_enum_v<T2>); \
-		return a = static_cast<T1>(to_underlying(a) op to_underlying(b)), a; \
+// For any ops like |=, &=, +=, -=
+#define FASTGLTF_ASSIGNMENT_OP_TEMPLATE_MACRO(T1, T2, op)                         \
+	FASTGLTF_EXPORT constexpr T1& operator op##=(T1 & a, const T2 & b) noexcept { \
+		static_assert(std::is_enum_v<T1> && std::is_enum_v<T2>);                  \
+		return a = static_cast<T1>(to_underlying(a) op to_underlying(b)), a;      \
 	}
 
-	// For unary +, unary -, and bitwise NOT
-#define FASTGLTF_UNARY_OP_TEMPLATE_MACRO(T, op) \
+// For unary +, unary -, and bitwise NOT
+#define FASTGLTF_UNARY_OP_TEMPLATE_MACRO(T, op)                    \
 	FASTGLTF_EXPORT constexpr T operator op(const T& a) noexcept { \
-		static_assert(std::is_enum_v<T>); \
-		return static_cast<T>(op to_underlying(a)); \
+		static_assert(std::is_enum_v<T>);                          \
+		return static_cast<T>(op to_underlying(a));                \
 	}
 
-	/**
-	 * Returns the absolute value of the given integer in its unsigned type.
-	 * This avoids the issue with two complementary signed integers not being able to represent INT_MIN.
-	 */
-	template <std::integral T>
-	[[nodiscard]] constexpr std::make_unsigned_t<T> uabs(T val) {
-		if constexpr (std::is_signed_v<T>) {
-			using unsigned_t = std::make_unsigned_t<T>;
-			return (val < 0)
-				? static_cast<unsigned_t>(-(val + 1)) + 1
-				: static_cast<unsigned_t>(val);
-		} else {
-			return val;
-		}
+/**
+ * Returns the absolute value of the given integer in its unsigned type.
+ * This avoids the issue with two complementary signed integers not being able to represent INT_MIN.
+ */
+template <std::integral T>
+[[nodiscard]] constexpr std::make_unsigned_t<T> uabs(T val) {
+	if constexpr (std::is_signed_v<T>) {
+		using unsigned_t = std::make_unsigned_t<T>;
+		return (val < 0) ? static_cast<unsigned_t>(-(val + 1)) + 1 : static_cast<unsigned_t>(val);
+	} else {
+		return val;
 	}
+}
 
-	/**
-	 * Simple function to check if the given string starts with a given set of characters.
-	 */
-	inline bool startsWith(std::string_view str, std::string_view search) {
-		return str.rfind(search, 0) == 0;
-	}
-} // namespace fastgltf
+/**
+ * Simple function to check if the given string starts with a given set of characters.
+ */
+inline bool startsWith(std::string_view str, std::string_view search) {
+	return str.rfind(search, 0) == 0;
+}
+}  // namespace fastgltf
 
 #ifdef _MSC_VER
-#pragma warning(pop)
+#	pragma warning(pop)
 #endif
 
 #endif

--- a/src/base64.cpp
+++ b/src/base64.cpp
@@ -24,253 +24,267 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#if !defined(__cplusplus) || (!defined(_MSVC_LANG) && __cplusplus < 201703L) || (defined(_MSVC_LANG) && _MSVC_LANG < 201703L)
-#error "fastgltf requires C++17"
+#if !defined(__cplusplus) || (!defined(_MSVC_LANG) && __cplusplus < 202002L) || \
+	(defined(_MSVC_LANG) && _MSVC_LANG < 202002L)
+#	error "fastgltf requires C++20"
 #endif
 
 #include <array>
 #include <cmath>
+#include <fastgltf/base64.hpp>
 #include <functional>
 
 #include "simdjson.h"
 
-#include <fastgltf/base64.hpp>
-
 #if defined(FASTGLTF_IS_X86)
-#if defined(__clang__) || defined(__GNUC__)
+#	if defined(__clang__) || defined(__GNUC__)
 // The idea behind manually including all headers with the required intrinsics
 // is that the usual intrin.h will only include these under Clang when -mavx or
 // -mavx2 is specified, which in turn would have the entire program be compiled
 // with these instructions used in optimisations.
-#include <immintrin.h>
-#include <smmintrin.h>
-#include <avxintrin.h>
-#include <avx2intrin.h>
-#else
-#include <intrin.h>
-#endif
+// clang-format off
+#		include <immintrin.h>
+#		include <smmintrin.h>
+#		include <avxintrin.h>
+#		include <avx2intrin.h>
+// clang-format on
+#	else
+#		include <intrin.h>
+#	endif
 #elif defined(FASTGLTF_IS_A64)
-#include <arm_neon.h> // Includes arm64_neon.h on MSVC
+#	include <arm_neon.h>  // Includes arm64_neon.h on MSVC
 #endif
 
 #ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 5030) // attribute 'x' is not recognized
-#pragma warning(disable : 4710) // function not inlined
+#	pragma warning(push)
+#	pragma warning(disable : 5030)  // attribute 'x' is not recognized
+#	pragma warning(disable : 4710)  // function not inlined
 #endif
 
 namespace fg = fastgltf;
 
 namespace fastgltf::base64 {
-    using DecodeFunctionInplace = std::function<void(std::string_view, std::uint8_t*, std::size_t)>;
-    using DecodeFunction = std::function<fg::StaticVector<std::uint8_t>(std::string_view)>;
+using DecodeFunctionInplace = std::function<void(std::string_view, std::uint8_t*, std::size_t)>;
+using DecodeFunction = std::function<fg::StaticVector<std::uint8_t>(std::string_view)>;
 
-    struct DecodeFunctionGetter {
-        DecodeFunction func;
-        DecodeFunctionInplace inplace;
+struct DecodeFunctionGetter {
+	DecodeFunction func;
+	DecodeFunctionInplace inplace;
 
-        explicit DecodeFunctionGetter() {
-            // We use simdjson's helper functions to determine which SIMD intrinsics are available at runtime.
-            // The different implementations, because they're SIMD based, require a minimum amount of chars, as
-            // they load multiple at once.
-            const auto& impls = simdjson::get_available_implementations();
+	explicit DecodeFunctionGetter() {
+		// We use simdjson's helper functions to determine which SIMD intrinsics are available at
+		// runtime. The different implementations, because they're SIMD based, require a minimum
+		// amount of chars, as they load multiple at once.
+		const auto& impls = simdjson::get_available_implementations();
 #if defined(FASTGLTF_IS_X86)
-            if (const auto* avx2 = impls["haswell"]; avx2 != nullptr && avx2->supported_by_runtime_system()) {
-                func = avx2_decode;
-                inplace = avx2_decode_inplace;
-            } else if (const auto* sse4 = impls["westmere"]; sse4 != nullptr && sse4->supported_by_runtime_system()) {
-                func = sse4_decode;
-                inplace = sse4_decode_inplace;
-            }
+		if (const auto* avx2 = impls["haswell"];
+			avx2 != nullptr && avx2->supported_by_runtime_system()) {
+			func = avx2_decode;
+			inplace = avx2_decode_inplace;
+		} else if (const auto* sse4 = impls["westmere"];
+				   sse4 != nullptr && sse4->supported_by_runtime_system()) {
+			func = sse4_decode;
+			inplace = sse4_decode_inplace;
+		}
 #elif defined(FASTGLTF_IS_A64)
-            // _M_ARM64 always guarantees 64-bit ARM processors that support NEON, defined by MSVC.
-            // __aarch64__ always guarantees 64-bit ARMv8 processors that support NEON, defined by Clang.
-            // __ARM_NEON always guarantees NEON support, defined by Clang and GCC.
-            if (const auto* neon = impls["arm64"]; neon && neon->supported_by_runtime_system()) {
-                func = neon_decode;
-                inplace = neon_decode_inplace;
-            }
+		// _M_ARM64 always guarantees 64-bit ARM processors that support NEON, defined by MSVC.
+		// __aarch64__ always guarantees 64-bit ARMv8 processors that support NEON, defined by
+		// Clang.
+		// __ARM_NEON always guarantees NEON support, defined by Clang and GCC.
+		if (const auto* neon = impls["arm64"]; neon && neon->supported_by_runtime_system()) {
+			func = neon_decode;
+			inplace = neon_decode_inplace;
+		}
 #else
-            if (false) {}
+		if (false) {
+		}
 #endif
-            else {
-                func = fallback_decode;
-                inplace = fallback_decode_inplace;
-            }
-        }
+		else {
+			func = fallback_decode;
+			inplace = fallback_decode_inplace;
+		}
+	}
 
-        static DecodeFunctionGetter* get() {
-            static DecodeFunctionGetter getter;
-            return &getter;
-        }
-    };
-} // namespace fastgltf::base64
+	static DecodeFunctionGetter* get() {
+		static DecodeFunctionGetter getter;
+		return &getter;
+	}
+};
+}  // namespace fastgltf::base64
 
 #if defined(FASTGLTF_IS_X86)
-// The AVX and SSE decoding functions are based on http://0x80.pl/notesen/2016-01-17-sse-base64-decoding.html.
-// It covers various methods of en-/decoding base64 using SSE and AVX and also shows their
-// performance metrics.
+// The AVX and SSE decoding functions are based on
+// http://0x80.pl/notesen/2016-01-17-sse-base64-decoding.html. It covers various methods of
+// en-/decoding base64 using SSE and AVX and also shows their performance metrics.
 [[gnu::target("avx2")]] FASTGLTF_FORCEINLINE auto avx2_lookup_pshufb_bitmask(const __m256i input) {
-    const auto higher_nibble = _mm256_and_si256(_mm256_srli_epi32(input, 4), _mm256_set1_epi8(0x0f));
+	const auto higher_nibble =
+		_mm256_and_si256(_mm256_srli_epi32(input, 4), _mm256_set1_epi8(0x0f));
 
-    const auto shiftLUT = _mm256_setr_epi8(
-        0,   0,  19,   4, -65, -65, -71, -71,
-        0,   0,   0,   0,   0,   0,   0,   0,
+	const auto shiftLUT = _mm256_setr_epi8(0, 0, 19, 4, -65, -65, -71, -71, 0, 0, 0, 0, 0, 0, 0, 0,
 
-        0,   0,  19,   4, -65, -65, -71, -71,
-        0,   0,   0,   0,   0,   0,   0,   0);
+										   0, 0, 19, 4, -65, -65, -71, -71, 0, 0, 0, 0, 0, 0, 0, 0);
 
-    const auto sh     = _mm256_shuffle_epi8(shiftLUT,  higher_nibble);
-    const auto eq_2f  = _mm256_cmpeq_epi8(input, _mm256_set1_epi8(0x2f));
-    const auto shift  = _mm256_blendv_epi8(sh, _mm256_set1_epi8(16), eq_2f);
+	const auto sh = _mm256_shuffle_epi8(shiftLUT, higher_nibble);
+	const auto eq_2f = _mm256_cmpeq_epi8(input, _mm256_set1_epi8(0x2f));
+	const auto shift = _mm256_blendv_epi8(sh, _mm256_set1_epi8(16), eq_2f);
 
-    return _mm256_add_epi8(input, shift);
+	return _mm256_add_epi8(input, shift);
 }
 
 [[gnu::target("avx2")]] FASTGLTF_FORCEINLINE auto avx2_pack_ints(__m256i input) {
-    const auto merge = _mm256_maddubs_epi16(input, _mm256_set1_epi32(0x01400140));
-    return _mm256_madd_epi16(merge, _mm256_set1_epi32(0x00011000));
+	const auto merge = _mm256_maddubs_epi16(input, _mm256_set1_epi32(0x01400140));
+	return _mm256_madd_epi16(merge, _mm256_set1_epi32(0x00011000));
 }
 
-[[gnu::target("avx2")]] void fg::base64::avx2_decode_inplace(std::string_view encoded, std::uint8_t* output, std::size_t padding) {
-    constexpr auto dataSetSize = 32;
-    constexpr auto dataOutputSize = 24;
+[[gnu::target("avx2")]] void fg::base64::avx2_decode_inplace(std::string_view encoded,
+															 std::uint8_t* output,
+															 std::size_t padding) {
+	constexpr auto dataSetSize = 32;
+	constexpr auto dataOutputSize = 24;
 
-    if (encoded.size() < dataSetSize) {
-        fallback_decode_inplace(encoded, output, padding);
-        return;
-    }
+	if (encoded.size() < dataSetSize) {
+		fallback_decode_inplace(encoded, output, padding);
+		return;
+	}
 
-    // We align the size to the highest size divisible by 32. By doing this, we don't need to
-    // allocate any new memory to hold the encoded data and let the fallback decoder decode the
-    // remaining data.
-    const auto encodedSize = encoded.size();
-    const auto alignedSize = encodedSize - (encodedSize % dataOutputSize);
-    auto* out = output;
+	// We align the size to the highest size divisible by 32. By doing this, we don't need to
+	// allocate any new memory to hold the encoded data and let the fallback decoder decode the
+	// remaining data.
+	const auto encodedSize = encoded.size();
+	const auto alignedSize = encodedSize - (encodedSize % dataOutputSize);
+	auto* out = output;
 
-    // _mm256_setr_epi8 accepts only 'char' but 0xff would overflow a signed char, which makes some compilers unhappy.
-    // This gets optimised to the same assembly as a call to the aforementioned intrinsic.
-    static const std::array<std::uint8_t, 32> shuffleData = {{
-        2,  1,  0,
-        6,  5,  4,
-        10,  9,  8,
-        14, 13, 12,
-        0xff, 0xff, 0xff, 0xff,
-        2,  1,  0,
-        6,  5,  4,
-        10,  9,  8,
-        14, 13, 12,
-        0xff, 0xff, 0xff, 0xff
-    }};
-    __m256i shuffle;
-    std::memcpy(&shuffle, shuffleData.data(), shuffleData.size());
+	// _mm256_setr_epi8 accepts only 'char' but 0xff would overflow a signed char, which makes some
+	// compilers unhappy. This gets optimised to the same assembly as a call to the aforementioned
+	// intrinsic.
+	static const std::array<std::uint8_t, 32> shuffleData = {
+		{2, 1, 0, 6, 5, 4, 10, 9, 8, 14, 13, 12, 0xff, 0xff, 0xff, 0xff,
+		 2, 1, 0, 6, 5, 4, 10, 9, 8, 14, 13, 12, 0xff, 0xff, 0xff, 0xff}};
+	__m256i shuffle;
+	std::memcpy(&shuffle, shuffleData.data(), shuffleData.size());
 
-    std::size_t pos = 0;
-    while ((pos + dataSetSize) < alignedSize) {
-        auto in = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(&encoded[pos]));
-        auto values = avx2_lookup_pshufb_bitmask(in);
-        const auto merged = avx2_pack_ints(values);
-        const auto shuffled = _mm256_shuffle_epi8(merged, shuffle);
+	std::size_t pos = 0;
+	while ((pos + dataSetSize) < alignedSize) {
+		auto in = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(&encoded[pos]));
+		auto values = avx2_lookup_pshufb_bitmask(in);
+		const auto merged = avx2_pack_ints(values);
+		const auto shuffled = _mm256_shuffle_epi8(merged, shuffle);
 
-        // Beware: This writes 32 bytes, we just discard the top 8 bytes.
-        _mm_storeu_si128(reinterpret_cast<__m128i*>(out), _mm256_castsi256_si128(shuffled));
-        _mm_storeu_si128(reinterpret_cast<__m128i*>(out + (dataOutputSize / 2)), _mm256_extracti128_si256(shuffled, 1));
+		// Beware: This writes 32 bytes, we just discard the top 8 bytes.
+		_mm_storeu_si128(reinterpret_cast<__m128i*>(out), _mm256_castsi256_si128(shuffled));
+		_mm_storeu_si128(reinterpret_cast<__m128i*>(out + (dataOutputSize / 2)),
+						 _mm256_extracti128_si256(shuffled, 1));
 
-        out += dataOutputSize;
-        pos += dataSetSize;
-    }
+		out += dataOutputSize;
+		pos += dataSetSize;
+	}
 
-    // Decode the last chunk traditionally
-    fallback_decode_inplace(encoded.substr(pos, encodedSize - pos), out, padding);
+	// Decode the last chunk traditionally
+	fallback_decode_inplace(encoded.substr(pos, encodedSize - pos), out, padding);
 }
 
-[[gnu::target("avx2")]] fg::StaticVector<std::uint8_t> fg::base64::avx2_decode(std::string_view encoded) {
-    const auto encodedSize = encoded.size();
-    const auto padding = getPadding(encoded);
+[[gnu::target("avx2")]] fg::StaticVector<std::uint8_t> fg::base64::avx2_decode(
+	std::string_view encoded) {
+	const auto encodedSize = encoded.size();
+	const auto padding = getPadding(encoded);
 
-    fg::StaticVector<std::uint8_t> ret(getOutputSize(encodedSize, padding));
-    avx2_decode_inplace(encoded, ret.data(), padding);
+	fg::StaticVector<std::uint8_t> ret(getOutputSize(encodedSize, padding));
+	avx2_decode_inplace(encoded, ret.data(), padding);
 
-    return ret;
+	return ret;
 }
 
-[[gnu::target("sse4.1")]] FASTGLTF_FORCEINLINE auto sse4_lookup_pshufb_bitmask(const __m128i input) {
-    const auto higher_nibble = _mm_and_si128(_mm_srli_epi32(input, 4), _mm_set1_epi8(0x0f));
+[[gnu::target("sse4.1")]] FASTGLTF_FORCEINLINE auto sse4_lookup_pshufb_bitmask(
+	const __m128i input) {
+	const auto higher_nibble = _mm_and_si128(_mm_srli_epi32(input, 4), _mm_set1_epi8(0x0f));
 
-    const auto shiftLUT = _mm_setr_epi8(
-        0,   0,  19,   4, -65, -65, -71, -71,
-        0,   0,   0,   0,   0,   0,   0,   0);
+	const auto shiftLUT = _mm_setr_epi8(0, 0, 19, 4, -65, -65, -71, -71, 0, 0, 0, 0, 0, 0, 0, 0);
 
-    const auto sh     = _mm_shuffle_epi8(shiftLUT,  higher_nibble);
-    const auto eq_2f  = _mm_cmpeq_epi8(input, _mm_set1_epi8(0x2f));
-    const auto shift  = _mm_blendv_epi8(sh, _mm_set1_epi8(16), eq_2f);
+	const auto sh = _mm_shuffle_epi8(shiftLUT, higher_nibble);
+	const auto eq_2f = _mm_cmpeq_epi8(input, _mm_set1_epi8(0x2f));
+	const auto shift = _mm_blendv_epi8(sh, _mm_set1_epi8(16), eq_2f);
 
-    return _mm_add_epi8(input, shift);
+	return _mm_add_epi8(input, shift);
 }
 
 [[gnu::target("sse4.1")]] FASTGLTF_FORCEINLINE auto sse4_pack_ints(__m128i input) {
-    const auto merge = _mm_maddubs_epi16(input, _mm_set1_epi32(0x01400140));
-    return _mm_madd_epi16(merge, _mm_set1_epi32(0x00011000));
+	const auto merge = _mm_maddubs_epi16(input, _mm_set1_epi32(0x01400140));
+	return _mm_madd_epi16(merge, _mm_set1_epi32(0x00011000));
 }
 
-[[gnu::target("sse4.1")]] void fg::base64::sse4_decode_inplace(std::string_view encoded, std::uint8_t* output, std::size_t padding) {
-    constexpr auto dataSetSize = 16;
-    constexpr auto dataOutputSize = 12;
+[[gnu::target("sse4.1")]] void fg::base64::sse4_decode_inplace(std::string_view encoded,
+															   std::uint8_t* output,
+															   std::size_t padding) {
+	constexpr auto dataSetSize = 16;
+	constexpr auto dataOutputSize = 12;
 
-    if (encoded.size() < dataSetSize) {
-        fallback_decode_inplace(encoded, output, padding);
-        return;
-    }
+	if (encoded.size() < dataSetSize) {
+		fallback_decode_inplace(encoded, output, padding);
+		return;
+	}
 
-    // We align the size to the highest size divisible by 16. By doing this, we don't need to
-    // allocate any new memory to hold the encoded data and let the fallback decoder decode the
-    // remaining data.
+	// We align the size to the highest size divisible by 16. By doing this, we don't need to
+	// allocate any new memory to hold the encoded data and let the fallback decoder decode the
+	// remaining data.
 	const auto encodedSize = encoded.size();
 	const auto alignedSize = encodedSize - (encodedSize % dataOutputSize);
-    auto* out = output;
+	auto* out = output;
 
-    // _mm_setr_epi8 accepts only 'char' but 0xff would overflow a signed char, which makes some compilers unhappy.
-    // This gets optimised to the same assembly as a call to the aforementioned intrinsic.
-    static const std::array<std::uint8_t, 16> shuffleData = {{
-        2,  1,  0,
-        6,  5,  4,
-        10,  9,  8,
-        14, 13, 12,
-        0xff, 0xff, 0xff, 0xff,
-    }};
-    __m128i shuffle;
-    std::memcpy(&shuffle, shuffleData.data(), shuffleData.size());
+	// _mm_setr_epi8 accepts only 'char' but 0xff would overflow a signed char, which makes some
+	// compilers unhappy. This gets optimised to the same assembly as a call to the aforementioned
+	// intrinsic.
+	static const std::array<std::uint8_t, 16> shuffleData = {{
+		2,
+		1,
+		0,
+		6,
+		5,
+		4,
+		10,
+		9,
+		8,
+		14,
+		13,
+		12,
+		0xff,
+		0xff,
+		0xff,
+		0xff,
+	}};
+	__m128i shuffle;
+	std::memcpy(&shuffle, shuffleData.data(), shuffleData.size());
 
-    std::size_t pos = 0;
-    while ((pos + dataSetSize) < alignedSize) {
-        auto in = _mm_loadu_si128(reinterpret_cast<const __m128i*>(&encoded[pos]));
-        auto values = sse4_lookup_pshufb_bitmask(in);
-        const auto merged = sse4_pack_ints(values);
-        const auto shuffled = _mm_shuffle_epi8(merged, shuffle);
+	std::size_t pos = 0;
+	while ((pos + dataSetSize) < alignedSize) {
+		auto in = _mm_loadu_si128(reinterpret_cast<const __m128i*>(&encoded[pos]));
+		auto values = sse4_lookup_pshufb_bitmask(in);
+		const auto merged = sse4_pack_ints(values);
+		const auto shuffled = _mm_shuffle_epi8(merged, shuffle);
 
-        // Beware: This writes 16 bytes, we just discard the top 4 bytes.
-        _mm_storeu_si128(reinterpret_cast<__m128i*>(out), shuffled);
+		// Beware: This writes 16 bytes, we just discard the top 4 bytes.
+		_mm_storeu_si128(reinterpret_cast<__m128i*>(out), shuffled);
 
-        out += dataOutputSize;
-        pos += dataSetSize;
-    }
+		out += dataOutputSize;
+		pos += dataSetSize;
+	}
 
-    // Decode the last chunk traditionally
-    fallback_decode_inplace(encoded.substr(pos, encodedSize - pos), out, padding);
+	// Decode the last chunk traditionally
+	fallback_decode_inplace(encoded.substr(pos, encodedSize - pos), out, padding);
 }
 
-[[gnu::target("sse4.1")]] fg::StaticVector<std::uint8_t> fg::base64::sse4_decode(std::string_view encoded) {
-    const auto encodedSize = encoded.size();
-    const auto padding = getPadding(encoded);
+[[gnu::target("sse4.1")]] fg::StaticVector<std::uint8_t> fg::base64::sse4_decode(
+	std::string_view encoded) {
+	const auto encodedSize = encoded.size();
+	const auto padding = getPadding(encoded);
 
-    fg::StaticVector<std::uint8_t> ret(getOutputSize(encodedSize, padding));
-    sse4_decode_inplace(encoded, ret.data(), padding);
+	fg::StaticVector<std::uint8_t> ret(getOutputSize(encodedSize, padding));
+	sse4_decode_inplace(encoded, ret.data(), padding);
 
-    return ret;
+	return ret;
 }
 #elif defined(FASTGLTF_IS_A64)
 FASTGLTF_FORCEINLINE int8x16_t neon_lookup_pshufb_bitmask(const uint8x16_t input) {
-    // clang-format off
+	// clang-format off
     constexpr std::array<int8_t, 16> shiftLUTdata = {
         0,   0,  19,   4, -65, -65, -71, -71,
         0,   0,   0,   0,   0,   0,   0,   0
@@ -376,22 +390,23 @@ static constexpr std::array<std::uint8_t, 128> base64lut = {
 // clang-format on
 
 namespace fastgltf::base64 {
-    template <typename Output>
-	FASTGLTF_FORCEINLINE void decode_block(std::array<std::uint8_t, 4>& sixBitChars, Output output) {
-		for (std::size_t i = 0; i < 4; i++) {
-			assert(static_cast<std::size_t>(sixBitChars[i]) < base64lut.size());
-			sixBitChars[i] = base64lut[sixBitChars[i]];
-		}
-
-		output[0] = (sixBitChars[0] << 2U) + ((sixBitChars[1] & 0x30U) >> 4U);
-		output[1] = ((sixBitChars[1] & 0xfU) << 4U) + ((sixBitChars[2] & 0x3cU) >> 2U);
-		output[2] = ((sixBitChars[2] & 0x3U) << 6U) + sixBitChars[3];
+template <typename Output>
+FASTGLTF_FORCEINLINE void decode_block(std::array<std::uint8_t, 4>& sixBitChars, Output output) {
+	for (std::size_t i = 0; i < 4; i++) {
+		assert(static_cast<std::size_t>(sixBitChars[i]) < base64lut.size());
+		sixBitChars[i] = base64lut[sixBitChars[i]];
 	}
-} // namespace fastgltf::base64
 
-void fg::base64::fallback_decode_inplace(std::string_view encoded, std::uint8_t* output, std::size_t padding) {
+	output[0] = (sixBitChars[0] << 2U) + ((sixBitChars[1] & 0x30U) >> 4U);
+	output[1] = ((sixBitChars[1] & 0xfU) << 4U) + ((sixBitChars[2] & 0x3cU) >> 2U);
+	output[2] = ((sixBitChars[2] & 0x3U) << 6U) + sixBitChars[3];
+}
+}  // namespace fastgltf::base64
+
+void fg::base64::fallback_decode_inplace(std::string_view encoded, std::uint8_t* output,
+										 std::size_t padding) {
 	constexpr std::size_t blockSize = 4;
-	std::array<std::uint8_t, blockSize> sixBitChars {};
+	std::array<std::uint8_t, blockSize> sixBitChars{};
 
 	const auto encodedSize = encoded.size();
 	for (auto pos = 0U; pos + 4 < encodedSize; pos += 4) {
@@ -404,7 +419,7 @@ void fg::base64::fallback_decode_inplace(std::string_view encoded, std::uint8_t*
 	// Decode the last (possibly) padded characters
 	std::memcpy(sixBitChars.data(), &encoded[encodedSize - 4], blockSize);
 
-	std::array<std::uint8_t, 4> eightBitChars {};
+	std::array<std::uint8_t, 4> eightBitChars{};
 	decode_block<decltype(eightBitChars)&>(sixBitChars, eightBitChars);
 
 	// Write the last characters, making sure not to write over the end.
@@ -415,27 +430,28 @@ void fg::base64::fallback_decode_inplace(std::string_view encoded, std::uint8_t*
 }
 
 fg::StaticVector<std::uint8_t> fg::base64::fallback_decode(std::string_view encoded) {
-    const auto encodedSize = encoded.size();
-    const auto padding = getPadding(encoded);
+	const auto encodedSize = encoded.size();
+	const auto padding = getPadding(encoded);
 
-    fg::StaticVector<std::uint8_t> ret(getOutputSize(encodedSize, padding));
-    fallback_decode_inplace(encoded, ret.data(), padding);
+	fg::StaticVector<std::uint8_t> ret(getOutputSize(encodedSize, padding));
+	fallback_decode_inplace(encoded, ret.data(), padding);
 
-    return ret;
+	return ret;
 }
 
-void fg::base64::decode_inplace(std::string_view encoded, std::uint8_t* output, std::size_t padding) {
-    assert(encoded.size() % 4 == 0);
+void fg::base64::decode_inplace(std::string_view encoded, std::uint8_t* output,
+								std::size_t padding) {
+	assert(encoded.size() % 4 == 0);
 
-    return DecodeFunctionGetter::get()->inplace(encoded, output, padding);
+	return DecodeFunctionGetter::get()->inplace(encoded, output, padding);
 }
 
 fg::StaticVector<std::uint8_t> fg::base64::decode(std::string_view encoded) {
-    assert(encoded.size() % 4 == 0);
+	assert(encoded.size() % 4 == 0);
 
-    return DecodeFunctionGetter::get()->func(encoded);
+	return DecodeFunctionGetter::get()->func(encoded);
 }
 
 #ifdef _MSC_VER
-#pragma warning(pop)
+#	pragma warning(pop)
 #endif

--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -24,9 +24,9 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#include "fastgltf/types.hpp"
-#if !defined(__cplusplus) || (!defined(_MSVC_LANG) && __cplusplus < 202002L) || (defined(_MSVC_LANG) && _MSVC_LANG < 202002L)
-#error "fastgltf requires C++20"
+#if !defined(__cplusplus) || (!defined(_MSVC_LANG) && __cplusplus < 202002L) || \
+	(defined(_MSVC_LANG) && _MSVC_LANG < 202002L)
+#	error "fastgltf requires C++20"
 #endif
 
 #include <fstream>
@@ -35,371 +35,377 @@
 #include <utility>
 
 #ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 5030) // attribute 'x' is not recognized
-#pragma warning(disable : 4514) // unreferenced inline function has been removed
-#pragma warning(disable : 4710) // function not inlined
+#	pragma warning(push)
+#	pragma warning(disable : 5030)  // attribute 'x' is not recognized
+#	pragma warning(disable : 4514)  // unreferenced inline function has been removed
+#	pragma warning(disable : 4710)  // function not inlined
 #endif
 
 #include <simdjson.h>
 
 #ifdef SIMDJSON_TARGET_VERSION
 // Make sure that SIMDJSON_TARGET_VERSION is equal to SIMDJSON_VERSION.
-static_assert(std::string_view { SIMDJSON_TARGET_VERSION } == SIMDJSON_VERSION, "Outdated version of simdjson. Reconfigure project to update.");
+static_assert(std::string_view{SIMDJSON_TARGET_VERSION} == SIMDJSON_VERSION,
+			  "Outdated version of simdjson. Reconfigure project to update.");
 #endif
 
-#include <fastgltf/core.hpp>
 #include <fastgltf/base64.hpp>
+#include <fastgltf/core.hpp>
 
 #if defined(FASTGLTF_IS_X86)
-#include <nmmintrin.h> // SSE4.2 for the CRC-32C instructions
+#	include <nmmintrin.h>  // SSE4.2 for the CRC-32C instructions
 #elif defined(FASTGLTF_ENABLE_ARMV8_CRC)
 // MSVC does not provide the arm crc32 intrinsics.
-#include <arm_acle.h>
-#ifdef __APPLE__
-#include <sys/sysctl.h>
-#endif
+#	include <arm_acle.h>
+#	ifdef __APPLE__
+#		include <sys/sysctl.h>
+#	endif
 #endif
 
 namespace fg = fastgltf;
 namespace fs = std::filesystem;
 
 namespace fastgltf {
-    constexpr std::uint32_t binaryGltfHeaderMagic = 0x46546C67; // ASCII for "glTF".
-    constexpr std::uint32_t binaryGltfJsonChunkMagic = 0x4E4F534A;
-    constexpr std::uint32_t binaryGltfDataChunkMagic = 0x004E4942;
+constexpr std::uint32_t binaryGltfHeaderMagic = 0x46546C67;  // ASCII for "glTF".
+constexpr std::uint32_t binaryGltfJsonChunkMagic = 0x4E4F534A;
+constexpr std::uint32_t binaryGltfDataChunkMagic = 0x004E4942;
 
-    struct BinaryGltfHeader {
-        std::uint32_t magic;
-        std::uint32_t version;
-        std::uint32_t length;
-    };
-    static_assert(sizeof(BinaryGltfHeader) == 12, "Binary gltf header must be 12 bytes");
-	static_assert(std::is_trivially_copyable_v<BinaryGltfHeader>);
+struct BinaryGltfHeader {
+	std::uint32_t magic;
+	std::uint32_t version;
+	std::uint32_t length;
+};
+static_assert(sizeof(BinaryGltfHeader) == 12, "Binary gltf header must be 12 bytes");
+static_assert(std::is_trivially_copyable_v<BinaryGltfHeader>);
 
-	constexpr void readUint32LE(std::uint32_t& x, std::byte* bytes) noexcept {
-		x = static_cast<std::uint32_t>(bytes[0])
-				| (static_cast<std::uint32_t>(bytes[1]) << 8)
-				| (static_cast<std::uint32_t>(bytes[2]) << 16)
-				| (static_cast<std::uint32_t>(bytes[3]) << 24);
-	}
+constexpr void readUint32LE(std::uint32_t& x, std::byte* bytes) noexcept {
+	x = static_cast<std::uint32_t>(bytes[0]) | (static_cast<std::uint32_t>(bytes[1]) << 8) |
+		(static_cast<std::uint32_t>(bytes[2]) << 16) | (static_cast<std::uint32_t>(bytes[3]) << 24);
+}
 
-	constexpr void writeUint32LE(std::uint32_t x, std::byte* buffer) noexcept {
-		buffer[0] = static_cast<std::byte>(x);
-		buffer[1] = static_cast<std::byte>(x >> 8);
-		buffer[2] = static_cast<std::byte>(x >> 16);
-		buffer[3] = static_cast<std::byte>(x >> 24);
-	}
+constexpr void writeUint32LE(std::uint32_t x, std::byte* buffer) noexcept {
+	buffer[0] = static_cast<std::byte>(x);
+	buffer[1] = static_cast<std::byte>(x >> 8);
+	buffer[2] = static_cast<std::byte>(x >> 16);
+	buffer[3] = static_cast<std::byte>(x >> 24);
+}
 
-	/** GLBs are always little-endian, meaning we need to read the values accordingly */
-	[[nodiscard, gnu::always_inline]] inline auto readBinaryHeader(GltfDataGetter& getter) noexcept {
-		std::array<std::byte, sizeof(BinaryGltfHeader)> bytes {};
-		getter.read(bytes.data(), bytes.size());
+/** GLBs are always little-endian, meaning we need to read the values accordingly */
+[[nodiscard, gnu::always_inline]] inline auto readBinaryHeader(GltfDataGetter& getter) noexcept {
+	std::array<std::byte, sizeof(BinaryGltfHeader)> bytes{};
+	getter.read(bytes.data(), bytes.size());
 
-		BinaryGltfHeader header = {};
-		readUint32LE(header.magic, &bytes[offsetof(BinaryGltfHeader, magic)]);
-		readUint32LE(header.version, &bytes[offsetof(BinaryGltfHeader, version)]);
-		readUint32LE(header.length, &bytes[offsetof(BinaryGltfHeader, length)]);
-		return header;
-	}
+	BinaryGltfHeader header = {};
+	readUint32LE(header.magic, &bytes[offsetof(BinaryGltfHeader, magic)]);
+	readUint32LE(header.version, &bytes[offsetof(BinaryGltfHeader, version)]);
+	readUint32LE(header.length, &bytes[offsetof(BinaryGltfHeader, length)]);
+	return header;
+}
 
-	[[gnu::always_inline]] inline auto writeBinaryHeader(const BinaryGltfHeader& header) noexcept {
-		std::array<std::byte, sizeof(BinaryGltfHeader)> bytes {};
-		writeUint32LE(header.magic, &bytes[offsetof(BinaryGltfHeader, magic)]);
-		writeUint32LE(header.version, &bytes[offsetof(BinaryGltfHeader, version)]);
-		writeUint32LE(header.length, &bytes[offsetof(BinaryGltfHeader, length)]);
-		return bytes;
-	}
+[[gnu::always_inline]] inline auto writeBinaryHeader(const BinaryGltfHeader& header) noexcept {
+	std::array<std::byte, sizeof(BinaryGltfHeader)> bytes{};
+	writeUint32LE(header.magic, &bytes[offsetof(BinaryGltfHeader, magic)]);
+	writeUint32LE(header.version, &bytes[offsetof(BinaryGltfHeader, version)]);
+	writeUint32LE(header.length, &bytes[offsetof(BinaryGltfHeader, length)]);
+	return bytes;
+}
 
-    struct BinaryGltfChunk {
-        std::uint32_t chunkLength;
-        std::uint32_t chunkType;
-    };
-	static_assert(std::is_trivially_copyable_v<BinaryGltfChunk>);
+struct BinaryGltfChunk {
+	std::uint32_t chunkLength;
+	std::uint32_t chunkType;
+};
+static_assert(std::is_trivially_copyable_v<BinaryGltfChunk>);
 
-	[[nodiscard, gnu::always_inline]] inline auto readBinaryChunk(GltfDataGetter& getter) noexcept {
-		std::array<std::byte, sizeof(BinaryGltfChunk)> bytes {};
-		getter.read(bytes.data(), bytes.size());
+[[nodiscard, gnu::always_inline]] inline auto readBinaryChunk(GltfDataGetter& getter) noexcept {
+	std::array<std::byte, sizeof(BinaryGltfChunk)> bytes{};
+	getter.read(bytes.data(), bytes.size());
 
-		BinaryGltfChunk chunk = {};
-		readUint32LE(chunk.chunkLength, &bytes[offsetof(BinaryGltfChunk, chunkLength)]);
-		readUint32LE(chunk.chunkType, &bytes[offsetof(BinaryGltfChunk, chunkType)]);
-		return chunk;
-	}
+	BinaryGltfChunk chunk = {};
+	readUint32LE(chunk.chunkLength, &bytes[offsetof(BinaryGltfChunk, chunkLength)]);
+	readUint32LE(chunk.chunkType, &bytes[offsetof(BinaryGltfChunk, chunkType)]);
+	return chunk;
+}
 
-	[[gnu::always_inline]] inline auto writeBinaryChunk(const BinaryGltfChunk& chunk) noexcept {
-		std::array<std::byte, sizeof(BinaryGltfChunk)> bytes {};
-		writeUint32LE(chunk.chunkLength, &bytes[offsetof(BinaryGltfChunk, chunkLength)]);
-		writeUint32LE(chunk.chunkType, &bytes[offsetof(BinaryGltfChunk, chunkType)]);
-		return bytes;
-	}
+[[gnu::always_inline]] inline auto writeBinaryChunk(const BinaryGltfChunk& chunk) noexcept {
+	std::array<std::byte, sizeof(BinaryGltfChunk)> bytes{};
+	writeUint32LE(chunk.chunkLength, &bytes[offsetof(BinaryGltfChunk, chunkLength)]);
+	writeUint32LE(chunk.chunkType, &bytes[offsetof(BinaryGltfChunk, chunkType)]);
+	return bytes;
+}
 
-	using CRCStringFunction = std::uint32_t(*)(std::string_view str);
+using CRCStringFunction = std::uint32_t (*)(std::string_view str);
 
 #if defined(FASTGLTF_IS_X86)
-    [[gnu::hot, gnu::const, gnu::target("sse4.2")]] std::uint32_t sse_crc32c(std::string_view str) noexcept {
-        return sse_crc32c(reinterpret_cast<const std::uint8_t*>(str.data()), str.size());
-    }
+[[gnu::hot, gnu::const, gnu::target("sse4.2")]] std::uint32_t sse_crc32c(
+	std::string_view str) noexcept {
+	return sse_crc32c(reinterpret_cast<const std::uint8_t*>(str.data()), str.size());
+}
 
-    [[gnu::hot, gnu::const, gnu::target("sse4.2")]] std::uint32_t sse_crc32c(const std::uint8_t* d, std::size_t len) noexcept {
-        std::uint32_t crc = 0;
+[[gnu::hot, gnu::const, gnu::target("sse4.2")]] std::uint32_t sse_crc32c(const std::uint8_t* d,
+																		 std::size_t len) noexcept {
+	std::uint32_t crc = 0;
 
-        // Ddecode as much as possible using 4 byte steps.
-        // We specifically don't use the 8 byte instruction here because it uses a 64-bit output integer.
-        auto length = static_cast<std::int64_t>(len);
-        while ((length -= sizeof(std::uint32_t)) >= 0) {
-            std::uint32_t v;
-            std::memcpy(&v, d, sizeof v);
-            crc = _mm_crc32_u32(crc, v);
-            d += sizeof v;
-        }
+	// Ddecode as much as possible using 4 byte steps.
+	// We specifically don't use the 8 byte instruction here because it uses a 64-bit output
+	// integer.
+	auto length = static_cast<std::int64_t>(len);
+	while ((length -= sizeof(std::uint32_t)) >= 0) {
+		std::uint32_t v;
+		std::memcpy(&v, d, sizeof v);
+		crc = _mm_crc32_u32(crc, v);
+		d += sizeof v;
+	}
 
-        if (length & sizeof(std::uint16_t)) {
-            std::uint16_t v;
-            std::memcpy(&v, d, sizeof v);
-            crc = _mm_crc32_u16(crc, v);
-            d += sizeof v;
-        }
+	if (length & sizeof(std::uint16_t)) {
+		std::uint16_t v;
+		std::memcpy(&v, d, sizeof v);
+		crc = _mm_crc32_u16(crc, v);
+		d += sizeof v;
+	}
 
-        if (length & sizeof(std::uint8_t)) {
-            crc = _mm_crc32_u8(crc, *d);
-        }
+	if (length & sizeof(std::uint8_t)) {
+		crc = _mm_crc32_u8(crc, *d);
+	}
 
-        return crc;
-    }
+	return crc;
+}
 #elif defined(FASTGLTF_ENABLE_ARMV8_CRC)
-	[[gnu::hot, gnu::const, gnu::target("+crc")]] std::uint32_t armv8_crc32c(std::string_view str) noexcept {
-		return armv8_crc32c(reinterpret_cast<const std::uint8_t*>(str.data()), str.size());
+[[gnu::hot, gnu::const, gnu::target("+crc")]] std::uint32_t armv8_crc32c(
+	std::string_view str) noexcept {
+	return armv8_crc32c(reinterpret_cast<const std::uint8_t*>(str.data()), str.size());
+}
+
+[[gnu::hot, gnu::const, gnu::target("+crc")]] std::uint32_t armv8_crc32c(const std::uint8_t* d,
+																		 std::size_t len) noexcept {
+	std::uint32_t crc = 0;
+
+	// Decrementing the length variable and incrementing the pointer directly has better codegen
+	// with Clang than using a std::size_t i = 0.
+	auto length = static_cast<std::int64_t>(len);
+	while ((length -= sizeof(std::uint64_t)) >= 0) {
+		std::uint64_t value;
+		std::memcpy(&value, d, sizeof value);
+		crc = __crc32cd(crc, value);
+		d += sizeof value;
 	}
 
-	[[gnu::hot, gnu::const, gnu::target("+crc")]] std::uint32_t armv8_crc32c(const std::uint8_t* d, std::size_t len) noexcept {
-		std::uint32_t crc = 0;
-
-		// Decrementing the length variable and incrementing the pointer directly has better codegen with Clang
-		// than using a std::size_t i = 0.
-		auto length = static_cast<std::int64_t>(len);
-		while ((length -= sizeof(std::uint64_t)) >= 0) {
-			std::uint64_t value;
-			std::memcpy(&value, d, sizeof value);
-			crc = __crc32cd(crc, value);
-			d += sizeof value;
-		}
-
-		if (length & sizeof(std::uint32_t)) {
-			std::uint32_t value;
-			std::memcpy(&value, d, sizeof value);
-			crc = __crc32cw(crc, value);
-			d += sizeof value;
-		}
-
-		if (length & sizeof(std::uint16_t)) {
-			std::uint16_t value;
-			std::memcpy(&value, d, sizeof value);
-			crc = __crc32ch(crc, value);
-			d += sizeof value;
-		}
-
-		if (length & sizeof(std::uint8_t)) {
-			crc = __crc32cb(crc, *d);
-		}
-
-		return crc;
+	if (length & sizeof(std::uint32_t)) {
+		std::uint32_t value;
+		std::memcpy(&value, d, sizeof value);
+		crc = __crc32cw(crc, value);
+		d += sizeof value;
 	}
+
+	if (length & sizeof(std::uint16_t)) {
+		std::uint16_t value;
+		std::memcpy(&value, d, sizeof value);
+		crc = __crc32ch(crc, value);
+		d += sizeof value;
+	}
+
+	if (length & sizeof(std::uint8_t)) {
+		crc = __crc32cb(crc, *d);
+	}
+
+	return crc;
+}
 #endif
 
-    /**
-     * Points to the most 'optimal' CRC32-C encoding function. After initialiseCrc has been called,
-     * this might also point to sse_crc32c or armv8_crc32c. We only use this for runtime evaluation of hashes, and is
-     * intended to work for any length of data.
-     */
-    static CRCStringFunction crcStringFunction = crc32c;
+/**
+ * Points to the most 'optimal' CRC32-C encoding function. After initialiseCrc has been called,
+ * this might also point to sse_crc32c or armv8_crc32c. We only use this for runtime evaluation of
+ * hashes, and is intended to work for any length of data.
+ */
+static CRCStringFunction crcStringFunction = crc32c;
 
-    std::once_flag crcInitialisation;
+std::once_flag crcInitialisation;
 
-    /**
-     * Checks if SSE4.2 is available to try and use the hardware accelerated version.
-     */
-    void initialiseCrc() {
+/**
+ * Checks if SSE4.2 is available to try and use the hardware accelerated version.
+ */
+void initialiseCrc() {
 #if defined(FASTGLTF_IS_X86)
-        const auto& impls = simdjson::get_available_implementations();
-        if (const auto* sse4 = impls["westmere"]; sse4 != nullptr && sse4->supported_by_runtime_system()) {
-            crcStringFunction = sse_crc32c;
-        }
+	const auto& impls = simdjson::get_available_implementations();
+	if (const auto* sse4 = impls["westmere"];
+		sse4 != nullptr && sse4->supported_by_runtime_system()) {
+		crcStringFunction = sse_crc32c;
+	}
 #elif defined(FASTGLTF_ENABLE_ARMV8_CRC)
-		const auto& impls = simdjson::get_available_implementations();
-		if (const auto* neon = impls["arm64"]; neon != nullptr && neon->supported_by_runtime_system()) {
-#ifdef __APPLE__
-			std::int64_t ret = 0;
-			std::size_t size = sizeof(ret);
-			if (sysctlbyname("hw.optional.armv8_crc32", &ret, &size, nullptr, 0) == 0 && ret == 1)
-#endif
+	const auto& impls = simdjson::get_available_implementations();
+	if (const auto* neon = impls["arm64"]; neon != nullptr && neon->supported_by_runtime_system()) {
+#	ifdef __APPLE__
+		std::int64_t ret = 0;
+		std::size_t size = sizeof(ret);
+		if (sysctlbyname("hw.optional.armv8_crc32", &ret, &size, nullptr, 0) == 0 && ret == 1)
+#	endif
 			crcStringFunction = armv8_crc32c;
-		}
+	}
 #endif
-    }
+}
 
-	[[nodiscard, gnu::always_inline]] inline bool getImageIndexForExtension(const simdjson::dom::element& element, Optional<std::size_t>& imageIndexOut) {
-		using namespace simdjson;
+[[nodiscard, gnu::always_inline]] inline bool getImageIndexForExtension(
+	const simdjson::dom::element& element, Optional<std::size_t>& imageIndexOut) {
+	using namespace simdjson;
 
-		dom::object source;
-		if (element.get(source) != simdjson::SUCCESS) [[unlikely]] {
-			return false;
-		}
-		std::uint64_t imageIndex;
-		if (source["source"].get_uint64().get(imageIndex) != simdjson::SUCCESS) [[unlikely]] {
-			return false;
-		}
-
-		imageIndexOut = static_cast<std::size_t>(imageIndex);
-		return true;
+	dom::object source;
+	if (element.get(source) != simdjson::SUCCESS) [[unlikely]] {
+		return false;
+	}
+	std::uint64_t imageIndex;
+	if (source["source"].get_uint64().get(imageIndex) != simdjson::SUCCESS) [[unlikely]] {
+		return false;
 	}
 
-	[[nodiscard, gnu::always_inline]] inline bool parseTextureExtensions(Texture& texture, const simdjson::dom::object& extensions, const Extensions extensionFlags) {
-		for (auto extension : extensions) {
-			switch (crcStringFunction(extension.key)) {
-				case force_consteval<crc32c(extensions::KHR_texture_basisu)>: {
-					if (!hasBit(extensionFlags, Extensions::KHR_texture_basisu))
-						break;
-					if (!getImageIndexForExtension(extension.value, texture.basisuImageIndex))
-						return false;
-					break;
-				}
-				case force_consteval<crc32c(extensions::MSFT_texture_dds)>: {
-					if (!hasBit(extensionFlags, Extensions::MSFT_texture_dds))
-						break;
-					if (!getImageIndexForExtension(extension.value, texture.ddsImageIndex))
-						return false;
-					break;
-				}
-				case force_consteval<crc32c(extensions::EXT_texture_webp)>: {
-					if (!hasBit(extensionFlags, Extensions::EXT_texture_webp))
-						break;
-					if (!getImageIndexForExtension(extension.value, texture.webpImageIndex))
-						return false;
-					break;
-				}
-				default:
-					break;
+	imageIndexOut = static_cast<std::size_t>(imageIndex);
+	return true;
+}
+
+[[nodiscard, gnu::always_inline]] inline bool parseTextureExtensions(
+	Texture& texture, const simdjson::dom::object& extensions, const Extensions extensionFlags) {
+	for (auto extension : extensions) {
+		switch (crcStringFunction(extension.key)) {
+			case force_consteval<crc32c(extensions::KHR_texture_basisu)>: {
+				if (!hasBit(extensionFlags, Extensions::KHR_texture_basisu)) break;
+				if (!getImageIndexForExtension(extension.value, texture.basisuImageIndex))
+					return false;
+				break;
 			}
+			case force_consteval<crc32c(extensions::MSFT_texture_dds)>: {
+				if (!hasBit(extensionFlags, Extensions::MSFT_texture_dds)) break;
+				if (!getImageIndexForExtension(extension.value, texture.ddsImageIndex))
+					return false;
+				break;
+			}
+			case force_consteval<crc32c(extensions::EXT_texture_webp)>: {
+				if (!hasBit(extensionFlags, Extensions::EXT_texture_webp)) break;
+				if (!getImageIndexForExtension(extension.value, texture.webpImageIndex))
+					return false;
+				break;
+			}
+			default: break;
 		}
-
-		return true;
 	}
 
-	[[nodiscard, gnu::always_inline]] inline Error getJsonArray(const simdjson::dom::object& parent, std::string_view arrayName, simdjson::dom::array* array) noexcept {
-		using namespace simdjson;
+	return true;
+}
 
-		const auto error = parent[arrayName].get_array().get(*array);
-		if (error == NO_SUCH_FIELD) {
-			return Error::MissingField;
-		}
-		if (error == SUCCESS) [[likely]] {
-			return Error::None;
-		}
+[[nodiscard, gnu::always_inline]] inline Error getJsonArray(const simdjson::dom::object& parent,
+															std::string_view arrayName,
+															simdjson::dom::array* array) noexcept {
+	using namespace simdjson;
+
+	const auto error = parent[arrayName].get_array().get(*array);
+	if (error == NO_SUCH_FIELD) {
+		return Error::MissingField;
+	}
+	if (error == SUCCESS) [[likely]] {
+		return Error::None;
+	}
+	return Error::InvalidJson;
+}
+
+enum class TextureInfoType : std::uint_fast8_t {
+	Standard = 0,
+	NormalTexture = 1,
+	OcclusionTexture = 2,
+};
+
+Error parseTextureInfo(const simdjson::dom::object& object, const std::string_view key,
+					   TextureInfo* info, const Extensions extensions,
+					   const TextureInfoType type = TextureInfoType::Standard) noexcept {
+	using namespace simdjson;
+
+	dom::object child;
+	if (auto childErr = object[key].get_object().get(child); childErr == NO_SUCH_FIELD) {
+		return Error::MissingField;
+	} else if (childErr != SUCCESS) [[unlikely]] {
+		return Error::InvalidGltf;
+	}
+
+	std::uint64_t index;
+	if (child["index"].get_uint64().get(index) == SUCCESS) [[likely]] {
+		info->textureIndex = static_cast<std::size_t>(index);
+	} else {
+		return Error::InvalidGltf;
+	}
+
+	if (const auto error = child["texCoord"].get_uint64().get(index); error == SUCCESS) [[likely]] {
+		info->texCoordIndex = static_cast<std::size_t>(index);
+	} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 		return Error::InvalidJson;
 	}
 
-	enum class TextureInfoType : std::uint_fast8_t {
-		Standard = 0,
-		NormalTexture = 1,
-		OcclusionTexture = 2,
-	};
-
-	Error parseTextureInfo(const simdjson::dom::object& object, const std::string_view key,
-		TextureInfo* info, const Extensions extensions, const TextureInfoType type = TextureInfoType::Standard) noexcept {
-		using namespace simdjson;
-
-		dom::object child;
-		if (auto childErr = object[key].get_object().get(child); childErr == NO_SUCH_FIELD) {
-			return Error::MissingField;
-		} else if (childErr != SUCCESS) [[unlikely]] {
-			return Error::InvalidGltf;
-		}
-
-		std::uint64_t index;
-		if (child["index"].get_uint64().get(index) == SUCCESS) [[likely]] {
-			info->textureIndex = static_cast<std::size_t>(index);
-		} else {
-			return Error::InvalidGltf;
-		}
-
-		if (const auto error = child["texCoord"].get_uint64().get(index); error == SUCCESS) [[likely]] {
-			info->texCoordIndex = static_cast<std::size_t>(index);
+	if (type == TextureInfoType::NormalTexture) {
+		double scale;
+		if (const auto error = child["scale"].get_double().get(scale); error == SUCCESS)
+			[[likely]] {
+			reinterpret_cast<NormalTextureInfo*>(info)->scale = static_cast<num>(scale);
 		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
-            return Error::InvalidJson;
+			return Error::InvalidGltf;
 		}
-
-		if (type == TextureInfoType::NormalTexture) {
-            double scale;
-			if (const auto error = child["scale"].get_double().get(scale); error == SUCCESS) [[likely]] {
-				reinterpret_cast<NormalTextureInfo*>(info)->scale = static_cast<num>(scale);
-			} else if (error != NO_SUCH_FIELD) [[unlikely]] {
-                return Error::InvalidGltf;
-			}
-		} else if (type == TextureInfoType::OcclusionTexture) {
-			double strength;
-			if (const auto error = child["strength"].get_double().get(strength); error == SUCCESS) [[likely]] {
-				reinterpret_cast<OcclusionTextureInfo*>(info)->strength = static_cast<num>(strength);
-			} else if (error != NO_SUCH_FIELD) [[unlikely]] {
-                return Error::InvalidGltf;
-            }
+	} else if (type == TextureInfoType::OcclusionTexture) {
+		double strength;
+		if (const auto error = child["strength"].get_double().get(strength); error == SUCCESS)
+			[[likely]] {
+			reinterpret_cast<OcclusionTextureInfo*>(info)->strength = static_cast<num>(strength);
+		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
+			return Error::InvalidGltf;
 		}
-
-		dom::object extensionsObject;
-		if (child["extensions"].get_object().get(extensionsObject) == SUCCESS) [[likely]] {
-			dom::object textureTransform;
-			if (hasBit(extensions, Extensions::KHR_texture_transform) && extensionsObject[extensions::KHR_texture_transform].get_object().get(textureTransform) == SUCCESS) [[likely]] {
-				auto transform = std::make_unique<TextureTransform>();
-				transform->rotation = 0.0F;
-
-				if (textureTransform["texCoord"].get_uint64().get(index) == SUCCESS) [[likely]] {
-					transform->texCoordIndex = index;
-				}
-
-				double rotation = 0.0F;
-				if (textureTransform["rotation"].get_double().get(rotation) == SUCCESS) [[likely]] {
-					transform->rotation = static_cast<num>(rotation);
-				}
-
-				dom::array array;
-				if (textureTransform["offset"].get_array().get(array) == SUCCESS) [[likely]] {
-					for (auto i = 0U; i < 2; ++i) {
-						double val;
-						if (array.at(i).get_double().get(val) != SUCCESS) [[unlikely]] {
-							return Error::InvalidGltf;
-						}
-						transform->uvOffset[i] = static_cast<num>(val);
-					}
-				}
-
-				if (textureTransform["scale"].get_array().get(array) == SUCCESS) [[likely]] {
-					for (auto i = 0U; i < 2; ++i) {
-						double val;
-						if (array.at(i).get_double().get(val) != SUCCESS) [[unlikely]] {
-							return Error::InvalidGltf;
-						}
-						transform->uvScale[i] = static_cast<num>(val);
-					}
-				}
-
-				info->transform = std::move(transform);
-			}
-		}
-
-		return Error::None;
 	}
-} // namespace fastgltf
+
+	dom::object extensionsObject;
+	if (child["extensions"].get_object().get(extensionsObject) == SUCCESS) [[likely]] {
+		dom::object textureTransform;
+		if (hasBit(extensions, Extensions::KHR_texture_transform) &&
+			extensionsObject[extensions::KHR_texture_transform].get_object().get(
+				textureTransform) == SUCCESS) [[likely]] {
+			auto transform = std::make_unique<TextureTransform>();
+			transform->rotation = 0.0F;
+
+			if (textureTransform["texCoord"].get_uint64().get(index) == SUCCESS) [[likely]] {
+				transform->texCoordIndex = index;
+			}
+
+			double rotation = 0.0F;
+			if (textureTransform["rotation"].get_double().get(rotation) == SUCCESS) [[likely]] {
+				transform->rotation = static_cast<num>(rotation);
+			}
+
+			dom::array array;
+			if (textureTransform["offset"].get_array().get(array) == SUCCESS) [[likely]] {
+				for (auto i = 0U; i < 2; ++i) {
+					double val;
+					if (array.at(i).get_double().get(val) != SUCCESS) [[unlikely]] {
+						return Error::InvalidGltf;
+					}
+					transform->uvOffset[i] = static_cast<num>(val);
+				}
+			}
+
+			if (textureTransform["scale"].get_array().get(array) == SUCCESS) [[likely]] {
+				for (auto i = 0U; i < 2; ++i) {
+					double val;
+					if (array.at(i).get_double().get(val) != SUCCESS) [[unlikely]] {
+						return Error::InvalidGltf;
+					}
+					transform->uvScale[i] = static_cast<num>(val);
+				}
+			}
+
+			info->transform = std::move(transform);
+		}
+	}
+
+	return Error::None;
+}
+}  // namespace fastgltf
 
 #pragma region URI
 fg::URIView::URIView() noexcept = default;
 
-fg::URIView::URIView(std::string_view uri) noexcept : view(uri) {
-	parse();
-}
+fg::URIView::URIView(std::string_view uri) noexcept : view(uri) { parse(); }
 
-fg::URIView::URIView(const URIView& other) noexcept {
-	*this = other;
-}
+fg::URIView::URIView(const URIView& other) noexcept { *this = other; }
 
 fg::URIView& fg::URIView::operator=(const URIView& other) {
 	view = other.view;
@@ -465,14 +471,14 @@ void fg::URIView::parse() {
 
 		if (portColon != std::string::npos) {
 			_host = view.substr(idx, portColon - idx);
-			++portColon; // We don't want to include the colon in the port string.
+			++portColon;  // We don't want to include the colon in the port string.
 			_port = view.substr(portColon, nextSlash - portColon);
 		} else {
 			++idx;
 			_host = view.substr(idx, hostEnd - idx);
 		}
 
-		idx = nextSlash; // Path includes this slash
+		idx = nextSlash;  // Path includes this slash
 	}
 
 	if (_scheme == "data") {
@@ -503,9 +509,7 @@ void fg::URIView::parse() {
 	}
 }
 
-const char* fg::URIView::data() const noexcept {
-	return view.data();
-}
+const char* fg::URIView::data() const noexcept { return view.data(); }
 
 std::string_view fg::URIView::string() const noexcept { return view; }
 std::string_view fg::URIView::scheme() const noexcept { return _scheme; }
@@ -517,35 +521,30 @@ std::string_view fg::URIView::query() const noexcept { return _query; }
 std::string_view fg::URIView::fragment() const noexcept { return _fragment; }
 
 fs::path fg::URIView::fspath() const {
-	if (!isLocalPath())
-		return {};
+	if (!isLocalPath()) return {};
 
 	const std::string_view charPath = path();
-	return { std::u8string_view { reinterpret_cast<const char8_t*>(charPath.data()), charPath.size() } };
+	return {std::u8string_view{reinterpret_cast<const char8_t*>(charPath.data()), charPath.size()}};
 }
 
-bool fg::URIView::valid() const noexcept {
-	return _valid;
-}
+bool fg::URIView::valid() const noexcept { return _valid; }
 
 bool fg::URIView::isLocalPath() const noexcept {
 	return scheme().empty() || (scheme() == "file" && host().empty());
 }
 
-bool fg::URIView::isDataUri() const noexcept {
-	return scheme() == "data";
-}
+bool fg::URIView::isDataUri() const noexcept { return scheme() == "data"; }
 
 fg::URI::URI() noexcept = default;
 
 fg::URI::URI(std::string uri) noexcept : uri(std::move(uri)) {
 	decodePercents(this->uri);
-	view = this->uri; // Also parses.
+	view = this->uri;  // Also parses.
 }
 
 fg::URI::URI(std::string_view uri) noexcept : uri(uri) {
 	decodePercents(this->uri);
-	view = this->uri; // Also parses.
+	view = this->uri;  // Also parses.
 }
 
 fg::URI::URI(const URIView& view) noexcept : uri(view.view) {
@@ -562,13 +561,9 @@ fg::URI::URI(const URIView& view) noexcept : uri(view.view) {
 // Some C++ stdlib implementations copy in some cases when moving strings, which invalidates the
 // views stored in the URI struct. This function adjusts the views from the old string to the new
 // string for safe copying.
-fg::URI::URI(const URI& other) {
-	*this = other;
-}
+fg::URI::URI(const URI& other) { *this = other; }
 
-fg::URI::URI(URI&& other) noexcept {
-	*this = other;
-}
+fg::URI::URI(URI&& other) noexcept { *this = other; }
 
 fg::URI& fg::URI::operator=(const URI& other) {
 	uri = other.uri;
@@ -609,26 +604,44 @@ fg::URI& fg::URI::operator=(URI&& other) noexcept {
 	return *this;
 }
 
-fg::URI::operator fg::URIView() const noexcept {
-	return view;
-}
+fg::URI::operator fg::URIView() const noexcept { return view; }
 
 void fg::URI::readjustViews(const URIView& other) {
-	if (!other._scheme.empty())   { view._scheme     = std::string_view(uri.data() + (other._scheme.data()     - other.view.data()), other._scheme.size()); }
-	if (!other._path.empty())     { view._path       = std::string_view(uri.data() + (other._path.data()       - other.view.data()), other._path.size()); }
-	if (!other._userinfo.empty()) { view._userinfo   = std::string_view(uri.data() + (other._userinfo.data()   - other.view.data()), other._userinfo.size()); }
-	if (!other._host.empty())     { view._host       = std::string_view(uri.data() + (other._host.data()       - other.view.data()), other._host.size()); }
-	if (!other._port.empty())     { view._port       = std::string_view(uri.data() + (other._port.data()       - other.view.data()), other._port.size()); }
-	if (!other._query.empty())    { view._query      = std::string_view(uri.data() + (other._query.data()      - other.view.data()), other._query.size()); }
-	if (!other._fragment.empty()) { view._fragment   = std::string_view(uri.data() + (other._fragment.data()   - other.view.data()), other._fragment.size()); }
+	if (!other._scheme.empty()) {
+		view._scheme = std::string_view(uri.data() + (other._scheme.data() - other.view.data()),
+										other._scheme.size());
+	}
+	if (!other._path.empty()) {
+		view._path = std::string_view(uri.data() + (other._path.data() - other.view.data()),
+									  other._path.size());
+	}
+	if (!other._userinfo.empty()) {
+		view._userinfo = std::string_view(uri.data() + (other._userinfo.data() - other.view.data()),
+										  other._userinfo.size());
+	}
+	if (!other._host.empty()) {
+		view._host = std::string_view(uri.data() + (other._host.data() - other.view.data()),
+									  other._host.size());
+	}
+	if (!other._port.empty()) {
+		view._port = std::string_view(uri.data() + (other._port.data() - other.view.data()),
+									  other._port.size());
+	}
+	if (!other._query.empty()) {
+		view._query = std::string_view(uri.data() + (other._query.data() - other.view.data()),
+									   other._query.size());
+	}
+	if (!other._fragment.empty()) {
+		view._fragment = std::string_view(uri.data() + (other._fragment.data() - other.view.data()),
+										  other._fragment.size());
+	}
 
 	view.view = uri;
 }
 
 void fg::URI::decodePercents(std::string& x) noexcept {
 	for (std::size_t i = 0; i < x.size(); ++i) {
-		if (x[i] != '%')
-			continue;
+		if (x[i] != '%') continue;
 
 		// Read the next two chars and store them
 		std::array<char, 3> chars = {x[i + 1], x[i + 2]};
@@ -638,7 +651,7 @@ void fg::URI::decodePercents(std::string& x) noexcept {
 }
 
 std::string_view fg::URI::string() const noexcept { return uri; }
-const char*      fg::URI::c_str() const noexcept { return uri.c_str(); }
+const char* fg::URI::c_str() const noexcept { return uri.c_str(); }
 std::string_view fg::URI::scheme() const noexcept { return view.scheme(); }
 std::string_view fg::URI::userinfo() const noexcept { return view.userinfo(); }
 std::string_view fg::URI::host() const noexcept { return view.host(); }
@@ -647,139 +660,134 @@ std::string_view fg::URI::path() const noexcept { return view.path(); }
 std::string_view fg::URI::query() const noexcept { return view.query(); }
 std::string_view fg::URI::fragment() const noexcept { return view.fragment(); }
 
-fs::path fg::URI::fspath() const {
-	return view.fspath();
-}
+fs::path fg::URI::fspath() const { return view.fspath(); }
 
-bool fg::URI::valid() const noexcept {
-	return view.valid();
-}
+bool fg::URI::valid() const noexcept { return view.valid(); }
 
-bool fg::URI::isLocalPath() const noexcept {
-	return view.isLocalPath();
-}
+bool fg::URI::isLocalPath() const noexcept { return view.isLocalPath(); }
 
-bool fg::URI::isDataUri() const noexcept {
-	return view.isDataUri();
-}
+bool fg::URI::isDataUri() const noexcept { return view.isDataUri(); }
 #pragma endregion
 
 #pragma region glTF parsing
 fg::Expected<fg::DataSource> fg::Parser::decodeDataUri(const URIView& uri) const noexcept {
-    auto path = uri.path();
-    auto mimeEnd = path.find(';');
-    auto mime = path.substr(0, mimeEnd);
+	auto path = uri.path();
+	auto mimeEnd = path.find(';');
+	auto mime = path.substr(0, mimeEnd);
 
-    auto encodingEnd = path.find(',');
-    auto encoding = path.substr(mimeEnd + 1, encodingEnd - mimeEnd - 1);
-    if (encoding != "base64") {
+	auto encodingEnd = path.find(',');
+	auto encoding = path.substr(mimeEnd + 1, encodingEnd - mimeEnd - 1);
+	if (encoding != "base64") {
 		return Error::InvalidURI;
-    }
+	}
 
-    auto encodedData = path.substr(encodingEnd + 1);
-    if (config.mapCallback != nullptr) {
-        // If a map callback is specified, we use a pointer to memory specified by it.
-        auto padding = base64::getPadding(encodedData);
-        auto size = base64::getOutputSize(encodedData.size(), padding);
-        auto info = config.mapCallback(size, config.userPointer);
-        if (info.mappedMemory != nullptr) {
-            if (config.decodeCallback != nullptr) {
-                config.decodeCallback(encodedData, static_cast<std::uint8_t*>(info.mappedMemory), padding, size, config.userPointer);
-            } else {
-                base64::decode_inplace(encodedData, static_cast<std::uint8_t*>(info.mappedMemory), padding);
-            }
+	auto encodedData = path.substr(encodingEnd + 1);
+	if (config.mapCallback != nullptr) {
+		// If a map callback is specified, we use a pointer to memory specified by it.
+		auto padding = base64::getPadding(encodedData);
+		auto size = base64::getOutputSize(encodedData.size(), padding);
+		auto info = config.mapCallback(size, config.userPointer);
+		if (info.mappedMemory != nullptr) {
+			if (config.decodeCallback != nullptr) {
+				config.decodeCallback(encodedData, static_cast<std::uint8_t*>(info.mappedMemory),
+									  padding, size, config.userPointer);
+			} else {
+				base64::decode_inplace(encodedData, static_cast<std::uint8_t*>(info.mappedMemory),
+									   padding);
+			}
 
-            if (config.unmapCallback != nullptr) {
-                config.unmapCallback(&info, config.userPointer);
-            }
+			if (config.unmapCallback != nullptr) {
+				config.unmapCallback(&info, config.userPointer);
+			}
 
-            sources::CustomBuffer source = {};
-            source.id = info.customId;
-            source.mimeType = getMimeTypeFromString(mime);
-			return { source };
-        }
-    }
+			sources::CustomBuffer source = {};
+			source.id = info.customId;
+			source.mimeType = getMimeTypeFromString(mime);
+			return {source};
+		}
+	}
 
 	// Decode the base64 data into a traditional vector
 	auto padding = base64::getPadding(encodedData);
 	fg::StaticVector<std::byte> uriData(base64::getOutputSize(encodedData.size(), padding));
 	if (config.decodeCallback != nullptr) {
-		config.decodeCallback(encodedData, reinterpret_cast<std::uint8_t*>(uriData.data()), padding, uriData.size(), config.userPointer);
+		config.decodeCallback(encodedData, reinterpret_cast<std::uint8_t*>(uriData.data()), padding,
+							  uriData.size(), config.userPointer);
 	} else {
-		base64::decode_inplace(encodedData, reinterpret_cast<std::uint8_t*>(uriData.data()), padding);
+		base64::decode_inplace(encodedData, reinterpret_cast<std::uint8_t*>(uriData.data()),
+							   padding);
 	}
 
-	sources::Array source {
+	sources::Array source{
 		std::move(uriData),
 		getMimeTypeFromString(mime),
 	};
-	return { std::move(source) };
+	return {std::move(source)};
 }
 
 void fg::Parser::fillCategories(Category& inputCategories) noexcept {
-    if (inputCategories == Category::All)
-        return;
+	if (inputCategories == Category::All) return;
 
-    // The Category enum used to already OR values together so that e.g. Scenes would also implicitly
-    // have the Nodes bit set. This, however, caused some issues within the parse function as it tries
-    // to bail out when all requested categories have been parsed, as now something that hasn't been
-    // parsed could still be set. So, this has to exist...
-    if (hasBit(inputCategories, Category::Scenes))
-        inputCategories |= Category::Nodes;
-    if (hasBit(inputCategories, Category::Nodes))
-        inputCategories |= Category::Cameras | Category::Meshes | Category::Skins;
-    if (hasBit(inputCategories, Category::Skins))
-        // Skins needs nodes, nodes needs skins. To counter this circular dep we just redefine what we just wrote above.
-        inputCategories |= Category::Accessors | (Category::Nodes | Category::Cameras | Category::Meshes | Category::Skins);
-    if (hasBit(inputCategories, Category::Meshes))
-        inputCategories |= Category::Accessors | Category::Materials;
-    if (hasBit(inputCategories, Category::Materials))
-        inputCategories |= Category::Textures;
-    if (hasBit(inputCategories, Category::Animations))
-        inputCategories |= Category::Accessors;
-    if (hasBit(inputCategories, Category::Textures))
-        inputCategories |= Category::Images | Category::Samplers;
-    if (hasBit(inputCategories, Category::Images) || hasBit(inputCategories, Category::Accessors))
-        inputCategories |= Category::BufferViews;
-    if (hasBit(inputCategories, Category::BufferViews))
-        inputCategories |= Category::Buffers;
+	// The Category enum used to already OR values together so that e.g. Scenes would also
+	// implicitly have the Nodes bit set. This, however, caused some issues within the parse
+	// function as it tries to bail out when all requested categories have been parsed, as now
+	// something that hasn't been parsed could still be set. So, this has to exist...
+	if (hasBit(inputCategories, Category::Scenes)) inputCategories |= Category::Nodes;
+	if (hasBit(inputCategories, Category::Nodes))
+		inputCategories |= Category::Cameras | Category::Meshes | Category::Skins;
+	if (hasBit(inputCategories, Category::Skins))
+		// Skins needs nodes, nodes needs skins. To counter this circular dep we just redefine what
+		// we just wrote above.
+		inputCategories |= Category::Accessors | (Category::Nodes | Category::Cameras |
+												  Category::Meshes | Category::Skins);
+	if (hasBit(inputCategories, Category::Meshes))
+		inputCategories |= Category::Accessors | Category::Materials;
+	if (hasBit(inputCategories, Category::Materials)) inputCategories |= Category::Textures;
+	if (hasBit(inputCategories, Category::Animations)) inputCategories |= Category::Accessors;
+	if (hasBit(inputCategories, Category::Textures))
+		inputCategories |= Category::Images | Category::Samplers;
+	if (hasBit(inputCategories, Category::Images) || hasBit(inputCategories, Category::Accessors))
+		inputCategories |= Category::BufferViews;
+	if (hasBit(inputCategories, Category::BufferViews)) inputCategories |= Category::Buffers;
 }
 
 fg::MimeType fg::Parser::getMimeTypeFromString(std::string_view mime) {
-    switch (crcStringFunction(mime)) {
-        case force_consteval<crc32c(mimeTypeJpeg)>: {
-            return MimeType::JPEG;
-        }
-        case force_consteval<crc32c(mimeTypePng)>: {
-            return MimeType::PNG;
-        }
-        case force_consteval<crc32c(mimeTypeKtx)>: {
-            return MimeType::KTX2;
-        }
-        case force_consteval<crc32c(mimeTypeDds)>: {
-            return MimeType::DDS;
-        }
-        case force_consteval<crc32c(mimeTypeGltfBuffer)>: {
-            return MimeType::GltfBuffer;
-        }
-        case force_consteval<crc32c(mimeTypeOctetStream)>: {
-            return MimeType::OctetStream;
-        }
-        case force_consteval<crc32c(mimeTypeWebp)>: {
-            return MimeType::WEBP;
-        }
-        default: {
-            return MimeType::None;
-        }
-    }
+	switch (crcStringFunction(mime)) {
+		case force_consteval<crc32c(mimeTypeJpeg)>: {
+			return MimeType::JPEG;
+		}
+		case force_consteval<crc32c(mimeTypePng)>: {
+			return MimeType::PNG;
+		}
+		case force_consteval<crc32c(mimeTypeKtx)>: {
+			return MimeType::KTX2;
+		}
+		case force_consteval<crc32c(mimeTypeDds)>: {
+			return MimeType::DDS;
+		}
+		case force_consteval<crc32c(mimeTypeGltfBuffer)>: {
+			return MimeType::GltfBuffer;
+		}
+		case force_consteval<crc32c(mimeTypeOctetStream)>: {
+			return MimeType::OctetStream;
+		}
+		case force_consteval<crc32c(mimeTypeWebp)>: {
+			return MimeType::WEBP;
+		}
+		default: {
+			return MimeType::None;
+		}
+	}
 }
 
-template <typename T> fg::Error fg::Parser::parseAttributes(simdjson::dom::object& object, T& attributes) {
+template <typename T>
+fg::Error fg::Parser::parseAttributes(simdjson::dom::object& object, T& attributes) {
 	using namespace simdjson;
 
 	// We iterate through the JSON object and write each key/pair value into the
 	// attribute map. The keys are only validated in the validate() method.
-	attributes = FASTGLTF_CONSTRUCT_PMR_RESOURCE(std::remove_reference_t<decltype(attributes)>, resourceAllocator.get(), 0);
+	attributes = FASTGLTF_CONSTRUCT_PMR_RESOURCE(std::remove_reference_t<decltype(attributes)>,
+												 resourceAllocator.get(), 0);
 	attributes.reserve(object.size());
 	for (const auto field : object) {
 		const auto key = field.key;
@@ -788,8 +796,9 @@ template <typename T> fg::Error fg::Parser::parseAttributes(simdjson::dom::objec
 		if (field.value.get_uint64().get(accessorIndex) != SUCCESS) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
-		attributes.emplace_back(Attribute {
-			FASTGLTF_CONSTRUCT_PMR_RESOURCE(FASTGLTF_STD_PMR_NS::string, resourceAllocator.get(), key),
+		attributes.emplace_back(Attribute{
+			FASTGLTF_CONSTRUCT_PMR_RESOURCE(FASTGLTF_STD_PMR_NS::string, resourceAllocator.get(),
+											key),
 			static_cast<std::size_t>(accessorIndex),
 		});
 	}
@@ -797,24 +806,25 @@ template <typename T> fg::Error fg::Parser::parseAttributes(simdjson::dom::objec
 }
 
 // TODO: Is there some nicer way of declaring a templated version parseAttributes?
-//       Currently, this exists because resourceAllocator is a optional field of Parser, which we can't unconditionally
-//       pass as a parameter to a function, so parseAttributes needs to be a member function of Parser.
-template fg::Error fg::Parser::parseAttributes(simdjson::dom::object&, FASTGLTF_STD_PMR_NS::vector<Attribute>&);
-template fg::Error fg::Parser::parseAttributes(simdjson::dom::object&, decltype(fastgltf::Primitive::attributes)&);
+//       Currently, this exists because resourceAllocator is a optional field of Parser, which we
+//       can't unconditionally pass as a parameter to a function, so parseAttributes needs to be a
+//       member function of Parser.
+template fg::Error fg::Parser::parseAttributes(simdjson::dom::object&,
+											   FASTGLTF_STD_PMR_NS::vector<Attribute>&);
+template fg::Error fg::Parser::parseAttributes(simdjson::dom::object&,
+											   decltype(fastgltf::Primitive::attributes)&);
 
 namespace fastgltf {
-template<typename T>
-void writeIndices(StaticVector<std::byte>& generatedIndices,
-	const PrimitiveType type, const std::size_t primitiveCount) {
-
+template <typename T>
+void writeIndices(StaticVector<std::byte>& generatedIndices, const PrimitiveType type,
+				  const std::size_t primitiveCount) {
 	const std::span indices(reinterpret_cast<T*>(generatedIndices.data()),
-		generatedIndices.size() / sizeof(T));
+							generatedIndices.size() / sizeof(T));
 
 	// Generate the correct indices for every primitive topology
 	switch (type) {
 		case PrimitiveType::Points: {
-			for (std::size_t i = 0; i < primitiveCount; ++i)
-				indices[i] = static_cast<T>(i);
+			for (std::size_t i = 0; i < primitiveCount; ++i) indices[i] = static_cast<T>(i);
 			break;
 		}
 		case PrimitiveType::Lines:
@@ -828,7 +838,7 @@ void writeIndices(StaticVector<std::byte>& generatedIndices,
 		}
 		case PrimitiveType::Triangles:
 		case PrimitiveType::TriangleStrip:
-		case PrimitiveType::TriangleFan: {
+		case PrimitiveType::TriangleFan:   {
 			for (std::size_t i = 0; i < primitiveCount; ++i) {
 				indices[i * 3 + 0] = static_cast<T>(i * 3 + 0);
 				indices[i * 3 + 1] = static_cast<T>(i * 3 + 1);
@@ -840,9 +850,9 @@ void writeIndices(StaticVector<std::byte>& generatedIndices,
 	}
 }
 
-std::pair<StaticVector<std::byte>, ComponentType> writeIndices(
-	const PrimitiveType type, const std::size_t indexCount, const std::size_t primitiveCount) {
-
+std::pair<StaticVector<std::byte>, ComponentType> writeIndices(const PrimitiveType type,
+															   const std::size_t indexCount,
+															   const std::size_t primitiveCount) {
 	if (indexCount < 255) {
 		StaticVector<std::byte> generatedIndices(indexCount * sizeof(std::uint8_t));
 		writeIndices<std::uint8_t>(generatedIndices, type, primitiveCount);
@@ -859,13 +869,12 @@ std::pair<StaticVector<std::byte>, ComponentType> writeIndices(
 	writeIndices<std::uint32_t>(generatedIndices, type, primitiveCount);
 	return std::make_pair(generatedIndices, ComponentType::UnsignedInt);
 }
-}
+}  // namespace fastgltf
 
 fg::Error fg::Parser::generateMeshIndices(fastgltf::Asset& asset) const {
 	for (auto& mesh : asset.meshes) {
 		for (auto& primitive : mesh.primitives) {
-			if (primitive.indicesAccessor.has_value())
-				continue;
+			if (primitive.indicesAccessor.has_value()) continue;
 
 			auto* positionAttribute = primitive.findAttribute("POSITION");
 			if (positionAttribute == primitive.attributes.end()) {
@@ -875,35 +884,37 @@ fg::Error fg::Parser::generateMeshIndices(fastgltf::Asset& asset) const {
 
 			auto primitiveCount = [&]() -> std::size_t {
 				switch (primitive.type) {
-					case PrimitiveType::Points: return positionCount;
-					case PrimitiveType::Lines: return positionCount / 2;
+					case PrimitiveType::Points:    return positionCount;
+					case PrimitiveType::Lines:     return positionCount / 2;
 					case PrimitiveType::LineLoop:
 					case PrimitiveType::LineStrip: return max<std::size_t>(0, positionCount - 1);
 					case PrimitiveType::Triangles: return positionCount / 3;
-					case PrimitiveType::TriangleStrip: return max<std::size_t>(0U, positionCount - 2);
+					case PrimitiveType::TriangleStrip:
+						return max<std::size_t>(0U, positionCount - 2);
 					case PrimitiveType::TriangleFan: return max<std::size_t>(0U, positionCount - 2);
-					default: FASTGLTF_UNREACHABLE
+					default:                         FASTGLTF_UNREACHABLE
 				}
 			}();
 			auto indexCount = [&]() -> std::size_t {
 				switch (primitive.type) {
-					case PrimitiveType::Points: return primitiveCount;
+					case PrimitiveType::Points:        return primitiveCount;
 					case PrimitiveType::Lines:
 					case PrimitiveType::LineLoop:
-					case PrimitiveType::LineStrip: return primitiveCount * 2;
+					case PrimitiveType::LineStrip:     return primitiveCount * 2;
 					case PrimitiveType::Triangles:
 					case PrimitiveType::TriangleStrip:
-					case PrimitiveType::TriangleFan: return primitiveCount * 3;
-					default: FASTGLTF_UNREACHABLE
+					case PrimitiveType::TriangleFan:   return primitiveCount * 3;
+					default:                           FASTGLTF_UNREACHABLE
 				}
 			}();
 
-			auto [generatedIndices, componentType] = writeIndices(primitive.type, indexCount, primitiveCount);
+			auto [generatedIndices, componentType] =
+				writeIndices(primitive.type, indexCount, primitiveCount);
 
 			auto bufferIdx = asset.buffers.size();
 			auto& buffer = asset.buffers.emplace_back();
 			buffer.byteLength = generatedIndices.size_bytes();
-			sources::Array indicesArray {
+			sources::Array indicesArray{
 				std::move(generatedIndices),
 				MimeType::GltfBuffer,
 			};
@@ -930,151 +941,140 @@ fg::Error fg::Parser::generateMeshIndices(fastgltf::Asset& asset) const {
 
 fg::Error fg::validate(const Asset& asset) {
 	auto isExtensionUsed = [&used = asset.extensionsUsed](const std::string_view extension) {
-		return std::ranges::any_of(used, [&](auto& arg) {
-			return arg == extension;
-		});
+		return std::ranges::any_of(used, [&](auto& arg) { return arg == extension; });
 	};
 
-	// From the spec: extensionsRequired is a subset of extensionsUsed. All values in extensionsRequired MUST also exist in extensionsUsed.
+	// From the spec: extensionsRequired is a subset of extensionsUsed. All values in
+	// extensionsRequired MUST also exist in extensionsUsed.
 	if (asset.extensionsRequired.size() > asset.extensionsUsed.size()) {
 		return Error::InvalidGltf;
 	}
 	for (const auto& required : asset.extensionsRequired) {
 		bool found = false;
 		for (const auto& used : asset.extensionsUsed) {
-			if (required == used)
-				found = true;
+			if (required == used) found = true;
 		}
-		if (!found)
-			return Error::InvalidGltf;
+		if (!found) return Error::InvalidGltf;
 	}
 
 	for (const auto& accessor : asset.accessors) {
-		if (accessor.type == AccessorType::Invalid)
-			return Error::InvalidGltf;
-		if (accessor.componentType == ComponentType::Invalid)
-			return Error::InvalidGltf;
-		if (accessor.count < 1)
-			return Error::InvalidGltf;
+		if (accessor.type == AccessorType::Invalid) return Error::InvalidGltf;
+		if (accessor.componentType == ComponentType::Invalid) return Error::InvalidGltf;
+		if (accessor.count < 1) return Error::InvalidGltf;
 		if (accessor.bufferViewIndex.has_value() &&
-		    accessor.bufferViewIndex.value() >= asset.bufferViews.size())
+			accessor.bufferViewIndex.value() >= asset.bufferViews.size())
 			return Error::InvalidGltf;
 		if (accessor.byteOffset != 0) {
 			// The offset of an accessor into a bufferView (i.e., accessor.byteOffset)
-			// and the offset of an accessor into a buffer (i.e., accessor.byteOffset + bufferView.byteOffset)
-			// MUST be a multiple of the size of the accessor’s component type.
+			// and the offset of an accessor into a buffer (i.e., accessor.byteOffset +
+			// bufferView.byteOffset) MUST be a multiple of the size of the accessor’s component
+			// type.
 			auto componentByteSize = getComponentByteSize(accessor.componentType);
-			if (accessor.byteOffset % componentByteSize != 0)
-				return Error::InvalidGltf;
+			if (accessor.byteOffset % componentByteSize != 0) return Error::InvalidGltf;
 
 			if (accessor.bufferViewIndex.has_value()) {
 				const auto& bufferView = asset.bufferViews[accessor.bufferViewIndex.value()];
 				if ((accessor.byteOffset + bufferView.byteOffset) % componentByteSize != 0)
 					return Error::InvalidGltf;
 
-				// When byteStride is defined, it MUST be a multiple of the size of the accessor’s component type.
-				if (bufferView.byteStride.has_value() && bufferView.byteStride.value() % componentByteSize != 0)
+				// When byteStride is defined, it MUST be a multiple of the size of the accessor’s
+				// component type.
+				if (bufferView.byteStride.has_value() &&
+					bufferView.byteStride.value() % componentByteSize != 0)
 					return Error::InvalidGltf;
 			}
 		}
 
 		if (accessor.max.has_value()) {
-			if ((accessor.componentType == ComponentType::Float || accessor.componentType == ComponentType::Double)
-				&& !accessor.max->isType<double>())
+			if ((accessor.componentType == ComponentType::Float ||
+				 accessor.componentType == ComponentType::Double) &&
+				!accessor.max->isType<double>())
 				return Error::InvalidGltf;
 
-			if (accessor.max->size() != getNumComponents(accessor.type))
-				return Error::InvalidGltf;
+			if (accessor.max->size() != getNumComponents(accessor.type)) return Error::InvalidGltf;
 		}
 
 		if (accessor.min.has_value()) {
-			if ((accessor.componentType == ComponentType::Float || accessor.componentType == ComponentType::Double)
-				&& !accessor.min->isType<double>())
+			if ((accessor.componentType == ComponentType::Float ||
+				 accessor.componentType == ComponentType::Double) &&
+				!accessor.min->isType<double>())
 				return Error::InvalidGltf;
 
-			if (accessor.min->size() != getNumComponents(accessor.type))
-				return Error::InvalidGltf;
+			if (accessor.min->size() != getNumComponents(accessor.type)) return Error::InvalidGltf;
 		}
 
 		if (accessor.sparse) {
 			const auto& indicesView = asset.bufferViews[accessor.sparse->indicesBufferView];
-			if (indicesView.byteStride || indicesView.target)
-				return Error::InvalidGltf;
+			if (indicesView.byteStride || indicesView.target) return Error::InvalidGltf;
 
 			const auto& valueView = asset.bufferViews[accessor.sparse->valuesBufferView];
-			if (valueView.byteStride || valueView.target)
-				return Error::InvalidGltf;
+			if (valueView.byteStride || valueView.target) return Error::InvalidGltf;
 		}
 	}
 
 	for (const auto& animation : asset.animations) {
-		if (animation.channels.empty())
-			return Error::InvalidGltf;
+		if (animation.channels.empty()) return Error::InvalidGltf;
 		for (const auto& channel1 : animation.channels) {
-			if (!channel1.nodeIndex.has_value())
-				continue;
+			if (!channel1.nodeIndex.has_value()) continue;
 			for (const auto& channel2 : animation.channels) {
-				if (&channel1 == &channel2)
-					continue;
+				if (&channel1 == &channel2) continue;
 				if (channel1.nodeIndex == channel2.nodeIndex && channel1.path == channel2.path)
 					return Error::InvalidGltf;
 			}
 		}
 
-		if (animation.samplers.empty())
-			return Error::InvalidGltf;
+		if (animation.samplers.empty()) return Error::InvalidGltf;
 		for (const auto& channel : animation.channels) {
 			const auto& sampler = animation.samplers[channel.samplerIndex];
 
 			const auto& inputAccessor = asset.accessors[sampler.inputAccessor];
 			// The accessor MUST be of scalar type with floating-point components
-			if (inputAccessor.type != AccessorType::Scalar)
+			if (inputAccessor.type != AccessorType::Scalar) return Error::InvalidGltf;
+			if (inputAccessor.componentType != ComponentType::Float &&
+				inputAccessor.componentType != ComponentType::Double)
 				return Error::InvalidGltf;
-			if (inputAccessor.componentType != ComponentType::Float && inputAccessor.componentType != ComponentType::Double)
-				return Error::InvalidGltf;
-			if (inputAccessor.bufferViewIndex && asset.bufferViews[*inputAccessor.bufferViewIndex].meshoptCompression)
+			if (inputAccessor.bufferViewIndex &&
+				asset.bufferViews[*inputAccessor.bufferViewIndex].meshoptCompression)
 				continue;
 
-			if (inputAccessor.count == 0)
-				continue;
+			if (inputAccessor.count == 0) continue;
 
 			if (channel.path == AnimationPath::Weights)
-				continue; // TODO: For weights, the input count needs to be multiplied by the morph target count.
+				continue;  // TODO: For weights, the input count needs to be multiplied by the morph
+						   // target count.
 
 			const auto& outputAccessor = asset.accessors[sampler.outputAccessor];
-			if (outputAccessor.bufferViewIndex && asset.bufferViews[*outputAccessor.bufferViewIndex].meshoptCompression)
+			if (outputAccessor.bufferViewIndex &&
+				asset.bufferViews[*outputAccessor.bufferViewIndex].meshoptCompression)
 				continue;
 
 			switch (sampler.interpolation) {
 				case AnimationInterpolation::Linear:
 				case AnimationInterpolation::Step:
-					if (inputAccessor.count != outputAccessor.count)
-						return Error::InvalidGltf;
+					if (inputAccessor.count != outputAccessor.count) return Error::InvalidGltf;
 					break;
 				case AnimationInterpolation::CubicSpline:
-					if (inputAccessor.count < 2)
-						return Error::InvalidGltf;
-					if (inputAccessor.count * 3 != outputAccessor.count)
-						return Error::InvalidGltf;
+					if (inputAccessor.count < 2) return Error::InvalidGltf;
+					if (inputAccessor.count * 3 != outputAccessor.count) return Error::InvalidGltf;
 					break;
 			}
 		}
 	}
 
 	for (const auto& buffer : asset.buffers) {
-		if (buffer.byteLength < 1)
-			return Error::InvalidGltf;
+		if (buffer.byteLength < 1) return Error::InvalidGltf;
 	}
 
 	for (const auto& bufferView : asset.bufferViews) {
-		if (bufferView.byteLength < 1)
+		if (bufferView.byteLength < 1) return Error::InvalidGltf;
+		if (bufferView.byteStride.has_value() &&
+			(*bufferView.byteStride < 4U || *bufferView.byteStride > 252U ||
+			 *bufferView.byteStride % 4 != 0))
 			return Error::InvalidGltf;
-		if (bufferView.byteStride.has_value() && (*bufferView.byteStride < 4U || *bufferView.byteStride > 252U || *bufferView.byteStride % 4 != 0))
-			return Error::InvalidGltf;
-		if (bufferView.bufferIndex >= asset.buffers.size())
-			return Error::InvalidGltf;
+		if (bufferView.bufferIndex >= asset.buffers.size()) return Error::InvalidGltf;
 
-		if (bufferView.meshoptCompression != nullptr && !isExtensionUsed(extensions::EXT_meshopt_compression))
+		if (bufferView.meshoptCompression != nullptr &&
+			!isExtensionUsed(extensions::EXT_meshopt_compression))
 			return Error::InvalidGltf;
 
 		if (bufferView.meshoptCompression) {
@@ -1085,8 +1085,7 @@ fg::Error fg::validate(const Asset& asset) {
 						return Error::InvalidGltf;
 					break;
 				case MeshoptCompressionMode::Triangles:
-					if (compression->count % 3 != 0)
-						return Error::InvalidGltf;
+					if (compression->count % 3 != 0) return Error::InvalidGltf;
 					[[fallthrough]];
 				case MeshoptCompressionMode::Indices:
 					if (compression->byteStride != 2 && compression->byteStride != 4)
@@ -1098,17 +1097,14 @@ fg::Error fg::validate(const Asset& asset) {
 
 	for (const auto& camera : asset.cameras) {
 		if (const auto* pOrthographic = std::get_if<Camera::Orthographic>(&camera.camera)) {
-			if (pOrthographic->zfar == 0)
-				return Error::InvalidGltf;
+			if (pOrthographic->zfar == 0) return Error::InvalidGltf;
 		} else if (const auto* pPerspective = std::get_if<Camera::Perspective>(&camera.camera)) {
 			if (pPerspective->aspectRatio.has_value() && pPerspective->aspectRatio == .0f)
 				return Error::InvalidGltf;
-			if (pPerspective->yfov == 0)
-				return Error::InvalidGltf;
+			if (pPerspective->yfov == 0) return Error::InvalidGltf;
 			if (pPerspective->zfar.has_value() && pPerspective->zfar == .0f)
 				return Error::InvalidGltf;
-			if (pPerspective->znear == 0.0F)
-				return Error::InvalidGltf;
+			if (pPerspective->znear == 0.0F) return Error::InvalidGltf;
 		}
 	}
 
@@ -1123,8 +1119,7 @@ fg::Error fg::validate(const Asset& asset) {
 	for (const auto& light : asset.lights) {
 		if (light.type == LightType::Directional && light.range.has_value())
 			return Error::InvalidGltf;
-		if (light.range.has_value() && light.range.value() <= 0)
-			return Error::InvalidGltf;
+		if (light.range.has_value() && light.range.value() <= 0) return Error::InvalidGltf;
 
 		if (light.type != LightType::Spot) {
 			if (light.innerConeAngle.has_value() || light.outerConeAngle.has_value()) {
@@ -1133,33 +1128,36 @@ fg::Error fg::validate(const Asset& asset) {
 		} else {
 			if (!light.innerConeAngle.has_value() || !light.outerConeAngle.has_value())
 				return Error::InvalidGltf;
-			if (light.innerConeAngle.value() < 0)
-				return Error::InvalidGltf;
+			if (light.innerConeAngle.value() < 0) return Error::InvalidGltf;
 			if (light.innerConeAngle.value() > light.outerConeAngle.value())
 				return Error::InvalidGltf;
-			if (light.outerConeAngle.value() > math::pi / 2)
-				return Error::InvalidGltf;
+			if (light.outerConeAngle.value() > math::pi / 2) return Error::InvalidGltf;
 		}
 	}
 
 	for (const auto& material : asset.materials) {
-		auto isInvalidTexture = [&textures = asset.textures](std::optional<std::size_t> textureIndex) {
+		auto isInvalidTexture = [&textures =
+									 asset.textures](std::optional<std::size_t> textureIndex) {
 			return textureIndex.has_value() && textureIndex.value() >= textures.size();
 		};
-		if (material.normalTexture.has_value() && isInvalidTexture(material.normalTexture->textureIndex))
+		if (material.normalTexture.has_value() &&
+			isInvalidTexture(material.normalTexture->textureIndex))
 			return Error::InvalidGltf;
-		if (material.emissiveTexture.has_value() && isInvalidTexture(material.emissiveTexture->textureIndex))
+		if (material.emissiveTexture.has_value() &&
+			isInvalidTexture(material.emissiveTexture->textureIndex))
 			return Error::InvalidGltf;
-		if (material.occlusionTexture.has_value() && isInvalidTexture(material.occlusionTexture->textureIndex))
+		if (material.occlusionTexture.has_value() &&
+			isInvalidTexture(material.occlusionTexture->textureIndex))
 			return Error::InvalidGltf;
 		if (material.pbrData.baseColorTexture.has_value() &&
-		    isInvalidTexture(material.pbrData.baseColorTexture->textureIndex))
+			isInvalidTexture(material.pbrData.baseColorTexture->textureIndex))
 			return Error::InvalidGltf;
 		if (material.pbrData.metallicRoughnessTexture.has_value() &&
-		    isInvalidTexture(material.pbrData.metallicRoughnessTexture->textureIndex))
+			isInvalidTexture(material.pbrData.metallicRoughnessTexture->textureIndex))
 			return Error::InvalidGltf;
 
-		// Validate that for every additional material field from an extension the correct extension is marked as used by the asset.
+		// Validate that for every additional material field from an extension the correct extension
+		// is marked as used by the asset.
 		if (material.anisotropy && !isExtensionUsed(extensions::KHR_materials_anisotropy))
 			return Error::InvalidGltf;
 		if (material.clearcoat && !isExtensionUsed(extensions::KHR_materials_clearcoat))
@@ -1171,28 +1169,34 @@ fg::Error fg::validate(const Asset& asset) {
 		if (material.specular && !isExtensionUsed(extensions::KHR_materials_specular))
 			return Error::InvalidGltf;
 #if FASTGLTF_ENABLE_DEPRECATED_EXT
-		if (material.specularGlossiness && !isExtensionUsed(extensions::KHR_materials_pbrSpecularGlossiness))
+		if (material.specularGlossiness &&
+			!isExtensionUsed(extensions::KHR_materials_pbrSpecularGlossiness))
 			return Error::InvalidGltf;
 #endif
 		if (material.transmission && !isExtensionUsed(extensions::KHR_materials_transmission))
 			return Error::InvalidGltf;
 		if (material.volume && !isExtensionUsed(extensions::KHR_materials_volume))
 			return Error::InvalidGltf;
-		if (material.emissiveStrength != 1.0f && !isExtensionUsed(extensions::KHR_materials_emissive_strength))
+		if (material.emissiveStrength != 1.0f &&
+			!isExtensionUsed(extensions::KHR_materials_emissive_strength))
 			return Error::InvalidGltf;
 		if (material.ior != 1.5f && !isExtensionUsed(extensions::KHR_materials_ior))
 			return Error::InvalidGltf;
-		if (material.packedNormalMetallicRoughnessTexture && !isExtensionUsed(extensions::MSFT_packing_normalRoughnessMetallic))
+		if (material.packedNormalMetallicRoughnessTexture &&
+			!isExtensionUsed(extensions::MSFT_packing_normalRoughnessMetallic))
 			return Error::InvalidGltf;
-		if (material.packedOcclusionRoughnessMetallicTextures && !isExtensionUsed(extensions::MSFT_packing_occlusionRoughnessMetallic))
+		if (material.packedOcclusionRoughnessMetallicTextures &&
+			!isExtensionUsed(extensions::MSFT_packing_occlusionRoughnessMetallic))
 			return Error::InvalidGltf;
-		if (material.diffuseTransmission && !isExtensionUsed(extensions::KHR_materials_diffuse_transmission))
+		if (material.diffuseTransmission &&
+			!isExtensionUsed(extensions::KHR_materials_diffuse_transmission))
 			return Error::InvalidGltf;
 	}
 
 	for (const auto& mesh : asset.meshes) {
 		for (const auto& primitive : mesh.primitives) {
-			if (primitive.materialIndex.has_value() && *primitive.materialIndex >= asset.materials.size())
+			if (primitive.materialIndex.has_value() &&
+				*primitive.materialIndex >= asset.materials.size())
 				return Error::InvalidGltf;
 
 			if (!primitive.mappings.empty()) {
@@ -1201,35 +1205,30 @@ fg::Error fg::validate(const Asset& asset) {
 				if (primitive.mappings.size() != asset.materialVariants.size())
 					return Error::InvalidGltf;
 				for (const auto& mapping : primitive.mappings) {
-					if (!mapping.has_value())
-						continue;
-					if (mapping.value() >= asset.materials.size())
-						return Error::InvalidGltf;
+					if (!mapping.has_value()) continue;
+					if (mapping.value() >= asset.materials.size()) return Error::InvalidGltf;
 				}
 			}
 
 			if (primitive.indicesAccessor.has_value()) {
-				if (*primitive.indicesAccessor >= asset.accessors.size())
-					return Error::InvalidGltf;
+				if (*primitive.indicesAccessor >= asset.accessors.size()) return Error::InvalidGltf;
 				const auto& accessor = asset.accessors[*primitive.indicesAccessor];
 				if (accessor.bufferViewIndex.has_value()) {
 					const auto& bufferView = asset.bufferViews[*accessor.bufferViewIndex];
 					// The byteStride property must not be set on anything but vertex attributes.
-					if (bufferView.byteStride.has_value())
-						return Error::InvalidGltf;
+					if (bufferView.byteStride.has_value()) return Error::InvalidGltf;
 				}
 			}
 
 			for (const auto& [name, index] : primitive.attributes) {
-				if (asset.accessors.size() <= index)
-					return Error::InvalidGltf;
+				if (asset.accessors.size() <= index) return Error::InvalidGltf;
 
 				// The spec provides a list of attributes that it accepts and mentions that all
 				// custom attributes have to start with an underscore. We'll enforce this.
 				if (!startsWith(name, "_")) {
 					if (name != "POSITION" && name != "NORMAL" && name != "TANGENT" &&
-					    !startsWith(name, "TEXCOORD_") && !startsWith(name, "COLOR_") &&
-					    !startsWith(name, "JOINTS_") && !startsWith(name, "WEIGHTS_")) {
+						!startsWith(name, "TEXCOORD_") && !startsWith(name, "COLOR_") &&
+						!startsWith(name, "JOINTS_") && !startsWith(name, "WEIGHTS_")) {
 						return Error::InvalidGltf;
 					}
 				}
@@ -1237,54 +1236,52 @@ fg::Error fg::validate(const Asset& asset) {
 				// https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#meshes-overview
 				const auto& accessor = asset.accessors[index];
 				if (name == "POSITION") {
-					// Animation input and vertex position attribute accessors MUST have accessor.min and accessor.max defined.
+					// Animation input and vertex position attribute accessors MUST have
+					// accessor.min and accessor.max defined.
 					if (!accessor.max.has_value() || !accessor.min.has_value())
 						return Error::InvalidGltf;
-					if (accessor.type != AccessorType::Vec3)
-						return Error::InvalidGltf;
+					if (accessor.type != AccessorType::Vec3) return Error::InvalidGltf;
 					if (!isExtensionUsed(extensions::KHR_mesh_quantization)) {
 						if (accessor.componentType != ComponentType::Float)
 							return Error::InvalidGltf;
 					} else {
-						if (accessor.componentType == ComponentType::Double || accessor.componentType == ComponentType::UnsignedInt)
+						if (accessor.componentType == ComponentType::Double ||
+							accessor.componentType == ComponentType::UnsignedInt)
 							return Error::InvalidGltf;
 					}
 				} else if (name == "NORMAL") {
-					if (accessor.type != AccessorType::Vec3)
-						return Error::InvalidGltf;
+					if (accessor.type != AccessorType::Vec3) return Error::InvalidGltf;
 					if (!isExtensionUsed(extensions::KHR_mesh_quantization)) {
 						if (accessor.componentType != ComponentType::Float)
 							return Error::InvalidGltf;
 					} else {
 						if (accessor.componentType != ComponentType::Float &&
-						    accessor.componentType != ComponentType::Short &&
-						    accessor.componentType != ComponentType::Byte)
+							accessor.componentType != ComponentType::Short &&
+							accessor.componentType != ComponentType::Byte)
 							return Error::InvalidGltf;
 					}
 				} else if (name == "TANGENT") {
-					if (accessor.type != AccessorType::Vec4)
-						return Error::InvalidGltf;
+					if (accessor.type != AccessorType::Vec4) return Error::InvalidGltf;
 					if (!isExtensionUsed(extensions::KHR_mesh_quantization)) {
 						if (accessor.componentType != ComponentType::Float)
 							return Error::InvalidGltf;
 					} else {
 						if (accessor.componentType != ComponentType::Float &&
-						    accessor.componentType != ComponentType::Short &&
-						    accessor.componentType != ComponentType::Byte)
+							accessor.componentType != ComponentType::Short &&
+							accessor.componentType != ComponentType::Byte)
 							return Error::InvalidGltf;
 					}
 				} else if (startsWith(name, "TEXCOORD_")) {
-					if (accessor.type != AccessorType::Vec2)
-						return Error::InvalidGltf;
+					if (accessor.type != AccessorType::Vec2) return Error::InvalidGltf;
 					if (!isExtensionUsed(extensions::KHR_mesh_quantization)) {
 						if (accessor.componentType != ComponentType::Float &&
-						    accessor.componentType != ComponentType::UnsignedByte &&
-						    accessor.componentType != ComponentType::UnsignedShort) {
+							accessor.componentType != ComponentType::UnsignedByte &&
+							accessor.componentType != ComponentType::UnsignedShort) {
 							return Error::InvalidGltf;
 						}
 					} else {
 						if (accessor.componentType == ComponentType::Double ||
-						    accessor.componentType == ComponentType::UnsignedInt) {
+							accessor.componentType == ComponentType::UnsignedInt) {
 							return Error::InvalidGltf;
 						}
 					}
@@ -1292,28 +1289,27 @@ fg::Error fg::validate(const Asset& asset) {
 					if (accessor.type != AccessorType::Vec3 && accessor.type != AccessorType::Vec4)
 						return Error::InvalidGltf;
 					if (accessor.componentType != ComponentType::Float &&
-					    accessor.componentType != ComponentType::UnsignedByte &&
-					    accessor.componentType != ComponentType::UnsignedShort) {
+						accessor.componentType != ComponentType::UnsignedByte &&
+						accessor.componentType != ComponentType::UnsignedShort) {
 						return Error::InvalidGltf;
 					}
 				} else if (startsWith(name, "JOINTS_")) {
-					if (accessor.type != AccessorType::Vec4)
-						return Error::InvalidGltf;
+					if (accessor.type != AccessorType::Vec4) return Error::InvalidGltf;
 					if (accessor.componentType != ComponentType::UnsignedByte &&
-					    accessor.componentType != ComponentType::UnsignedShort) {
+						accessor.componentType != ComponentType::UnsignedShort) {
 						return Error::InvalidGltf;
 					}
 				} else if (startsWith(name, "WEIGHTS_")) {
-					if (accessor.type != AccessorType::Vec4)
-						return Error::InvalidGltf;
+					if (accessor.type != AccessorType::Vec4) return Error::InvalidGltf;
 					if (accessor.componentType != ComponentType::Float &&
-					    accessor.componentType != ComponentType::UnsignedByte &&
-					    accessor.componentType != ComponentType::UnsignedShort) {
+						accessor.componentType != ComponentType::UnsignedByte &&
+						accessor.componentType != ComponentType::UnsignedShort) {
 						return Error::InvalidGltf;
 					}
 				} else if (startsWith(name, "_")) {
-					// Application-specific attribute semantics MUST start with an underscore, e.g., _TEMPERATURE.
-					// Application-specific attribute semantics MUST NOT use unsigned int component type.
+					// Application-specific attribute semantics MUST start with an underscore, e.g.,
+					// _TEMPERATURE. Application-specific attribute semantics MUST NOT use unsigned
+					// int component type.
 					if (accessor.componentType == ComponentType::UnsignedInt) {
 						return Error::InvalidGltf;
 					}
@@ -1331,14 +1327,10 @@ fg::Error fg::validate(const Asset& asset) {
 			return Error::InvalidGltf;
 
 		if (const auto* pTRS = std::get_if<TRS>(&node.transform)) {
-			if (pTRS->rotation.x() > 1.0 || pTRS->rotation.x() < -1.0)
-				return Error::InvalidGltf;
-			if (pTRS->rotation.y() > 1.0 || pTRS->rotation.y() < -1.0)
-				return Error::InvalidGltf;
-			if (pTRS->rotation.z() > 1.0 || pTRS->rotation.z() < -1.0)
-				return Error::InvalidGltf;
-			if (pTRS->rotation.w() > 1.0 || pTRS->rotation.w() < -1.0)
-				return Error::InvalidGltf;
+			if (pTRS->rotation.x() > 1.0 || pTRS->rotation.x() < -1.0) return Error::InvalidGltf;
+			if (pTRS->rotation.y() > 1.0 || pTRS->rotation.y() < -1.0) return Error::InvalidGltf;
+			if (pTRS->rotation.z() > 1.0 || pTRS->rotation.z() < -1.0) return Error::InvalidGltf;
+			if (pTRS->rotation.w() > 1.0 || pTRS->rotation.w() < -1.0) return Error::InvalidGltf;
 		}
 
 		if ((node.skinIndex.has_value() || !node.weights.empty()) && !node.meshIndex.has_value()) {
@@ -1346,7 +1338,8 @@ fg::Error fg::validate(const Asset& asset) {
 		}
 
 		if (node.skinIndex.has_value()) {
-			// "When the node contains skin, all mesh.primitives MUST contain JOINTS_0 and WEIGHTS_0 attributes."
+			// "When the node contains skin, all mesh.primitives MUST contain JOINTS_0 and WEIGHTS_0
+			// attributes."
 			const auto& mesh = asset.meshes[node.meshIndex.value()];
 			for (const auto& primitive : mesh.primitives) {
 				const auto* joints0 = primitive.findAttribute("JOINTS_0");
@@ -1358,33 +1351,39 @@ fg::Error fg::validate(const Asset& asset) {
 	}
 
 	for (const auto& sampler : asset.samplers) {
-		if (sampler.magFilter.has_value() && (sampler.magFilter != Filter::Nearest && sampler.magFilter != Filter::Linear)) {
+		if (sampler.magFilter.has_value() &&
+			(sampler.magFilter != Filter::Nearest && sampler.magFilter != Filter::Linear)) {
 			return Error::InvalidGltf;
 		}
 	}
 
 	for (const auto& scene : asset.scenes) {
 		for (const auto& node : scene.nodeIndices) {
-			if (node >= asset.nodes.size())
-				return Error::InvalidGltf;
+			if (node >= asset.nodes.size()) return Error::InvalidGltf;
 		}
 	}
 
 	for (const auto& skin : asset.skins) {
-		if (skin.joints.empty())
-			return Error::InvalidGltf;
+		if (skin.joints.empty()) return Error::InvalidGltf;
 		if (skin.skeleton.has_value() && skin.skeleton.value() >= asset.nodes.size())
 			return Error::InvalidGltf;
-		if (skin.inverseBindMatrices.has_value() && skin.inverseBindMatrices.value() >= asset.accessors.size())
+		if (skin.inverseBindMatrices.has_value() &&
+			skin.inverseBindMatrices.value() >= asset.accessors.size())
 			return Error::InvalidGltf;
 	}
 
 	for (const auto& texture : asset.textures) {
-		if (texture.samplerIndex.has_value() && texture.samplerIndex.value() >= asset.samplers.size())
+		if (texture.samplerIndex.has_value() &&
+			texture.samplerIndex.value() >= asset.samplers.size())
 			return Error::InvalidGltf;
-		// imageIndex needs to be defined, unless one of the texture extensions were enabled and define another image index.
-		if (isExtensionUsed(extensions::KHR_texture_basisu) || isExtensionUsed(extensions::MSFT_texture_dds) || isExtensionUsed(extensions::EXT_texture_webp)) {
-			if (!texture.imageIndex.has_value() && (!texture.basisuImageIndex.has_value() && !texture.ddsImageIndex.has_value() && !texture.webpImageIndex.has_value())) {
+		// imageIndex needs to be defined, unless one of the texture extensions were enabled and
+		// define another image index.
+		if (isExtensionUsed(extensions::KHR_texture_basisu) ||
+			isExtensionUsed(extensions::MSFT_texture_dds) ||
+			isExtensionUsed(extensions::EXT_texture_webp)) {
+			if (!texture.imageIndex.has_value() &&
+				(!texture.basisuImageIndex.has_value() && !texture.ddsImageIndex.has_value() &&
+				 !texture.webpImageIndex.has_value())) {
 				return Error::InvalidGltf;
 			}
 		} else if (!texture.imageIndex.has_value()) {
@@ -1392,11 +1391,14 @@ fg::Error fg::validate(const Asset& asset) {
 		}
 		if (texture.imageIndex.has_value() && texture.imageIndex.value() >= asset.images.size())
 			return Error::InvalidGltf;
-		if (texture.basisuImageIndex.has_value() && texture.basisuImageIndex.value() >= asset.images.size())
+		if (texture.basisuImageIndex.has_value() &&
+			texture.basisuImageIndex.value() >= asset.images.size())
 			return Error::InvalidGltf;
-		if (texture.ddsImageIndex.has_value() && texture.ddsImageIndex.value() >= asset.images.size())
+		if (texture.ddsImageIndex.has_value() &&
+			texture.ddsImageIndex.value() >= asset.images.size())
 			return Error::InvalidGltf;
-		if (texture.webpImageIndex.has_value() && texture.webpImageIndex.value() >= asset.images.size())
+		if (texture.webpImageIndex.has_value() &&
+			texture.webpImageIndex.value() >= asset.images.size())
 			return Error::InvalidGltf;
 	}
 
@@ -1405,7 +1407,8 @@ fg::Error fg::validate(const Asset& asset) {
 		if (asset.scenes.size() != 1) {
 			return Error::InvalidGltf;
 		}
-		// The document "scene" index MUST be set to 0, the index of the only scene in the "scenes" array.
+		// The document "scene" index MUST be set to 0, the index of the only scene in the "scenes"
+		// array.
 		if (asset.defaultScene != 0U) {
 			return Error::InvalidGltf;
 		}
@@ -1413,18 +1416,21 @@ fg::Error fg::validate(const Asset& asset) {
 		if (asset.scenes[0].nodeIndices.size() != 1) {
 			return Error::InvalidGltf;
 		}
-		// The scene's node index MUST be set to 0, the index of the first node in the "nodes" array.
+		// The scene's node index MUST be set to 0, the index of the first node in the "nodes"
+		// array.
 		if (asset.scenes[0].nodeIndices[0] != 0) {
 			return Error::InvalidGltf;
 		}
 		if (asset.nodes.empty()) {
 			return Error::InvalidGltf;
 		}
-		auto &transform = asset.nodes[0].transform;
+		auto& transform = asset.nodes[0].transform;
 		TRS trs;
-		// The "translation", "rotation", "scale", and "matrix" properties of the single root node MUST either be not defined or have default values.
-		if (!std::holds_alternative<TRS>(transform)){
-			math::decomposeTransformMatrix(std::get<math::fmat4x4>(transform), trs.scale, trs.rotation, trs.translation);
+		// The "translation", "rotation", "scale", and "matrix" properties of the single root node
+		// MUST either be not defined or have default values.
+		if (!std::holds_alternative<TRS>(transform)) {
+			math::decomposeTransformMatrix(std::get<math::fmat4x4>(transform), trs.scale,
+										   trs.rotation, trs.translation);
 		} else {
 			trs = std::get<TRS>(transform);
 		}
@@ -1447,11 +1453,12 @@ fg::Expected<fg::Asset> fg::Parser::parse(simdjson::dom::object root, Category c
 	using namespace simdjson;
 	fillCategories(categories);
 
-	Asset asset {};
+	Asset asset{};
 
 #if !FASTGLTF_DISABLE_CUSTOM_MEMORY_POOL
 	// Create a new chunk memory resource for each asset we parse.
-	asset.memoryResource = resourceAllocator = std::make_shared<std::pmr::monotonic_buffer_resource>();
+	asset.memoryResource = resourceAllocator =
+		std::make_shared<std::pmr::monotonic_buffer_resource>();
 #endif
 
 	if (!hasBit(options, Options::DontRequireValidAssetMember)) {
@@ -1475,22 +1482,23 @@ fg::Expected<fg::Asset> fg::Parser::parse(simdjson::dom::object root, Category c
 		if (major != 2U) {
 			return Error::UnsupportedVersion;
 		}
-		info.gltfVersion = std::string { version };
+		info.gltfVersion = std::string{version};
 
 		std::string_view copyright;
 		if (assetInfo["copyright"].get_string().get(copyright) == SUCCESS) [[likely]] {
-			info.copyright = std::string { copyright };
+			info.copyright = std::string{copyright};
 		}
 
 		std::string_view generator;
 		if (assetInfo["generator"].get_string().get(generator) == SUCCESS) [[likely]] {
-			info.generator = std::string { generator };
+			info.generator = std::string{generator};
 		}
 
 		asset.assetInfo = std::move(info);
 	}
 
-	if (dom::array extensionsRequired; root["extensionsRequired"].get_array().get(extensionsRequired) == SUCCESS) [[likely]] {
+	if (dom::array extensionsRequired;
+		root["extensionsRequired"].get_array().get(extensionsRequired) == SUCCESS) [[likely]] {
 		for (auto extension : extensionsRequired) {
 			std::string_view string;
 			if (extension.get_string().get(string) != SUCCESS) [[unlikely]] {
@@ -1512,7 +1520,8 @@ fg::Expected<fg::Asset> fg::Parser::parse(simdjson::dom::object root, Category c
 				return Error::UnknownRequiredExtension;
 			}
 
-			FASTGLTF_STD_PMR_NS::string FASTGLTF_CONSTRUCT_PMR_RESOURCE(requiredExtension, resourceAllocator.get(), string);
+			FASTGLTF_STD_PMR_NS::string FASTGLTF_CONSTRUCT_PMR_RESOURCE(
+				requiredExtension, resourceAllocator.get(), string);
 			asset.extensionsRequired.emplace_back(std::move(requiredExtension));
 		}
 	}
@@ -1540,7 +1549,8 @@ fg::Expected<fg::Asset> fg::Parser::parse(simdjson::dom::object root, Category c
 			continue;
 		}
 
-		if (hashedKey == force_consteval<crc32c("asset")> || hashedKey == force_consteval<crc32c("extras")>) {
+		if (hashedKey == force_consteval<crc32c("asset")> ||
+			hashedKey == force_consteval<crc32c("extras")>) {
 			continue;
 		}
 
@@ -1549,11 +1559,11 @@ fg::Expected<fg::Asset> fg::Parser::parse(simdjson::dom::object root, Category c
 			return Error::InvalidGltf;
 		}
 
-#define KEY_SWITCH_CASE(name, id) case force_consteval<crc32c(FASTGLTF_QUOTE(id))>:       \
-                if (hasBit(categories, Category::name))   \
-                    error = parse##name(array, asset);                     \
-                readCategories |= Category::name;         \
-                break;
+#define KEY_SWITCH_CASE(name, id)                                                  \
+	case force_consteval<crc32c(FASTGLTF_QUOTE(id))>:                              \
+		if (hasBit(categories, Category::name)) error = parse##name(array, asset); \
+		readCategories |= Category::name;                                          \
+		break;
 
 		auto error = Error::None;
 		switch (hashedKey) {
@@ -1573,8 +1583,10 @@ fg::Expected<fg::Asset> fg::Parser::parse(simdjson::dom::object root, Category c
 			case force_consteval<crc32c("extensionsUsed")>: {
 				for (auto usedValue : array) {
 					std::string_view usedString;
-					if (auto eError = usedValue.get_string().get(usedString); eError == SUCCESS) [[likely]] {
-						FASTGLTF_STD_PMR_NS::string FASTGLTF_CONSTRUCT_PMR_RESOURCE(string, resourceAllocator.get(), usedString);
+					if (auto eError = usedValue.get_string().get(usedString); eError == SUCCESS)
+						[[likely]] {
+						FASTGLTF_STD_PMR_NS::string FASTGLTF_CONSTRUCT_PMR_RESOURCE(
+							string, resourceAllocator.get(), usedString);
 						asset.extensionsUsed.emplace_back(std::move(string));
 					} else {
 						error = Error::InvalidGltf;
@@ -1586,12 +1598,10 @@ fg::Expected<fg::Asset> fg::Parser::parse(simdjson::dom::object root, Category c
 				// These are already parsed before this section.
 				break;
 			}
-			default:
-				break;
+			default: break;
 		}
 
-		if (error != Error::None)
-			return error;
+		if (error != Error::None) return error;
 
 #undef KEY_SWITCH_CASE
 	}
@@ -1605,7 +1615,8 @@ fg::Expected<fg::Asset> fg::Parser::parse(simdjson::dom::object root, Category c
 	}
 
 	// Resize primitive mappings to match the global variant count
-	if (hasBit(config.extensions, Extensions::KHR_materials_variants) && !asset.materialVariants.empty()) {
+	if (hasBit(config.extensions, Extensions::KHR_materials_variants) &&
+		!asset.materialVariants.empty()) {
 		const auto variantCount = asset.materialVariants.size();
 		for (auto& mesh : asset.meshes) {
 			for (auto& primitive : mesh.primitives) {
@@ -1620,59 +1631,65 @@ fg::Expected<fg::Asset> fg::Parser::parse(simdjson::dom::object root, Category c
 }
 
 fg::Error fg::Parser::parseAccessors(const simdjson::dom::array& accessors, Asset& asset) {
-    using namespace simdjson;
+	using namespace simdjson;
 
 	asset.accessors.reserve(accessors.size());
-    for (auto accessorValue : accessors) {
-        // Required fields: "componentType", "count"
-        Accessor accessor = {};
-        dom::object accessorObject;
-        if (accessorValue.get_object().get(accessorObject) != SUCCESS) [[unlikely]] {
-            return Error::InvalidGltf;
-        }
+	for (auto accessorValue : accessors) {
+		// Required fields: "componentType", "count"
+		Accessor accessor = {};
+		dom::object accessorObject;
+		if (accessorValue.get_object().get(accessorObject) != SUCCESS) [[unlikely]] {
+			return Error::InvalidGltf;
+		}
 
-        std::uint64_t componentType;
-        if (accessorObject["componentType"].get_uint64().get(componentType) != SUCCESS) [[unlikely]] {
-            return Error::InvalidGltf;
-        }
-		accessor.componentType = getComponentType(static_cast<std::underlying_type_t<ComponentType>>(componentType));
-        if (accessor.componentType == ComponentType::Double && (!hasBit(options, Options::AllowDouble) || !hasBit(config.extensions, Extensions::KHR_accessor_float64))) {
-            return Error::InvalidGltf;
-        }
+		std::uint64_t componentType;
+		if (accessorObject["componentType"].get_uint64().get(componentType) != SUCCESS)
+			[[unlikely]] {
+			return Error::InvalidGltf;
+		}
+		accessor.componentType =
+			getComponentType(static_cast<std::underlying_type_t<ComponentType>>(componentType));
+		if (accessor.componentType == ComponentType::Double &&
+			(!hasBit(options, Options::AllowDouble) ||
+			 !hasBit(config.extensions, Extensions::KHR_accessor_float64))) {
+			return Error::InvalidGltf;
+		}
 
-        std::string_view accessorType;
-        if (accessorObject["type"].get_string().get(accessorType) != SUCCESS) [[unlikely]] {
-            return Error::InvalidGltf;
-        }
+		std::string_view accessorType;
+		if (accessorObject["type"].get_string().get(accessorType) != SUCCESS) [[unlikely]] {
+			return Error::InvalidGltf;
+		}
 		accessor.type = getAccessorType(accessorType);
 
-        std::uint64_t accessorCount;
-        if (accessorObject["count"].get_uint64().get(accessorCount) != SUCCESS) [[unlikely]] {
-            return Error::InvalidGltf;
-        }
+		std::uint64_t accessorCount;
+		if (accessorObject["count"].get_uint64().get(accessorCount) != SUCCESS) [[unlikely]] {
+			return Error::InvalidGltf;
+		}
 		accessor.count = static_cast<std::size_t>(accessorCount);
 
+		std::uint64_t bufferView;
+		if (accessorObject["bufferView"].get_uint64().get(bufferView) == SUCCESS) [[likely]] {
+			accessor.bufferViewIndex = static_cast<std::size_t>(bufferView);
+		}
 
-        std::uint64_t bufferView;
-        if (accessorObject["bufferView"].get_uint64().get(bufferView) == SUCCESS) [[likely]] {
-            accessor.bufferViewIndex = static_cast<std::size_t>(bufferView);
-        }
-
-        // byteOffset is optional, but defaults to 0
-        std::uint64_t byteOffset;
-        if (auto error = accessorObject["byteOffset"].get_uint64().get(byteOffset); error == SUCCESS) [[likely]] {
-            accessor.byteOffset = static_cast<std::size_t>(byteOffset);
-        } else if (error != NO_SUCH_FIELD) [[unlikely]] {
-            return Error::InvalidGltf;
-        }
+		// byteOffset is optional, but defaults to 0
+		std::uint64_t byteOffset;
+		if (auto error = accessorObject["byteOffset"].get_uint64().get(byteOffset);
+			error == SUCCESS) [[likely]] {
+			accessor.byteOffset = static_cast<std::size_t>(byteOffset);
+		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
+			return Error::InvalidGltf;
+		}
 
 		// Type of min and max should always be the same.
-		auto parseMinMax = [&](const std::string_view key, std::optional<AccessorBoundsArray>& ref) -> Error {
+		auto parseMinMax = [&](const std::string_view key,
+							   std::optional<AccessorBoundsArray>& ref) -> Error {
 			dom::array elements;
 			if (accessorObject[key].get_array().get(elements) == SUCCESS) [[likely]] {
 				const auto num = getNumComponents(accessor.type);
 
-				if (accessor.componentType == ComponentType::Float || accessor.componentType == ComponentType::Double) {
+				if (accessor.componentType == ComponentType::Float ||
+					accessor.componentType == ComponentType::Double) {
 					ref = AccessorBoundsArray(num, AccessorBoundsArray::BoundsType::float64);
 				} else {
 					ref = AccessorBoundsArray(num, AccessorBoundsArray::BoundsType::int64);
@@ -1717,9 +1734,9 @@ fg::Error fg::Parser::parseAccessors(const simdjson::dom::array& accessors, Asse
 							break;
 						}
 						case dom::element_type::UINT64: {
-							// Note that the glTF spec doesn't care about any integer larger than 32-bits, so
-							// truncating uint64 to int64 wouldn't make any difference, as those large values
-							// aren't allowed anyway.
+							// Note that the glTF spec doesn't care about any integer larger than
+							// 32-bits, so truncating uint64 to int64 wouldn't make any difference,
+							// as those large values aren't allowed anyway.
 							std::uint64_t value;
 							if (element.get_uint64().get(value) != SUCCESS) [[unlikely]] {
 								return Error::InvalidGltf;
@@ -1752,241 +1769,256 @@ fg::Error fg::Parser::parseAccessors(const simdjson::dom::array& accessors, Asse
 			return error;
 		}
 
-        if (auto error = accessorObject["normalized"].get_bool().get(accessor.normalized); error != SUCCESS && error != NO_SUCH_FIELD) [[unlikely]] {
-            return Error::InvalidGltf;
-        }
-
-		// This property MUST NOT be set to true for accessors with FLOAT or UNSIGNED_INT component type.
-		if (accessor.normalized && (accessor.componentType == ComponentType::UnsignedInt || accessor.componentType == ComponentType::Float)) {
+		if (auto error = accessorObject["normalized"].get_bool().get(accessor.normalized);
+			error != SUCCESS && error != NO_SUCH_FIELD) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
-        dom::object sparseAccessorObject;
-        if (accessorObject["sparse"].get_object().get(sparseAccessorObject) == SUCCESS) [[likely]] {
-            SparseAccessor sparse = {};
-            std::uint64_t value;
-            dom::object child;
-            if (sparseAccessorObject["count"].get_uint64().get(value) != SUCCESS) [[unlikely]] {
-                return Error::InvalidGltf;
-            }
-            sparse.count = static_cast<std::size_t>(value);
+		// This property MUST NOT be set to true for accessors with FLOAT or UNSIGNED_INT component
+		// type.
+		if (accessor.normalized && (accessor.componentType == ComponentType::UnsignedInt ||
+									accessor.componentType == ComponentType::Float)) {
+			return Error::InvalidGltf;
+		}
 
-            // Accessor Sparce Indices
-            if (sparseAccessorObject["indices"].get_object().get(child) != SUCCESS) [[unlikely]] {
-                return Error::InvalidGltf;
-            }
+		dom::object sparseAccessorObject;
+		if (accessorObject["sparse"].get_object().get(sparseAccessorObject) == SUCCESS) [[likely]] {
+			SparseAccessor sparse = {};
+			std::uint64_t value;
+			dom::object child;
+			if (sparseAccessorObject["count"].get_uint64().get(value) != SUCCESS) [[unlikely]] {
+				return Error::InvalidGltf;
+			}
+			sparse.count = static_cast<std::size_t>(value);
 
-            if (child["bufferView"].get_uint64().get(value) != SUCCESS) [[unlikely]] {
-                return Error::InvalidGltf;
-            }
-            sparse.indicesBufferView = static_cast<std::size_t>(value);
+			// Accessor Sparce Indices
+			if (sparseAccessorObject["indices"].get_object().get(child) != SUCCESS) [[unlikely]] {
+				return Error::InvalidGltf;
+			}
 
-            if (auto error = child["byteOffset"].get_uint64().get(value); error == SUCCESS) [[likely]] {
-                sparse.indicesByteOffset = static_cast<std::size_t>(value);
-            } else if (error != NO_SUCH_FIELD) [[unlikely]] {
-                return Error::InvalidGltf;
-            }
+			if (child["bufferView"].get_uint64().get(value) != SUCCESS) [[unlikely]] {
+				return Error::InvalidGltf;
+			}
+			sparse.indicesBufferView = static_cast<std::size_t>(value);
 
-            if (child["componentType"].get_uint64().get(value) != SUCCESS) [[unlikely]] {
-                return Error::InvalidGltf;
-            }
-            sparse.indexComponentType = getComponentType(static_cast<std::underlying_type_t<ComponentType>>(value));
+			if (auto error = child["byteOffset"].get_uint64().get(value); error == SUCCESS)
+				[[likely]] {
+				sparse.indicesByteOffset = static_cast<std::size_t>(value);
+			} else if (error != NO_SUCH_FIELD) [[unlikely]] {
+				return Error::InvalidGltf;
+			}
 
-            // Accessor Sparse Values
-            if (sparseAccessorObject["values"].get_object().get(child) != SUCCESS) [[unlikely]] {
-                return Error::InvalidGltf;
-            }
+			if (child["componentType"].get_uint64().get(value) != SUCCESS) [[unlikely]] {
+				return Error::InvalidGltf;
+			}
+			sparse.indexComponentType =
+				getComponentType(static_cast<std::underlying_type_t<ComponentType>>(value));
 
-            if (child["bufferView"].get_uint64().get(value) != SUCCESS) [[unlikely]] {
-                return Error::InvalidGltf;
-            }
-            sparse.valuesBufferView = static_cast<std::size_t>(value);
+			// Accessor Sparse Values
+			if (sparseAccessorObject["values"].get_object().get(child) != SUCCESS) [[unlikely]] {
+				return Error::InvalidGltf;
+			}
 
-            if (auto error = child["byteOffset"].get_uint64().get(value); error == SUCCESS) [[likely]] {
-                sparse.valuesByteOffset = static_cast<std::size_t>(value);
-            } else if (error != NO_SUCH_FIELD) [[unlikely]] {
-                return Error::InvalidGltf;
-            }
+			if (child["bufferView"].get_uint64().get(value) != SUCCESS) [[unlikely]] {
+				return Error::InvalidGltf;
+			}
+			sparse.valuesBufferView = static_cast<std::size_t>(value);
 
-            accessor.sparse = sparse;
-        }
+			if (auto error = child["byteOffset"].get_uint64().get(value); error == SUCCESS)
+				[[likely]] {
+				sparse.valuesByteOffset = static_cast<std::size_t>(value);
+			} else if (error != NO_SUCH_FIELD) [[unlikely]] {
+				return Error::InvalidGltf;
+			}
+
+			accessor.sparse = sparse;
+		}
 
 		if (config.extrasCallback != nullptr) {
 			dom::object extrasObject;
-			if (auto extrasError = accessorObject["extras"].get_object().get(extrasObject); extrasError == SUCCESS) {
-				config.extrasCallback(&extrasObject, asset.accessors.size(), Category::Accessors, config.userPointer);
+			if (auto extrasError = accessorObject["extras"].get_object().get(extrasObject);
+				extrasError == SUCCESS) {
+				config.extrasCallback(&extrasObject, asset.accessors.size(), Category::Accessors,
+									  config.userPointer);
 			} else if (extrasError != NO_SUCH_FIELD) {
 				return Error::InvalidGltf;
 			}
 		}
 
 		std::string_view name;
-        if (accessorObject["name"].get_string().get(name) == SUCCESS) {
-	        accessor.name = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(accessor.name), resourceAllocator.get(), name);
-        }
+		if (accessorObject["name"].get_string().get(name) == SUCCESS) {
+			accessor.name = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(accessor.name),
+															resourceAllocator.get(), name);
+		}
 
-	    asset.accessors.emplace_back(std::move(accessor));
-    }
+		asset.accessors.emplace_back(std::move(accessor));
+	}
 
 	return Error::None;
 }
 
 fg::Error fg::Parser::parseAnimations(simdjson::dom::array& animations, Asset& asset) {
-    using namespace simdjson;
+	using namespace simdjson;
 
 	asset.animations.reserve(animations.size());
-    for (auto animationValue : animations) {
-        dom::object animationObject;
-        Animation animation = {};
-        if (animationValue.get_object().get(animationObject) != SUCCESS) [[unlikely]] {
-            return Error::InvalidGltf;
-        }
+	for (auto animationValue : animations) {
+		dom::object animationObject;
+		Animation animation = {};
+		if (animationValue.get_object().get(animationObject) != SUCCESS) [[unlikely]] {
+			return Error::InvalidGltf;
+		}
 
-        dom::array channels;
-        auto channelError = getJsonArray(animationObject, "channels", &channels);
-        if (channelError != Error::None) {
-            return Error::InvalidGltf;
-        }
+		dom::array channels;
+		auto channelError = getJsonArray(animationObject, "channels", &channels);
+		if (channelError != Error::None) {
+			return Error::InvalidGltf;
+		}
 
-	    animation.channels = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(animation.channels), resourceAllocator.get(), 0);
-        animation.channels.reserve(channels.size());
-        for (auto channelValue : channels) {
-            dom::object channelObject;
-            AnimationChannel channel = {};
-            if (channelValue.get_object().get(channelObject) != SUCCESS) [[unlikely]] {
-                return Error::InvalidGltf;
-            }
+		animation.channels = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(animation.channels),
+															 resourceAllocator.get(), 0);
+		animation.channels.reserve(channels.size());
+		for (auto channelValue : channels) {
+			dom::object channelObject;
+			AnimationChannel channel = {};
+			if (channelValue.get_object().get(channelObject) != SUCCESS) [[unlikely]] {
+				return Error::InvalidGltf;
+			}
 
-            std::uint64_t sampler;
-            if (channelObject["sampler"].get_uint64().get(sampler) != SUCCESS) [[unlikely]] {
-                return Error::InvalidGltf;
-            }
-            channel.samplerIndex = static_cast<std::size_t>(sampler);
+			std::uint64_t sampler;
+			if (channelObject["sampler"].get_uint64().get(sampler) != SUCCESS) [[unlikely]] {
+				return Error::InvalidGltf;
+			}
+			channel.samplerIndex = static_cast<std::size_t>(sampler);
 
-            dom::object targetObject;
-            if (channelObject["target"].get_object().get(targetObject) != SUCCESS) [[unlikely]] {
-                return Error::InvalidGltf;
-            } else {
-                std::uint64_t node;
-				if (auto error = targetObject["node"].get_uint64().get(node); error == SUCCESS) [[likely]] {
+			dom::object targetObject;
+			if (channelObject["target"].get_object().get(targetObject) != SUCCESS) [[unlikely]] {
+				return Error::InvalidGltf;
+			} else {
+				std::uint64_t node;
+				if (auto error = targetObject["node"].get_uint64().get(node); error == SUCCESS)
+					[[likely]] {
 					channel.nodeIndex = static_cast<std::size_t>(node);
 				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
-					// the glTF spec allows the node index of an animation channel to be absent, and requires
-					// implementations to just ignore the animation if no extension exists to override it.
-					// > When node isn't defined, channel SHOULD be ignored.
+					// the glTF spec allows the node index of an animation channel to be absent, and
+					// requires implementations to just ignore the animation if no extension exists
+					// to override it. > When node isn't defined, channel SHOULD be ignored.
 					return Error::InvalidGltf;
 				}
 
-                std::string_view path;
-                if (targetObject["path"].get_string().get(path) != SUCCESS) [[unlikely]] {
-                    return Error::InvalidGltf;
-                }
+				std::string_view path;
+				if (targetObject["path"].get_string().get(path) != SUCCESS) [[unlikely]] {
+					return Error::InvalidGltf;
+				}
 
-                if (path == "translation") {
-                    channel.path = AnimationPath::Translation;
-                } else if (path == "rotation") {
-                    channel.path = AnimationPath::Rotation;
-                } else if (path == "scale") {
-                    channel.path = AnimationPath::Scale;
-                } else if (path == "weights") {
-                    channel.path = AnimationPath::Weights;
-                }
-            }
+				if (path == "translation") {
+					channel.path = AnimationPath::Translation;
+				} else if (path == "rotation") {
+					channel.path = AnimationPath::Rotation;
+				} else if (path == "scale") {
+					channel.path = AnimationPath::Scale;
+				} else if (path == "weights") {
+					channel.path = AnimationPath::Weights;
+				}
+			}
 
-            animation.channels.emplace_back(channel);
-        }
+			animation.channels.emplace_back(channel);
+		}
 
-        dom::array samplers;
-        auto samplerError = getJsonArray(animationObject, "samplers", &samplers);
-        if (samplerError != Error::None) {
-            return Error::InvalidGltf;
-        }
+		dom::array samplers;
+		auto samplerError = getJsonArray(animationObject, "samplers", &samplers);
+		if (samplerError != Error::None) {
+			return Error::InvalidGltf;
+		}
 
-	    animation.samplers = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(animation.samplers), resourceAllocator.get(), 0);
-        animation.samplers.reserve(samplers.size());
-        for (auto samplerValue : samplers) {
-            dom::object samplerObject;
-            AnimationSampler sampler = {};
-            if (samplerValue.get_object().get(samplerObject) != SUCCESS) [[unlikely]] {
-                return Error::InvalidGltf;
-            }
+		animation.samplers = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(animation.samplers),
+															 resourceAllocator.get(), 0);
+		animation.samplers.reserve(samplers.size());
+		for (auto samplerValue : samplers) {
+			dom::object samplerObject;
+			AnimationSampler sampler = {};
+			if (samplerValue.get_object().get(samplerObject) != SUCCESS) [[unlikely]] {
+				return Error::InvalidGltf;
+			}
 
-            std::uint64_t input;
-            if (samplerObject["input"].get_uint64().get(input) != SUCCESS) [[unlikely]] {
-                return Error::InvalidGltf;
-            }
-            sampler.inputAccessor = static_cast<std::size_t>(input);
+			std::uint64_t input;
+			if (samplerObject["input"].get_uint64().get(input) != SUCCESS) [[unlikely]] {
+				return Error::InvalidGltf;
+			}
+			sampler.inputAccessor = static_cast<std::size_t>(input);
 
-            std::uint64_t output;
-            if (samplerObject["output"].get_uint64().get(output) != SUCCESS) [[unlikely]] {
-                return Error::InvalidGltf;
-            }
-            sampler.outputAccessor = static_cast<std::size_t>(output);
+			std::uint64_t output;
+			if (samplerObject["output"].get_uint64().get(output) != SUCCESS) [[unlikely]] {
+				return Error::InvalidGltf;
+			}
+			sampler.outputAccessor = static_cast<std::size_t>(output);
 
-            std::string_view interpolation;
-            if (samplerObject["interpolation"].get_string().get(interpolation) != SUCCESS) [[unlikely]] {
-                sampler.interpolation = AnimationInterpolation::Linear;
-            } else {
-                if (interpolation == "LINEAR") {
-                    sampler.interpolation = AnimationInterpolation::Linear;
-                } else if (interpolation == "STEP") {
-                    sampler.interpolation = AnimationInterpolation::Step;
-                } else if (interpolation == "CUBICSPLINE") {
-                    sampler.interpolation = AnimationInterpolation::CubicSpline;
-                } else {
-                    return Error::InvalidGltf;
-                }
-            }
+			std::string_view interpolation;
+			if (samplerObject["interpolation"].get_string().get(interpolation) != SUCCESS)
+				[[unlikely]] {
+				sampler.interpolation = AnimationInterpolation::Linear;
+			} else {
+				if (interpolation == "LINEAR") {
+					sampler.interpolation = AnimationInterpolation::Linear;
+				} else if (interpolation == "STEP") {
+					sampler.interpolation = AnimationInterpolation::Step;
+				} else if (interpolation == "CUBICSPLINE") {
+					sampler.interpolation = AnimationInterpolation::CubicSpline;
+				} else {
+					return Error::InvalidGltf;
+				}
+			}
 
-            animation.samplers.emplace_back(sampler);
-        }
+			animation.samplers.emplace_back(sampler);
+		}
 
 		if (config.extrasCallback != nullptr) {
 			dom::object extrasObject;
-			if (auto extrasError = animationObject["extras"].get_object().get(extrasObject); extrasError == SUCCESS) {
-				config.extrasCallback(&extrasObject, asset.animations.size(), Category::Animations, config.userPointer);
+			if (auto extrasError = animationObject["extras"].get_object().get(extrasObject);
+				extrasError == SUCCESS) {
+				config.extrasCallback(&extrasObject, asset.animations.size(), Category::Animations,
+									  config.userPointer);
 			} else if (extrasError != NO_SUCH_FIELD) {
 				return Error::InvalidGltf;
 			}
 		}
 
-
 		std::string_view name;
-        if (animationObject["name"].get_string().get(name) == SUCCESS) {
-	        animation.name = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(animation.name), resourceAllocator.get(), name);
-        }
+		if (animationObject["name"].get_string().get(name) == SUCCESS) {
+			animation.name = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(animation.name),
+															 resourceAllocator.get(), name);
+		}
 
-	    asset.animations.emplace_back(std::move(animation));
-    }
+		asset.animations.emplace_back(std::move(animation));
+	}
 
 	return Error::None;
 }
 
 fg::Error fg::Parser::parseBuffers(simdjson::dom::array& buffers, Asset& asset) {
-    using namespace simdjson;
+	using namespace simdjson;
 
 	asset.buffers.reserve(buffers.size());
-    std::size_t bufferIndex = 0;
-    for (auto bufferValue : buffers) {
-        // Required fields: "byteLength"
-        Buffer buffer = {};
-        dom::object bufferObject;
-        if (bufferValue.get_object().get(bufferObject) != SUCCESS) [[unlikely]] {
-            return Error::InvalidGltf;
-        }
+	std::size_t bufferIndex = 0;
+	for (auto bufferValue : buffers) {
+		// Required fields: "byteLength"
+		Buffer buffer = {};
+		dom::object bufferObject;
+		if (bufferValue.get_object().get(bufferObject) != SUCCESS) [[unlikely]] {
+			return Error::InvalidGltf;
+		}
 
-        std::uint64_t byteLength;
-        if (bufferObject["byteLength"].get_uint64().get(byteLength) != SUCCESS) [[unlikely]] {
-            return Error::InvalidGltf;
-        }
+		std::uint64_t byteLength;
+		if (bufferObject["byteLength"].get_uint64().get(byteLength) != SUCCESS) [[unlikely]] {
+			return Error::InvalidGltf;
+		}
 		buffer.byteLength = static_cast<std::size_t>(byteLength);
 
-		// The spec for EXT_meshopt_compression allows so-called 'fallback buffers' which only exist to
-		// act as a valid fallback for compressed buffer views, but actually do not contain any data.
-		// In these cases, there is either simply no URI, or a fallback boolean is added to the extensions'
-		// extension field.
-		// In these cases, fastgltf could just leave the std::monostate in the DataSource.
-		// However, to make the actual use of these buffers clear, we'll use an empty fallback type.
+		// The spec for EXT_meshopt_compression allows so-called 'fallback buffers' which only exist
+		// to act as a valid fallback for compressed buffer views, but actually do not contain any
+		// data. In these cases, there is either simply no URI, or a fallback boolean is added to
+		// the extensions' extension field. In these cases, fastgltf could just leave the
+		// std::monostate in the DataSource. However, to make the actual use of these buffers clear,
+		// we'll use an empty fallback type.
 		bool meshoptCompressionRequired = false;
 		for (const auto& extension : asset.extensionsRequired) {
 			if (extension == extensions::EXT_meshopt_compression) {
@@ -1994,362 +2026,393 @@ fg::Error fg::Parser::parseBuffers(simdjson::dom::array& buffers, Asset& asset) 
 			}
 		}
 
-        // When parsing GLB, there's a buffer object that will point to the BUF chunk in the
-        // file. Otherwise, data must be specified in the "uri" field.
-        std::string_view uriString;
-        if (bufferObject["uri"].get_string().get(uriString) == SUCCESS) [[likely]] {
+		// When parsing GLB, there's a buffer object that will point to the BUF chunk in the
+		// file. Otherwise, data must be specified in the "uri" field.
+		std::string_view uriString;
+		if (bufferObject["uri"].get_string().get(uriString) == SUCCESS) [[likely]] {
 			URIView uriView(uriString);
 
-            if (!uriView.valid()) {
-                return Error::InvalidURI;
-            }
+			if (!uriView.valid()) {
+				return Error::InvalidURI;
+			}
 
-            if (uriView.isDataUri()) {
-                auto [error, source] = decodeDataUri(uriView);
-                if (error != Error::None) {
-                    return error;
-                }
+			if (uriView.isDataUri()) {
+				auto [error, source] = decodeDataUri(uriView);
+				if (error != Error::None) {
+					return error;
+				}
 
-                buffer.data = std::move(source);
-            } else if (uriView.isLocalPath() && hasBit(options, Options::LoadExternalBuffers)) {
-	            auto [error, source] = loadFileFromUri(uriView);
-                if (error != Error::None) {
-                    return error;
-                }
+				buffer.data = std::move(source);
+			} else if (uriView.isLocalPath() && hasBit(options, Options::LoadExternalBuffers)) {
+				auto [error, source] = loadFileFromUri(uriView);
+				if (error != Error::None) {
+					return error;
+				}
 
-                buffer.data = std::move(source);
-            } else {
-                sources::URI filePath;
-                filePath.fileByteOffset = 0;
-                filePath.uri = uriView;
-                buffer.data = std::move(filePath);
-            }
-        } else if (bufferIndex == 0 && !std::holds_alternative<std::monostate>(glbBuffer)) {
-            buffer.data = std::move(glbBuffer);
-        } else if (meshoptCompressionRequired) {
+				buffer.data = std::move(source);
+			} else {
+				sources::URI filePath;
+				filePath.fileByteOffset = 0;
+				filePath.uri = uriView;
+				buffer.data = std::move(filePath);
+			}
+		} else if (bufferIndex == 0 && !std::holds_alternative<std::monostate>(glbBuffer)) {
+			buffer.data = std::move(glbBuffer);
+		} else if (meshoptCompressionRequired) {
 			// This buffer is not a GLB buffer and has no URI source and is therefore a fallback.
 			buffer.data = sources::Fallback();
 		} else {
-            // All other buffers have to contain an uri field.
-            return Error::InvalidGltf;
-        }
+			// All other buffers have to contain an uri field.
+			return Error::InvalidGltf;
+		}
 
-        if (std::holds_alternative<std::monostate>(buffer.data)) {
-            return Error::InvalidGltf;
-        }
+		if (std::holds_alternative<std::monostate>(buffer.data)) {
+			return Error::InvalidGltf;
+		}
 
 		if (config.extrasCallback != nullptr) {
 			dom::object extrasObject;
-			if (auto extrasError = bufferObject["extras"].get_object().get(extrasObject); extrasError == SUCCESS) {
-				config.extrasCallback(&extrasObject, asset.buffers.size(), Category::Buffers, config.userPointer);
+			if (auto extrasError = bufferObject["extras"].get_object().get(extrasObject);
+				extrasError == SUCCESS) {
+				config.extrasCallback(&extrasObject, asset.buffers.size(), Category::Buffers,
+									  config.userPointer);
 			} else if (extrasError != NO_SUCH_FIELD) {
 				return Error::InvalidGltf;
 			}
 		}
 
 		std::string_view name;
-        if (bufferObject["name"].get_string().get(name) == SUCCESS) {
-	        buffer.name = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(buffer.name), resourceAllocator.get(), name);
-        }
+		if (bufferObject["name"].get_string().get(name) == SUCCESS) {
+			buffer.name = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(buffer.name),
+														  resourceAllocator.get(), name);
+		}
 
-        ++bufferIndex;
-	    asset.buffers.emplace_back(std::move(buffer));
-    }
+		++bufferIndex;
+		asset.buffers.emplace_back(std::move(buffer));
+	}
 
 	return Error::None;
 }
 
 fg::Error fg::Parser::parseBufferViews(const simdjson::dom::array& bufferViews, Asset& asset) {
-    using namespace simdjson;
+	using namespace simdjson;
 
 	asset.bufferViews.reserve(bufferViews.size());
-    for (auto bufferViewValue : bufferViews) {
-        dom::object bufferViewObject;
-        if (bufferViewValue.get_object().get(bufferViewObject) != SUCCESS) [[unlikely]] {
-            return Error::InvalidGltf;
-        }
+	for (auto bufferViewValue : bufferViews) {
+		dom::object bufferViewObject;
+		if (bufferViewValue.get_object().get(bufferViewObject) != SUCCESS) [[unlikely]] {
+			return Error::InvalidGltf;
+		}
 
-        std::uint64_t number;
-        BufferView view;
-        if (auto error = bufferViewObject["buffer"].get_uint64().get(number); error != SUCCESS) [[unlikely]] {
-            return error == NO_SUCH_FIELD ? Error::InvalidGltf : Error::InvalidJson;
-        }
-        view.bufferIndex = static_cast<std::size_t>(number);
+		std::uint64_t number;
+		BufferView view;
+		if (auto error = bufferViewObject["buffer"].get_uint64().get(number); error != SUCCESS)
+			[[unlikely]] {
+			return error == NO_SUCH_FIELD ? Error::InvalidGltf : Error::InvalidJson;
+		}
+		view.bufferIndex = static_cast<std::size_t>(number);
 
-        if (auto error = bufferViewObject["byteOffset"].get_uint64().get(number); error == SUCCESS) [[likely]] {
-            view.byteOffset = static_cast<std::size_t>(number);
-        } else if (error != NO_SUCH_FIELD) [[unlikely]] {
-            return Error::InvalidJson;
-        }
+		if (auto error = bufferViewObject["byteOffset"].get_uint64().get(number); error == SUCCESS)
+			[[likely]] {
+			view.byteOffset = static_cast<std::size_t>(number);
+		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
+			return Error::InvalidJson;
+		}
 
-        if (auto error = bufferViewObject["byteLength"].get_uint64().get(number); error != SUCCESS) [[unlikely]] {
-            return error == NO_SUCH_FIELD ? Error::InvalidGltf : Error::InvalidJson;
-        }
-        view.byteLength = static_cast<std::size_t>(number);
+		if (auto error = bufferViewObject["byteLength"].get_uint64().get(number); error != SUCCESS)
+			[[unlikely]] {
+			return error == NO_SUCH_FIELD ? Error::InvalidGltf : Error::InvalidJson;
+		}
+		view.byteLength = static_cast<std::size_t>(number);
 
-        if (auto error = bufferViewObject["byteStride"].get_uint64().get(number); error == SUCCESS) [[likely]] {
-            view.byteStride = static_cast<std::size_t>(number);
-        } else if (error != NO_SUCH_FIELD) [[unlikely]] {
-            return Error::InvalidJson;
-        }
+		if (auto error = bufferViewObject["byteStride"].get_uint64().get(number); error == SUCCESS)
+			[[likely]] {
+			view.byteStride = static_cast<std::size_t>(number);
+		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
+			return Error::InvalidJson;
+		}
 
-        if (auto error = bufferViewObject["target"].get_uint64().get(number); error == SUCCESS) [[likely]] {
-            view.target = static_cast<BufferTarget>(number);
-        } else if (error != NO_SUCH_FIELD) [[unlikely]] {
-            return Error::InvalidJson;
-        }
+		if (auto error = bufferViewObject["target"].get_uint64().get(number); error == SUCCESS)
+			[[likely]] {
+			view.target = static_cast<BufferTarget>(number);
+		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
+			return Error::InvalidJson;
+		}
 
-        std::string_view string;
-        if (auto error = bufferViewObject["name"].get_string().get(string); error == SUCCESS) {
-	        view.name = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(view.name), resourceAllocator.get(), string);
-        } else if (error != NO_SUCH_FIELD) [[unlikely]] {
-            return Error::InvalidJson;
-        }
+		std::string_view string;
+		if (auto error = bufferViewObject["name"].get_string().get(string); error == SUCCESS) {
+			view.name = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(view.name),
+														resourceAllocator.get(), string);
+		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
+			return Error::InvalidJson;
+		}
 
-        dom::object extensionObject;
-        if (bufferViewObject["extensions"].get_object().get(extensionObject) == SUCCESS) [[likely]] {
-            dom::object meshoptCompression;
-            if (hasBit(config.extensions, Extensions::EXT_meshopt_compression) && extensionObject[extensions::EXT_meshopt_compression].get_object().get(meshoptCompression) == SUCCESS) [[likely]] {
-                auto compression = std::make_unique<CompressedBufferView>();
+		dom::object extensionObject;
+		if (bufferViewObject["extensions"].get_object().get(extensionObject) == SUCCESS)
+			[[likely]] {
+			dom::object meshoptCompression;
+			if (hasBit(config.extensions, Extensions::EXT_meshopt_compression) &&
+				extensionObject[extensions::EXT_meshopt_compression].get_object().get(
+					meshoptCompression) == SUCCESS) [[likely]] {
+				auto compression = std::make_unique<CompressedBufferView>();
 
-                if (auto error = meshoptCompression["buffer"].get_uint64().get(number); error != SUCCESS) [[unlikely]] {
-                    return error == NO_SUCH_FIELD ? Error::InvalidGltf : Error::InvalidJson;
-                }
-                compression->bufferIndex = static_cast<std::size_t>(number);
+				if (auto error = meshoptCompression["buffer"].get_uint64().get(number);
+					error != SUCCESS) [[unlikely]] {
+					return error == NO_SUCH_FIELD ? Error::InvalidGltf : Error::InvalidJson;
+				}
+				compression->bufferIndex = static_cast<std::size_t>(number);
 
-                if (auto error = meshoptCompression["byteOffset"].get_uint64().get(number); error == SUCCESS) [[likely]] {
-                    compression->byteOffset = static_cast<std::size_t>(number);
-                } else if (error == NO_SUCH_FIELD) {
-                    compression->byteOffset = 0;
-                } else {
-                    return Error::InvalidJson;
-                }
+				if (auto error = meshoptCompression["byteOffset"].get_uint64().get(number);
+					error == SUCCESS) [[likely]] {
+					compression->byteOffset = static_cast<std::size_t>(number);
+				} else if (error == NO_SUCH_FIELD) {
+					compression->byteOffset = 0;
+				} else {
+					return Error::InvalidJson;
+				}
 
-                if (auto error = meshoptCompression["byteLength"].get_uint64().get(number); error != SUCCESS) [[unlikely]] {
-                    return error == NO_SUCH_FIELD ? Error::InvalidGltf : Error::InvalidJson;
-                }
-                compression->byteLength = static_cast<std::size_t>(number);
+				if (auto error = meshoptCompression["byteLength"].get_uint64().get(number);
+					error != SUCCESS) [[unlikely]] {
+					return error == NO_SUCH_FIELD ? Error::InvalidGltf : Error::InvalidJson;
+				}
+				compression->byteLength = static_cast<std::size_t>(number);
 
-                if (auto error = meshoptCompression["byteStride"].get_uint64().get(number); error != SUCCESS) [[unlikely]] {
-                    return error == NO_SUCH_FIELD ? Error::InvalidGltf : Error::InvalidJson;
-                }
-                compression->byteStride = static_cast<std::size_t>(number);
+				if (auto error = meshoptCompression["byteStride"].get_uint64().get(number);
+					error != SUCCESS) [[unlikely]] {
+					return error == NO_SUCH_FIELD ? Error::InvalidGltf : Error::InvalidJson;
+				}
+				compression->byteStride = static_cast<std::size_t>(number);
 
-                if (auto error = meshoptCompression["count"].get_uint64().get(number); error != SUCCESS) [[unlikely]] {
-                    return error == NO_SUCH_FIELD ? Error::InvalidGltf : Error::InvalidJson;
-                }
-                compression->count = number;
+				if (auto error = meshoptCompression["count"].get_uint64().get(number);
+					error != SUCCESS) [[unlikely]] {
+					return error == NO_SUCH_FIELD ? Error::InvalidGltf : Error::InvalidJson;
+				}
+				compression->count = number;
 
-                if (auto error = meshoptCompression["mode"].get_string().get(string); error != SUCCESS) [[unlikely]] {
-                    return error == NO_SUCH_FIELD ? Error::InvalidGltf : Error::InvalidJson;
-                }
-                switch (crcStringFunction(string)) {
-                    case force_consteval<crc32c("ATTRIBUTES")>: {
-                        compression->mode = MeshoptCompressionMode::Attributes;
-                        break;
-                    }
-                    case force_consteval<crc32c("TRIANGLES")>: {
-                        compression->mode = MeshoptCompressionMode::Triangles;
-                        break;
-                    }
-                    case force_consteval<crc32c("INDICES")>: {
-                        compression->mode = MeshoptCompressionMode::Indices;
-                        break;
-                    }
-                    default: {
-                        return Error::InvalidGltf;
-                    }
-                }
+				if (auto error = meshoptCompression["mode"].get_string().get(string);
+					error != SUCCESS) [[unlikely]] {
+					return error == NO_SUCH_FIELD ? Error::InvalidGltf : Error::InvalidJson;
+				}
+				switch (crcStringFunction(string)) {
+					case force_consteval<crc32c("ATTRIBUTES")>: {
+						compression->mode = MeshoptCompressionMode::Attributes;
+						break;
+					}
+					case force_consteval<crc32c("TRIANGLES")>: {
+						compression->mode = MeshoptCompressionMode::Triangles;
+						break;
+					}
+					case force_consteval<crc32c("INDICES")>: {
+						compression->mode = MeshoptCompressionMode::Indices;
+						break;
+					}
+					default: {
+						return Error::InvalidGltf;
+					}
+				}
 
-                if (auto error = meshoptCompression["filter"].get_string().get(string); error == SUCCESS) [[likely]] {
-                    switch (crcStringFunction(string)) {
-                        case force_consteval<crc32c("NONE")>: {
-                            compression->filter = MeshoptCompressionFilter::None;
-                            break;
-                        }
-                        case force_consteval<crc32c("OCTAHEDRAL")>: {
-                            compression->filter = MeshoptCompressionFilter::Octahedral;
-                            break;
-                        }
-                        case force_consteval<crc32c("QUATERNION")>: {
-                            compression->filter = MeshoptCompressionFilter::Quaternion;
-                            break;
-                        }
-                        case force_consteval<crc32c("EXPONENTIAL")>: {
-                            compression->filter = MeshoptCompressionFilter::Exponential;
-                            break;
-                        }
-                        default: {
-                            return Error::InvalidGltf;
-                        }
-                    }
-                } else if (error == NO_SUCH_FIELD) {
-                    compression->filter = MeshoptCompressionFilter::None;
-                } else {
-                    return Error::InvalidJson;
-                }
+				if (auto error = meshoptCompression["filter"].get_string().get(string);
+					error == SUCCESS) [[likely]] {
+					switch (crcStringFunction(string)) {
+						case force_consteval<crc32c("NONE")>: {
+							compression->filter = MeshoptCompressionFilter::None;
+							break;
+						}
+						case force_consteval<crc32c("OCTAHEDRAL")>: {
+							compression->filter = MeshoptCompressionFilter::Octahedral;
+							break;
+						}
+						case force_consteval<crc32c("QUATERNION")>: {
+							compression->filter = MeshoptCompressionFilter::Quaternion;
+							break;
+						}
+						case force_consteval<crc32c("EXPONENTIAL")>: {
+							compression->filter = MeshoptCompressionFilter::Exponential;
+							break;
+						}
+						default: {
+							return Error::InvalidGltf;
+						}
+					}
+				} else if (error == NO_SUCH_FIELD) {
+					compression->filter = MeshoptCompressionFilter::None;
+				} else {
+					return Error::InvalidJson;
+				}
 
-                view.meshoptCompression = std::move(compression);
-            }
-        }
+				view.meshoptCompression = std::move(compression);
+			}
+		}
 
 		if (config.extrasCallback != nullptr) {
 			dom::object extrasObject;
-			if (auto extrasError = bufferViewObject["extras"].get_object().get(extrasObject); extrasError == SUCCESS) {
-				config.extrasCallback(&extrasObject, asset.bufferViews.size(), Category::BufferViews, config.userPointer);
+			if (auto extrasError = bufferViewObject["extras"].get_object().get(extrasObject);
+				extrasError == SUCCESS) {
+				config.extrasCallback(&extrasObject, asset.bufferViews.size(),
+									  Category::BufferViews, config.userPointer);
 			} else if (extrasError != NO_SUCH_FIELD) {
 				return Error::InvalidGltf;
 			}
 		}
 
 		asset.bufferViews.emplace_back(std::move(view));
-    }
+	}
 
 	return Error::None;
 }
 
 fg::Error fg::Parser::parseCameras(simdjson::dom::array& cameras, Asset& asset) {
-    using namespace simdjson;
+	using namespace simdjson;
 
 	asset.cameras.reserve(cameras.size());
-    for (auto cameraValue : cameras) {
-        Camera camera = {};
-        dom::object cameraObject;
-        if (cameraValue.get_object().get(cameraObject) != SUCCESS) [[unlikely]] {
-            return Error::InvalidGltf;
-        }
+	for (auto cameraValue : cameras) {
+		Camera camera = {};
+		dom::object cameraObject;
+		if (cameraValue.get_object().get(cameraObject) != SUCCESS) [[unlikely]] {
+			return Error::InvalidGltf;
+		}
 
-        std::string_view name;
-        if (cameraObject["name"].get_string().get(name) == SUCCESS) {
-	        camera.name = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(camera.name), resourceAllocator.get(), name);
-        }
+		std::string_view name;
+		if (cameraObject["name"].get_string().get(name) == SUCCESS) {
+			camera.name = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(camera.name),
+														  resourceAllocator.get(), name);
+		}
 
-        std::string_view type;
-        if (cameraObject["type"].get_string().get(type) != SUCCESS) [[unlikely]] {
-            return Error::InvalidGltf;
-        }
+		std::string_view type;
+		if (cameraObject["type"].get_string().get(type) != SUCCESS) [[unlikely]] {
+			return Error::InvalidGltf;
+		}
 
-        if (type == "perspective") {
-            dom::object perspectiveCamera;
-            if (cameraObject["perspective"].get_object().get(perspectiveCamera) != SUCCESS) [[unlikely]] {
-                return Error::InvalidGltf;
-            }
-
-            Camera::Perspective perspective = {};
-            double value;
-            if (auto error = perspectiveCamera["aspectRatio"].get_double().get(value); error == SUCCESS) [[likely]] {
-                perspective.aspectRatio = static_cast<num>(value);
-            } else if (error != NO_SUCH_FIELD) {
+		if (type == "perspective") {
+			dom::object perspectiveCamera;
+			if (cameraObject["perspective"].get_object().get(perspectiveCamera) != SUCCESS)
+				[[unlikely]] {
 				return Error::InvalidGltf;
 			}
 
-            if (auto error = perspectiveCamera["zfar"].get_double().get(value); error == SUCCESS) [[likely]] {
-                perspective.zfar = static_cast<num>(value);
-            } else if (error != NO_SUCH_FIELD) {
+			Camera::Perspective perspective = {};
+			double value;
+			if (auto error = perspectiveCamera["aspectRatio"].get_double().get(value);
+				error == SUCCESS) [[likely]] {
+				perspective.aspectRatio = static_cast<num>(value);
+			} else if (error != NO_SUCH_FIELD) {
 				return Error::InvalidGltf;
 			}
 
-            if (perspectiveCamera["yfov"].get_double().get(value) == SUCCESS) [[likely]] {
-                perspective.yfov = static_cast<num>(value);
-            } else {
-                return Error::InvalidGltf;
-            }
+			if (auto error = perspectiveCamera["zfar"].get_double().get(value); error == SUCCESS)
+				[[likely]] {
+				perspective.zfar = static_cast<num>(value);
+			} else if (error != NO_SUCH_FIELD) {
+				return Error::InvalidGltf;
+			}
 
-            if (perspectiveCamera["znear"].get_double().get(value) == SUCCESS) [[likely]] {
-                perspective.znear = static_cast<num>(value);
-            } else {
-                return Error::InvalidGltf;
-            }
+			if (perspectiveCamera["yfov"].get_double().get(value) == SUCCESS) [[likely]] {
+				perspective.yfov = static_cast<num>(value);
+			} else {
+				return Error::InvalidGltf;
+			}
 
-            camera.camera = perspective;
-        } else if (type == "orthographic") {
-            dom::object orthographicCamera;
-            if (cameraObject["orthographic"].get_object().get(orthographicCamera) != SUCCESS) [[unlikely]] {
-                return Error::InvalidGltf;
-            }
+			if (perspectiveCamera["znear"].get_double().get(value) == SUCCESS) [[likely]] {
+				perspective.znear = static_cast<num>(value);
+			} else {
+				return Error::InvalidGltf;
+			}
 
-            Camera::Orthographic orthographic = {};
-            double value;
-            if (orthographicCamera["xmag"].get_double().get(value) == SUCCESS) [[likely]] {
-                orthographic.xmag = static_cast<num>(value);
-            } else {
-                return Error::InvalidGltf;
-            }
+			camera.camera = perspective;
+		} else if (type == "orthographic") {
+			dom::object orthographicCamera;
+			if (cameraObject["orthographic"].get_object().get(orthographicCamera) != SUCCESS)
+				[[unlikely]] {
+				return Error::InvalidGltf;
+			}
 
-            if (orthographicCamera["ymag"].get_double().get(value) == SUCCESS) [[likely]] {
-                orthographic.ymag = static_cast<num>(value);
-            } else {
-                return Error::InvalidGltf;
-            }
+			Camera::Orthographic orthographic = {};
+			double value;
+			if (orthographicCamera["xmag"].get_double().get(value) == SUCCESS) [[likely]] {
+				orthographic.xmag = static_cast<num>(value);
+			} else {
+				return Error::InvalidGltf;
+			}
 
-            if (orthographicCamera["zfar"].get_double().get(value) == SUCCESS) [[likely]] {
-                orthographic.zfar = static_cast<num>(value);
-            } else {
-                return Error::InvalidGltf;
-            }
+			if (orthographicCamera["ymag"].get_double().get(value) == SUCCESS) [[likely]] {
+				orthographic.ymag = static_cast<num>(value);
+			} else {
+				return Error::InvalidGltf;
+			}
 
-            if (orthographicCamera["znear"].get_double().get(value) == SUCCESS) [[likely]] {
-                orthographic.znear = static_cast<num>(value);
-            } else {
-                return Error::InvalidGltf;
-            }
+			if (orthographicCamera["zfar"].get_double().get(value) == SUCCESS) [[likely]] {
+				orthographic.zfar = static_cast<num>(value);
+			} else {
+				return Error::InvalidGltf;
+			}
 
-            camera.camera = orthographic;
-        } else {
-            return Error::InvalidGltf;
-        }
+			if (orthographicCamera["znear"].get_double().get(value) == SUCCESS) [[likely]] {
+				orthographic.znear = static_cast<num>(value);
+			} else {
+				return Error::InvalidGltf;
+			}
+
+			camera.camera = orthographic;
+		} else {
+			return Error::InvalidGltf;
+		}
 
 		if (config.extrasCallback != nullptr) {
 			dom::object extrasObject;
-			if (auto extrasError = cameraObject["extras"].get_object().get(extrasObject); extrasError == SUCCESS) {
-				config.extrasCallback(&extrasObject, asset.cameras.size(), Category::Cameras, config.userPointer);
+			if (auto extrasError = cameraObject["extras"].get_object().get(extrasObject);
+				extrasError == SUCCESS) {
+				config.extrasCallback(&extrasObject, asset.cameras.size(), Category::Cameras,
+									  config.userPointer);
 			} else if (extrasError != NO_SUCH_FIELD) {
 				return Error::InvalidGltf;
 			}
 		}
 
 		asset.cameras.emplace_back(std::move(camera));
-    }
+	}
 
 	return Error::None;
 }
 
 fg::Error fg::Parser::parseExtensions(const simdjson::dom::object& extensionsObject, Asset& asset) {
-    using namespace simdjson;
+	using namespace simdjson;
 
-    for (auto extensionValue : extensionsObject) {
-        dom::object extensionObject;
-        if (auto error = extensionValue.value.get_object().get(extensionObject); error != SUCCESS) [[unlikely]] {
-            if (error == INCORRECT_TYPE) {
-                continue; // We want to ignore
-            }
-            return Error::InvalidGltf;
-        }
+	for (auto extensionValue : extensionsObject) {
+		dom::object extensionObject;
+		if (auto error = extensionValue.value.get_object().get(extensionObject); error != SUCCESS)
+			[[unlikely]] {
+			if (error == INCORRECT_TYPE) {
+				continue;  // We want to ignore
+			}
+			return Error::InvalidGltf;
+		}
 
-        switch (crcStringFunction(extensionValue.key)) {
-            case force_consteval<crc32c(extensions::KHR_lights_punctual)>: {
-                if (!hasBit(config.extensions, Extensions::KHR_lights_punctual))
-                    break;
+		switch (crcStringFunction(extensionValue.key)) {
+			case force_consteval<crc32c(extensions::KHR_lights_punctual)>: {
+				if (!hasBit(config.extensions, Extensions::KHR_lights_punctual)) break;
 
-                dom::array lightsArray;
-                if (auto error = extensionObject["lights"].get_array().get(lightsArray); error == SUCCESS) [[likely]] {
-                    if (auto lightsError = parseLights(lightsArray, asset); lightsError != Error::None)
+				dom::array lightsArray;
+				if (auto error = extensionObject["lights"].get_array().get(lightsArray);
+					error == SUCCESS) [[likely]] {
+					if (auto lightsError = parseLights(lightsArray, asset);
+						lightsError != Error::None)
 						return lightsError;
-                } else if (error != NO_SUCH_FIELD) {
-                    return Error::InvalidGltf;
-                }
-                break;
-            }
+				} else if (error != NO_SUCH_FIELD) {
+					return Error::InvalidGltf;
+				}
+				break;
+			}
 			case force_consteval<crc32c(extensions::KHR_materials_variants)>: {
-				if (!hasBit(config.extensions, Extensions::KHR_materials_variants))
-					break;
+				if (!hasBit(config.extensions, Extensions::KHR_materials_variants)) break;
 
 				dom::array variantsArray;
-				if (auto arrayError = extensionObject["variants"].get_array().get(variantsArray); arrayError == SUCCESS) [[likely]] {
+				if (auto arrayError = extensionObject["variants"].get_array().get(variantsArray);
+					arrayError == SUCCESS) [[likely]] {
 					asset.materialVariants.reserve(variantsArray.size());
 					for (auto variant : variantsArray) {
 						dom::object variantObject;
-						if (auto error = variant.get_object().get(variantObject); error == SUCCESS) {
+						if (auto error = variant.get_object().get(variantObject);
+							error == SUCCESS) {
 							std::string_view name;
 							if (variantObject["name"].get_string().get(name) != SUCCESS) {
 								return Error::InvalidGltf;
@@ -2372,15 +2435,17 @@ fg::Error fg::Parser::parseExtensions(const simdjson::dom::object& extensionsObj
 				}
 
 				dom::array shapesArray;
-				if (auto arrayError = extensionObject["shapes"].get_array().get(shapesArray); arrayError == SUCCESS) [[likely]] {
-					if (auto shapesError = parseShapes(shapesArray, asset); shapesError != Error::None) [[unlikely]] {
+				if (auto arrayError = extensionObject["shapes"].get_array().get(shapesArray);
+					arrayError == SUCCESS) [[likely]] {
+					if (auto shapesError = parseShapes(shapesArray, asset);
+						shapesError != Error::None) [[unlikely]] {
 						return shapesError;
 					}
 				} else {
 					return Error::InvalidGltf;
 				}
 				break;
-            }
+			}
 #endif
 #if FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES
 			case force_consteval<crc32c(extensions::KHR_physics_rigid_bodies)>: {
@@ -2389,8 +2454,11 @@ fg::Error fg::Parser::parseExtensions(const simdjson::dom::object& extensionsObj
 				}
 
 				dom::array materialsArray;
-				if (auto arrayError = extensionObject["physicsMaterials"].get_array().get(materialsArray); arrayError == SUCCESS) {
-					if (auto materialsError = parsePhysicsMaterials(materialsArray, asset); materialsError != Error::None) [[unlikely]] {
+				if (auto arrayError =
+						extensionObject["physicsMaterials"].get_array().get(materialsArray);
+					arrayError == SUCCESS) {
+					if (auto materialsError = parsePhysicsMaterials(materialsArray, asset);
+						materialsError != Error::None) [[unlikely]] {
 						return materialsError;
 					}
 				} else if (arrayError != NO_SUCH_FIELD) [[unlikely]] {
@@ -2398,8 +2466,11 @@ fg::Error fg::Parser::parseExtensions(const simdjson::dom::object& extensionsObj
 				}
 
 				dom::array filtersArray;
-				if (auto arrayError = extensionObject["collisionFilters"].get_array().get(filtersArray); arrayError == SUCCESS) {
-					if (auto filtersError = parseCollisionFilters(filtersArray, asset); filtersError != Error::None) [[unlikely]] {
+				if (auto arrayError =
+						extensionObject["collisionFilters"].get_array().get(filtersArray);
+					arrayError == SUCCESS) {
+					if (auto filtersError = parseCollisionFilters(filtersArray, asset);
+						filtersError != Error::None) [[unlikely]] {
 						return filtersError;
 					}
 				} else if (arrayError != NO_SUCH_FIELD) [[unlikely]] {
@@ -2407,8 +2478,10 @@ fg::Error fg::Parser::parseExtensions(const simdjson::dom::object& extensionsObj
 				}
 
 				dom::array jointsArray;
-				if (auto arrayError = extensionObject["physicsJoints"].get_array().get(jointsArray); arrayError == SUCCESS) {
-					if (auto jointsError = parsePhysicsJoints(jointsArray, asset); jointsError != Error::None) [[unlikely]] {
+				if (auto arrayError = extensionObject["physicsJoints"].get_array().get(jointsArray);
+					arrayError == SUCCESS) {
+					if (auto jointsError = parsePhysicsJoints(jointsArray, asset);
+						jointsError != Error::None) [[unlikely]] {
 						return jointsError;
 					}
 				} else if (arrayError != NO_SUCH_FIELD) [[unlikely]] {
@@ -2418,217 +2491,223 @@ fg::Error fg::Parser::parseExtensions(const simdjson::dom::object& extensionsObj
 				break;
 			}
 #endif
-            default:
-                continue;
-        }
-    }
+			default: continue;
+		}
+	}
 
 	return Error::None;
 }
 
 fg::Error fg::Parser::parseImages(simdjson::dom::array& images, Asset& asset) {
-    using namespace simdjson;
+	using namespace simdjson;
 
 	asset.images.reserve(images.size());
-    for (auto imageValue : images) {
-        Image image = {};
-        dom::object imageObject;
-        if (imageValue.get_object().get(imageObject) != SUCCESS) [[unlikely]] {
-            return Error::InvalidGltf;
-        }
+	for (auto imageValue : images) {
+		Image image = {};
+		dom::object imageObject;
+		if (imageValue.get_object().get(imageObject) != SUCCESS) [[unlikely]] {
+			return Error::InvalidGltf;
+		}
 
-        std::string_view uriString;
-        if (imageObject["uri"].get_string().get(uriString) == SUCCESS) [[likely]] {
-            if (imageObject["bufferView"].error() == SUCCESS) [[likely]] {
-                // If uri is declared, bufferView cannot be declared.
-                return Error::InvalidGltf;
-            }
+		std::string_view uriString;
+		if (imageObject["uri"].get_string().get(uriString) == SUCCESS) [[likely]] {
+			if (imageObject["bufferView"].error() == SUCCESS) [[likely]] {
+				// If uri is declared, bufferView cannot be declared.
+				return Error::InvalidGltf;
+			}
 
-            URIView uriView(uriString);
-            if (!uriView.valid()) {
-                return Error::InvalidURI;
-            }
+			URIView uriView(uriString);
+			if (!uriView.valid()) {
+				return Error::InvalidURI;
+			}
 
-            if (uriView.isDataUri()) {
-                auto [error, source] = decodeDataUri(uriView);
-                if (error != Error::None) {
-                    return error;
-                }
+			if (uriView.isDataUri()) {
+				auto [error, source] = decodeDataUri(uriView);
+				if (error != Error::None) {
+					return error;
+				}
 
-                image.data = std::move(source);
-            } else if (uriView.isLocalPath() && hasBit(options, Options::LoadExternalImages)) {
-	            auto [error, source] = loadFileFromUri(uriView);
-                if (error != Error::None) {
-                    return error;
-                }
+				image.data = std::move(source);
+			} else if (uriView.isLocalPath() && hasBit(options, Options::LoadExternalImages)) {
+				auto [error, source] = loadFileFromUri(uriView);
+				if (error != Error::None) {
+					return error;
+				}
 
-                image.data = std::move(source);
-            } else {
-                sources::URI filePath;
-                filePath.fileByteOffset = 0;
-                filePath.uri = uriView;
-                image.data = std::move(filePath);
-            }
+				image.data = std::move(source);
+			} else {
+				sources::URI filePath;
+				filePath.fileByteOffset = 0;
+				filePath.uri = uriView;
+				image.data = std::move(filePath);
+			}
 
-            std::string_view mimeType;
-            if (imageObject["mimeType"].get_string().get(mimeType) == SUCCESS) [[likely]] {
-                std::visit([&]<typename T>(T& arg) {
-                    // This is kinda cursed
-                    if constexpr (is_any_of_v<T, sources::CustomBuffer, sources::BufferView, sources::URI, sources::Array, sources::Vector>) {
-                        arg.mimeType = getMimeTypeFromString(mimeType);
-                    }
-                }, image.data);
-            }
-        }
+			std::string_view mimeType;
+			if (imageObject["mimeType"].get_string().get(mimeType) == SUCCESS) [[likely]] {
+				std::visit([&]<typename T>(T& arg) {
+					// This is kinda cursed
+					if constexpr (is_any_of_v<T, sources::CustomBuffer, sources::BufferView,
+											  sources::URI, sources::Array, sources::Vector>) {
+						arg.mimeType = getMimeTypeFromString(mimeType);
+					}
+				}, image.data);
+			}
+		}
 
-        std::uint64_t bufferViewIndex;
-        if (imageObject["bufferView"].get_uint64().get(bufferViewIndex) == SUCCESS) [[likely]] {
-            std::string_view mimeType;
-            if (imageObject["mimeType"].get_string().get(mimeType) != SUCCESS) [[unlikely]] {
-                // If bufferView is defined, mimeType needs to also be defined.
-                return Error::InvalidGltf;
-            }
+		std::uint64_t bufferViewIndex;
+		if (imageObject["bufferView"].get_uint64().get(bufferViewIndex) == SUCCESS) [[likely]] {
+			std::string_view mimeType;
+			if (imageObject["mimeType"].get_string().get(mimeType) != SUCCESS) [[unlikely]] {
+				// If bufferView is defined, mimeType needs to also be defined.
+				return Error::InvalidGltf;
+			}
 
-            image.data = sources::BufferView {
-                static_cast<std::size_t>(bufferViewIndex),
-                getMimeTypeFromString(mimeType),
-            };
-        }
+			image.data = sources::BufferView{
+				static_cast<std::size_t>(bufferViewIndex),
+				getMimeTypeFromString(mimeType),
+			};
+		}
 
-        if (std::holds_alternative<std::monostate>(image.data)) {
-            return Error::InvalidGltf;
-        }
+		if (std::holds_alternative<std::monostate>(image.data)) {
+			return Error::InvalidGltf;
+		}
 
 		if (config.extrasCallback != nullptr) {
 			dom::object extrasObject;
-			if (auto extrasError = imageObject["extras"].get_object().get(extrasObject); extrasError == SUCCESS) {
-				config.extrasCallback(&extrasObject, asset.images.size(), Category::Images, config.userPointer);
+			if (auto extrasError = imageObject["extras"].get_object().get(extrasObject);
+				extrasError == SUCCESS) {
+				config.extrasCallback(&extrasObject, asset.images.size(), Category::Images,
+									  config.userPointer);
 			} else if (extrasError != NO_SUCH_FIELD) {
 				return Error::InvalidGltf;
 			}
 		}
 
 		// name is optional.
-        std::string_view name;
-        if (imageObject["name"].get_string().get(name) == SUCCESS) {
-	        image.name = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(image.name), resourceAllocator.get(), name);
-        }
+		std::string_view name;
+		if (imageObject["name"].get_string().get(name) == SUCCESS) {
+			image.name = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(image.name),
+														 resourceAllocator.get(), name);
+		}
 
-        asset.images.emplace_back(std::move(image));
-    }
+		asset.images.emplace_back(std::move(image));
+	}
 
 	return Error::None;
 }
 
 fg::Error fg::Parser::parseLights(const simdjson::dom::array& lights, Asset& asset) {
-    using namespace simdjson;
+	using namespace simdjson;
 
-    asset.lights.reserve(lights.size());
-    for (auto lightValue : lights) {
-        dom::object lightObject;
-        if (lightValue.get_object().get(lightObject) != SUCCESS) [[unlikely]] {
-            return Error::InvalidGltf;
-        }
-        Light light = {};
+	asset.lights.reserve(lights.size());
+	for (auto lightValue : lights) {
+		dom::object lightObject;
+		if (lightValue.get_object().get(lightObject) != SUCCESS) [[unlikely]] {
+			return Error::InvalidGltf;
+		}
+		Light light = {};
 
-        std::string_view type;
-        if (lightObject["type"].get_string().get(type) == SUCCESS) [[likely]] {
-            switch (crcStringFunction(type.data())) {
-                case force_consteval<crc32c("directional")>: {
-                    light.type = LightType::Directional;
-                    break;
-                }
-                case force_consteval<crc32c("spot")>: {
-                    light.type = LightType::Spot;
-                    break;
-                }
-                case force_consteval<crc32c("point")>: {
-                    light.type = LightType::Point;
-                    break;
-                }
-                default: {
-                    return Error::InvalidGltf;
-                }
-            }
-        } else {
-            return Error::InvalidGltf;
-        }
+		std::string_view type;
+		if (lightObject["type"].get_string().get(type) == SUCCESS) [[likely]] {
+			switch (crcStringFunction(type.data())) {
+				case force_consteval<crc32c("directional")>: {
+					light.type = LightType::Directional;
+					break;
+				}
+				case force_consteval<crc32c("spot")>: {
+					light.type = LightType::Spot;
+					break;
+				}
+				case force_consteval<crc32c("point")>: {
+					light.type = LightType::Point;
+					break;
+				}
+				default: {
+					return Error::InvalidGltf;
+				}
+			}
+		} else {
+			return Error::InvalidGltf;
+		}
 
-        if (light.type == LightType::Spot) {
-            dom::object spotObject;
-            if (lightObject["spot"].get_object().get(spotObject) != SUCCESS) [[unlikely]] {
-                return Error::InvalidGltf;
-            }
+		if (light.type == LightType::Spot) {
+			dom::object spotObject;
+			if (lightObject["spot"].get_object().get(spotObject) != SUCCESS) [[unlikely]] {
+				return Error::InvalidGltf;
+			}
 
-            double innerConeAngle;
-            if (auto error = spotObject["innerConeAngle"].get_double().get(innerConeAngle); error == SUCCESS) [[likely]] {
-                light.innerConeAngle = static_cast<num>(innerConeAngle);
-            } else if (error == NO_SUCH_FIELD) {
-                light.innerConeAngle = 0.0f;
-            } else {
-                return Error::InvalidGltf;
-            }
+			double innerConeAngle;
+			if (auto error = spotObject["innerConeAngle"].get_double().get(innerConeAngle);
+				error == SUCCESS) [[likely]] {
+				light.innerConeAngle = static_cast<num>(innerConeAngle);
+			} else if (error == NO_SUCH_FIELD) {
+				light.innerConeAngle = 0.0f;
+			} else {
+				return Error::InvalidGltf;
+			}
 
-            double outerConeAngle;
-            if (auto error = spotObject["outerConeAngle"].get_double().get(outerConeAngle); error == SUCCESS) [[likely]] {
-                light.outerConeAngle = static_cast<num>(outerConeAngle);
-            } else if (error == NO_SUCH_FIELD) {
-                light.outerConeAngle = static_cast<num>(math::pi / 4.0);
-            } else {
-                return Error::InvalidGltf;
-            }
-        }
+			double outerConeAngle;
+			if (auto error = spotObject["outerConeAngle"].get_double().get(outerConeAngle);
+				error == SUCCESS) [[likely]] {
+				light.outerConeAngle = static_cast<num>(outerConeAngle);
+			} else if (error == NO_SUCH_FIELD) {
+				light.outerConeAngle = static_cast<num>(math::pi / 4.0);
+			} else {
+				return Error::InvalidGltf;
+			}
+		}
 
-        dom::array colorArray;
-        if (auto error = lightObject["color"].get_array().get(colorArray); error == SUCCESS) [[likely]] {
-            if (colorArray.size() != 3U) {
-                return Error::InvalidGltf;
-            }
-            for (std::size_t i = 0U; i < colorArray.size(); ++i) {
-                double color;
-                if (colorArray.at(i).get_double().get(color) == SUCCESS) [[likely]] {
-                    light.color[i] = static_cast<num>(color);
-                } else {
-                    return Error::InvalidGltf;
-                }
-            }
-        } else if (error == NO_SUCH_FIELD) {
+		dom::array colorArray;
+		if (auto error = lightObject["color"].get_array().get(colorArray); error == SUCCESS)
+			[[likely]] {
+			if (colorArray.size() != 3U) {
+				return Error::InvalidGltf;
+			}
+			for (std::size_t i = 0U; i < colorArray.size(); ++i) {
+				double color;
+				if (colorArray.at(i).get_double().get(color) == SUCCESS) [[likely]] {
+					light.color[i] = static_cast<num>(color);
+				} else {
+					return Error::InvalidGltf;
+				}
+			}
+		} else if (error == NO_SUCH_FIELD) {
 			light.color = math::nvec3(1);
-        } else {
-            return Error::InvalidGltf;
-        }
+		} else {
+			return Error::InvalidGltf;
+		}
 
-        double intensity;
-        if (lightObject["intensity"].get_double().get(intensity) == SUCCESS) [[likely]] {
-            light.intensity = static_cast<num>(intensity);
-        } else {
-            light.intensity = 1.0f;
-        }
+		double intensity;
+		if (lightObject["intensity"].get_double().get(intensity) == SUCCESS) [[likely]] {
+			light.intensity = static_cast<num>(intensity);
+		} else {
+			light.intensity = 1.0f;
+		}
 
-        double range;
-        if (lightObject["range"].get_double().get(range) == SUCCESS) [[likely]] {
-            light.range = static_cast<num>(range);
-        }
+		double range;
+		if (lightObject["range"].get_double().get(range) == SUCCESS) [[likely]] {
+			light.range = static_cast<num>(range);
+		}
 
 		std::string_view name;
-        if (lightObject["name"].get_string().get(name) == SUCCESS) {
-	        light.name = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(light.name), resourceAllocator.get(), name);
-        }
+		if (lightObject["name"].get_string().get(name) == SUCCESS) {
+			light.name = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(light.name),
+														 resourceAllocator.get(), name);
+		}
 
-        asset.lights.emplace_back(std::move(light));
-    }
+		asset.lights.emplace_back(std::move(light));
+	}
 
 	return Error::None;
 }
 
-fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Material &material) {
+fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object& object, Material& material) {
 	using namespace simdjson;
 
 	for (auto extensionField : object) {
 		switch (crcStringFunction(extensionField.key)) {
 			case force_consteval<crc32c(extensions::KHR_materials_anisotropy)>: {
-				if (!hasBit(config.extensions, Extensions::KHR_materials_anisotropy))
-					break;
+				if (!hasBit(config.extensions, Extensions::KHR_materials_anisotropy)) break;
 
 				dom::object anisotropyObject;
 				auto anisotropyError = extensionField.value.get_object().get(anisotropyObject);
@@ -2639,24 +2718,27 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 				auto anisotropy = std::make_unique<MaterialAnisotropy>();
 
 				double anisotropyStrength;
-				if (auto error = anisotropyObject["anisotropyStrength"].get_double().get(anisotropyStrength);
-						error == SUCCESS) [[likely]] {
+				if (auto error =
+						anisotropyObject["anisotropyStrength"].get_double().get(anisotropyStrength);
+					error == SUCCESS) [[likely]] {
 					anisotropy->anisotropyStrength = static_cast<num>(anisotropyStrength);
 				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidJson;
 				}
 
 				double anisotropyRotation;
-				if (auto error = anisotropyObject["anisotropyRotation"].get_double().get(anisotropyRotation);
-						error == SUCCESS) [[likely]] {
+				if (auto error =
+						anisotropyObject["anisotropyRotation"].get_double().get(anisotropyRotation);
+					error == SUCCESS) [[likely]] {
 					anisotropy->anisotropyRotation = static_cast<num>(anisotropyRotation);
 				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidJson;
 				}
 
 				TextureInfo anisotropyTexture;
-				if (auto error = parseTextureInfo(anisotropyObject, "anisotropyTexture", &anisotropyTexture,
-												  config.extensions); error == Error::None) [[likely]] {
+				if (auto error = parseTextureInfo(anisotropyObject, "anisotropyTexture",
+												  &anisotropyTexture, config.extensions);
+					error == Error::None) [[likely]] {
 					anisotropy->anisotropyTexture = std::move(anisotropyTexture);
 				} else if (error != Error::MissingField) {
 					return error;
@@ -2666,8 +2748,7 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 				break;
 			}
 			case force_consteval<crc32c(extensions::KHR_materials_clearcoat)>: {
-				if (!hasBit(config.extensions, Extensions::KHR_materials_clearcoat))
-					break;
+				if (!hasBit(config.extensions, Extensions::KHR_materials_clearcoat)) break;
 
 				dom::object clearcoatObject;
 				auto clearcoatError = extensionField.value.get_object().get(clearcoatObject);
@@ -2678,16 +2759,18 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 				auto clearcoat = std::make_unique<MaterialClearcoat>();
 
 				double clearcoatFactor;
-				if (auto error = clearcoatObject["clearcoatFactor"].get_double().get(clearcoatFactor); error ==
-																									   SUCCESS) {
+				if (auto error =
+						clearcoatObject["clearcoatFactor"].get_double().get(clearcoatFactor);
+					error == SUCCESS) {
 					clearcoat->clearcoatFactor = static_cast<num>(clearcoatFactor);
 				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidJson;
 				}
 
 				TextureInfo clearcoatTexture;
-				if (auto error = parseTextureInfo(clearcoatObject, "clearcoatTexture", &clearcoatTexture,
-												  config.extensions); error == Error::None) [[likely]] {
+				if (auto error = parseTextureInfo(clearcoatObject, "clearcoatTexture",
+												  &clearcoatTexture, config.extensions);
+					error == Error::None) [[likely]] {
 					clearcoat->clearcoatTexture = std::move(clearcoatTexture);
 				} else if (error != Error::MissingField) {
 					return error;
@@ -2695,16 +2778,18 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 
 				double clearcoatRoughnessFactor;
 				if (auto error = clearcoatObject["clearcoatRoughnessFactor"].get_double().get(
-							clearcoatRoughnessFactor); error == SUCCESS) [[likely]] {
-					clearcoat->clearcoatRoughnessFactor = static_cast<num>(clearcoatRoughnessFactor);
+						clearcoatRoughnessFactor);
+					error == SUCCESS) [[likely]] {
+					clearcoat->clearcoatRoughnessFactor =
+						static_cast<num>(clearcoatRoughnessFactor);
 				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidJson;
 				}
 
 				TextureInfo clearcoatRoughnessTexture;
 				if (auto error = parseTextureInfo(clearcoatObject, "clearcoatRoughnessTexture",
-												  &clearcoatRoughnessTexture, config.extensions); error ==
-																								  Error::None) {
+												  &clearcoatRoughnessTexture, config.extensions);
+					error == Error::None) {
 					clearcoat->clearcoatRoughnessTexture = std::move(clearcoatRoughnessTexture);
 				} else if (error != Error::MissingField) {
 					return error;
@@ -2712,8 +2797,9 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 
 				NormalTextureInfo clearcoatNormalTexture;
 				if (auto error = parseTextureInfo(clearcoatObject, "clearcoatNormalTexture",
-												  &clearcoatNormalTexture, config.extensions, TextureInfoType::NormalTexture); error ==
-																							   Error::None) {
+												  &clearcoatNormalTexture, config.extensions,
+												  TextureInfoType::NormalTexture);
+					error == Error::None) {
 					clearcoat->clearcoatNormalTexture = std::move(clearcoatNormalTexture);
 				} else if (error != Error::MissingField) {
 					return error;
@@ -2723,8 +2809,7 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 				break;
 			}
 			case force_consteval<crc32c(extensions::KHR_materials_dispersion)>: {
-				if (!hasBit(config.extensions, Extensions::KHR_materials_dispersion))
-					break;
+				if (!hasBit(config.extensions, Extensions::KHR_materials_dispersion)) break;
 
 				dom::object dispersionObject;
 				auto dispersionError = extensionField.value.get_object().get(dispersionObject);
@@ -2742,8 +2827,7 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 				break;
 			}
 			case force_consteval<crc32c(extensions::KHR_materials_emissive_strength)>: {
-				if (!hasBit(config.extensions, Extensions::KHR_materials_emissive_strength))
-					break;
+				if (!hasBit(config.extensions, Extensions::KHR_materials_emissive_strength)) break;
 
 				dom::object emissiveObject;
 				auto emissiveError = extensionField.value.get_object().get(emissiveObject);
@@ -2761,8 +2845,7 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 				break;
 			}
 			case force_consteval<crc32c(extensions::KHR_materials_ior)>: {
-				if (!hasBit(config.extensions, Extensions::KHR_materials_ior))
-					break;
+				if (!hasBit(config.extensions, Extensions::KHR_materials_ior)) break;
 
 				dom::object iorObject;
 				auto iorError = extensionField.value.get_object().get(iorObject);
@@ -2780,8 +2863,7 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 				break;
 			}
 			case force_consteval<crc32c(extensions::KHR_materials_iridescence)>: {
-				if (!hasBit(config.extensions, Extensions::KHR_materials_iridescence))
-					break;
+				if (!hasBit(config.extensions, Extensions::KHR_materials_iridescence)) break;
 
 				dom::object iridescenceObject;
 				auto iridescenceError = extensionField.value.get_object().get(iridescenceObject);
@@ -2792,24 +2874,27 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 				auto iridescence = std::make_unique<MaterialIridescence>();
 
 				double iridescenceFactor;
-				if (auto error = iridescenceObject["iridescenceFactor"].get_double().get(iridescenceFactor);
-						error == SUCCESS) [[likely]] {
+				if (auto error =
+						iridescenceObject["iridescenceFactor"].get_double().get(iridescenceFactor);
+					error == SUCCESS) [[likely]] {
 					iridescence->iridescenceFactor = static_cast<num>(iridescenceFactor);
 				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
 				TextureInfo iridescenceTexture;
-				if (auto error = parseTextureInfo(iridescenceObject, "iridescenceTexture", &iridescenceTexture,
-												  config.extensions); error == Error::None) [[likely]] {
+				if (auto error = parseTextureInfo(iridescenceObject, "iridescenceTexture",
+												  &iridescenceTexture, config.extensions);
+					error == Error::None) [[likely]] {
 					iridescence->iridescenceTexture = std::move(iridescenceTexture);
 				} else if (error != Error::MissingField) {
 					return error;
 				}
 
 				double iridescenceIor;
-				if (auto error = iridescenceObject["iridescenceIor"].get_double().get(iridescenceIor); error ==
-																									   SUCCESS) {
+				if (auto error =
+						iridescenceObject["iridescenceIor"].get_double().get(iridescenceIor);
+					error == SUCCESS) {
 					iridescence->iridescenceIor = static_cast<num>(iridescenceIor);
 				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
@@ -2817,25 +2902,30 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 
 				double iridescenceThicknessMinimum;
 				if (auto error = iridescenceObject["iridescenceThicknessMinimum"].get_double().get(
-							iridescenceThicknessMinimum); error == SUCCESS) [[likely]] {
-					iridescence->iridescenceThicknessMinimum = static_cast<num>(iridescenceThicknessMinimum);
+						iridescenceThicknessMinimum);
+					error == SUCCESS) [[likely]] {
+					iridescence->iridescenceThicknessMinimum =
+						static_cast<num>(iridescenceThicknessMinimum);
 				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
 				double iridescenceThicknessMaximum;
 				if (auto error = iridescenceObject["iridescenceThicknessMaximum"].get_double().get(
-							iridescenceThicknessMaximum); error == SUCCESS) [[likely]] {
-					iridescence->iridescenceThicknessMaximum = static_cast<num>(iridescenceThicknessMaximum);
+						iridescenceThicknessMaximum);
+					error == SUCCESS) [[likely]] {
+					iridescence->iridescenceThicknessMaximum =
+						static_cast<num>(iridescenceThicknessMaximum);
 				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
 				TextureInfo iridescenceThicknessTexture;
 				if (auto error = parseTextureInfo(iridescenceObject, "iridescenceThicknessTexture",
-												  &iridescenceThicknessTexture, config.extensions); error ==
-																									Error::None) {
-					iridescence->iridescenceThicknessTexture = std::move(iridescenceThicknessTexture);
+												  &iridescenceThicknessTexture, config.extensions);
+					error == Error::None) {
+					iridescence->iridescenceThicknessTexture =
+						std::move(iridescenceThicknessTexture);
 				} else if (error != Error::MissingField) {
 					return error;
 				}
@@ -2848,31 +2938,43 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 					break;
 
 				dom::object diffuseTransmissionObject;
-				auto diffuseTransmissionError = extensionField.value.get_object().get(diffuseTransmissionObject);
+				auto diffuseTransmissionError =
+					extensionField.value.get_object().get(diffuseTransmissionObject);
 				if (diffuseTransmissionError != SUCCESS) [[unlikely]] {
 					return Error::InvalidGltf;
-				}	
+				}
 
 				auto diffuseTransmission = std::make_unique<MaterialDiffuseTransmission>();
 
 				double diffuseTransmissionFactor;
-				if (auto error = diffuseTransmissionObject["diffuseTransmissionFactor"].get_double().get(diffuseTransmissionFactor); error == SUCCESS) [[likely]] {
-					diffuseTransmission->diffuseTransmissionFactor = static_cast<num>(diffuseTransmissionFactor);
+				if (auto error =
+						diffuseTransmissionObject["diffuseTransmissionFactor"].get_double().get(
+							diffuseTransmissionFactor);
+					error == SUCCESS) [[likely]] {
+					diffuseTransmission->diffuseTransmissionFactor =
+						static_cast<num>(diffuseTransmissionFactor);
 				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
 				TextureInfo diffuseTransmissionTexture;
-				if (auto error = parseTextureInfo(diffuseTransmissionObject, "diffuseTransmissionTexture", &diffuseTransmissionTexture, config.extensions); error == Error::None) [[likely]] {
-					diffuseTransmission->diffuseTransmissionTexture = std::move(diffuseTransmissionTexture);
+				if (auto error =
+						parseTextureInfo(diffuseTransmissionObject, "diffuseTransmissionTexture",
+										 &diffuseTransmissionTexture, config.extensions);
+					error == Error::None) [[likely]] {
+					diffuseTransmission->diffuseTransmissionTexture =
+						std::move(diffuseTransmissionTexture);
 				} else if (error != Error::MissingField) {
 					return error;
 				}
 
 				dom::array diffuseTransmissionColorFactor;
-				if (auto error = diffuseTransmissionObject["diffuseTransmissionColorFactor"].get_array().get(diffuseTransmissionColorFactor); error == SUCCESS) [[likely]] {
+				if (auto error =
+						diffuseTransmissionObject["diffuseTransmissionColorFactor"].get_array().get(
+							diffuseTransmissionColorFactor);
+					error == SUCCESS) [[likely]] {
 					std::size_t i = 0;
-					for (auto factor: diffuseTransmissionColorFactor) {
+					for (auto factor : diffuseTransmissionColorFactor) {
 						if (i >= diffuseTransmission->diffuseTransmissionColorFactor.size()) {
 							return Error::InvalidGltf;
 						}
@@ -2880,13 +2982,18 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 						if (factor.get_double().get(value) != SUCCESS) [[unlikely]] {
 							return Error::InvalidGltf;
 						}
-						diffuseTransmission->diffuseTransmissionColorFactor[i++] = static_cast<num>(value);
+						diffuseTransmission->diffuseTransmissionColorFactor[i++] =
+							static_cast<num>(value);
 					}
 				}
 
 				TextureInfo diffuseTransmissionColorTexture;
-				if (auto error = parseTextureInfo(diffuseTransmissionObject, "diffuseTransmissionColorTexture", &diffuseTransmissionColorTexture, config.extensions); error == Error::None) [[likely]] {
-					diffuseTransmission->diffuseTransmissionColorTexture = std::move(diffuseTransmissionColorTexture);
+				if (auto error = parseTextureInfo(
+						diffuseTransmissionObject, "diffuseTransmissionColorTexture",
+						&diffuseTransmissionColorTexture, config.extensions);
+					error == Error::None) [[likely]] {
+					diffuseTransmission->diffuseTransmissionColorTexture =
+						std::move(diffuseTransmissionColorTexture);
 				} else if (error != Error::MissingField) {
 					return error;
 				}
@@ -2896,8 +3003,7 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 			}
 
 			case force_consteval<crc32c(extensions::KHR_materials_sheen)>: {
-				if (!hasBit(config.extensions, Extensions::KHR_materials_sheen))
-					break;
+				if (!hasBit(config.extensions, Extensions::KHR_materials_sheen)) break;
 
 				dom::object sheenObject;
 				auto sheenError = extensionField.value.get_object().get(sheenObject);
@@ -2908,10 +3014,10 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 				auto sheen = std::make_unique<MaterialSheen>();
 
 				dom::array sheenColorFactor;
-				if (auto error = sheenObject["sheenColorFactor"].get_array().get(sheenColorFactor); error ==
-																									SUCCESS) {
+				if (auto error = sheenObject["sheenColorFactor"].get_array().get(sheenColorFactor);
+					error == SUCCESS) {
 					std::size_t i = 0;
-					for (auto factor: sheenColorFactor) {
+					for (auto factor : sheenColorFactor) {
 						if (i >= sheen->sheenColorFactor.size()) {
 							return Error::InvalidGltf;
 						}
@@ -2926,24 +3032,27 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 				}
 
 				TextureInfo sheenColorTexture;
-				if (auto error = parseTextureInfo(sheenObject, "sheenColorTexture", &sheenColorTexture,
-												  config.extensions); error == Error::None) [[likely]] {
+				if (auto error = parseTextureInfo(sheenObject, "sheenColorTexture",
+												  &sheenColorTexture, config.extensions);
+					error == Error::None) [[likely]] {
 					sheen->sheenColorTexture = std::move(sheenColorTexture);
 				} else if (error != Error::MissingField) {
 					return error;
 				}
 
 				double sheenRoughnessFactor;
-				if (auto error = sheenObject["sheenRoughnessFactor"].get_double().get(sheenRoughnessFactor);
-						error == SUCCESS) [[likely]] {
+				if (auto error =
+						sheenObject["sheenRoughnessFactor"].get_double().get(sheenRoughnessFactor);
+					error == SUCCESS) [[likely]] {
 					sheen->sheenRoughnessFactor = static_cast<num>(sheenRoughnessFactor);
 				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
 				TextureInfo sheenRoughnessTexture;
-				if (auto error = parseTextureInfo(sheenObject, "sheenRoughnessTexture", &sheenRoughnessTexture,
-												  config.extensions); error == Error::None) [[likely]] {
+				if (auto error = parseTextureInfo(sheenObject, "sheenRoughnessTexture",
+												  &sheenRoughnessTexture, config.extensions);
+					error == Error::None) [[likely]] {
 					sheen->sheenRoughnessTexture = std::move(sheenRoughnessTexture);
 				} else if (error != Error::MissingField) {
 					return error;
@@ -2953,8 +3062,7 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 				break;
 			}
 			case force_consteval<crc32c(extensions::KHR_materials_specular)>: {
-				if (!hasBit(config.extensions, Extensions::KHR_materials_specular))
-					break;
+				if (!hasBit(config.extensions, Extensions::KHR_materials_specular)) break;
 
 				dom::object specularObject;
 				auto specularError = extensionField.value.get_object().get(specularObject);
@@ -2965,26 +3073,28 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 				auto specular = std::make_unique<MaterialSpecular>();
 
 				double specularFactor;
-				if (auto error = specularObject["specularFactor"].get_double().get(specularFactor); error ==
-																									SUCCESS) {
+				if (auto error = specularObject["specularFactor"].get_double().get(specularFactor);
+					error == SUCCESS) {
 					specular->specularFactor = static_cast<num>(specularFactor);
 				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
 				TextureInfo specularTexture;
-				if (auto error = parseTextureInfo(specularObject, "specularTexture", &specularTexture,
-												  config.extensions); error == Error::None) [[likely]] {
+				if (auto error = parseTextureInfo(specularObject, "specularTexture",
+												  &specularTexture, config.extensions);
+					error == Error::None) [[likely]] {
 					specular->specularTexture = std::move(specularTexture);
 				} else if (error != Error::MissingField) {
 					return error;
 				}
 
 				dom::array specularColorFactor;
-				if (auto error = specularObject["specularColorFactor"].get_array().get(specularColorFactor);
-						error == SUCCESS) [[likely]] {
+				if (auto error =
+						specularObject["specularColorFactor"].get_array().get(specularColorFactor);
+					error == SUCCESS) [[likely]] {
 					std::size_t i = 0;
-					for (auto factor: specularColorFactor) {
+					for (auto factor : specularColorFactor) {
 						if (i >= specular->specularColorFactor.size()) {
 							return Error::InvalidGltf;
 						}
@@ -2999,8 +3109,9 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 				}
 
 				TextureInfo specularColorTexture;
-				if (auto error = parseTextureInfo(specularObject, "specularColorTexture", &specularColorTexture,
-												  config.extensions); error == Error::None) [[likely]] {
+				if (auto error = parseTextureInfo(specularObject, "specularColorTexture",
+												  &specularColorTexture, config.extensions);
+					error == Error::None) [[likely]] {
 					specular->specularColorTexture = std::move(specularColorTexture);
 				} else if (error != Error::MissingField) {
 					return error;
@@ -3010,8 +3121,7 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 				break;
 			}
 			case force_consteval<crc32c(extensions::KHR_materials_transmission)>: {
-				if (!hasBit(config.extensions, Extensions::KHR_materials_transmission))
-					break;
+				if (!hasBit(config.extensions, Extensions::KHR_materials_transmission)) break;
 
 				dom::object transmissionObject;
 				auto transmissionError = extensionField.value.get_object().get(transmissionObject);
@@ -3022,16 +3132,18 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 				auto transmission = std::make_unique<MaterialTransmission>();
 
 				double transmissionFactor;
-				if (auto error = transmissionObject["transmissionFactor"].get_double().get(transmissionFactor);
-						error == SUCCESS) [[likely]] {
+				if (auto error = transmissionObject["transmissionFactor"].get_double().get(
+						transmissionFactor);
+					error == SUCCESS) [[likely]] {
 					transmission->transmissionFactor = static_cast<num>(transmissionFactor);
 				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
 				TextureInfo transmissionTexture;
-				if (auto error = parseTextureInfo(transmissionObject, "transmissionTexture", &transmissionTexture,
-												  config.extensions); error == Error::None) [[likely]] {
+				if (auto error = parseTextureInfo(transmissionObject, "transmissionTexture",
+												  &transmissionTexture, config.extensions);
+					error == Error::None) [[likely]] {
 					transmission->transmissionTexture = std::move(transmissionTexture);
 				} else if (error != Error::MissingField) {
 					return error;
@@ -3041,8 +3153,7 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 				break;
 			}
 			case force_consteval<crc32c(extensions::KHR_materials_unlit)>: {
-				if (!hasBit(config.extensions, Extensions::KHR_materials_unlit))
-					break;
+				if (!hasBit(config.extensions, Extensions::KHR_materials_unlit)) break;
 
 				dom::object unlitObject;
 				auto unlitError = extensionField.value.get_object().get(unlitObject);
@@ -3054,8 +3165,7 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 				break;
 			}
 			case force_consteval<crc32c(extensions::KHR_materials_volume)>: {
-				if (!hasBit(config.extensions, Extensions::KHR_materials_volume))
-					break;
+				if (!hasBit(config.extensions, Extensions::KHR_materials_volume)) break;
 
 				dom::object volumeObject;
 				auto volumeError = extensionField.value.get_object().get(volumeObject);
@@ -3066,28 +3176,34 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 				auto volume = std::make_unique<MaterialVolume>();
 
 				double thicknessFactor;
-				if (auto error = volumeObject["thicknessFactor"].get_double().get(thicknessFactor); error == SUCCESS) [[likely]] {
+				if (auto error = volumeObject["thicknessFactor"].get_double().get(thicknessFactor);
+					error == SUCCESS) [[likely]] {
 					volume->thicknessFactor = static_cast<num>(thicknessFactor);
 				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
 				TextureInfo thicknessTexture;
-				if (auto error = parseTextureInfo(volumeObject, "thicknessTexture", &thicknessTexture, config.extensions); error == Error::None) [[likely]] {
+				if (auto error = parseTextureInfo(volumeObject, "thicknessTexture",
+												  &thicknessTexture, config.extensions);
+					error == Error::None) [[likely]] {
 					volume->thicknessTexture = std::move(thicknessTexture);
 				} else if (error != Error::MissingField) {
 					return error;
 				}
 
 				double attenuationDistance;
-				if (auto error = volumeObject["attenuationDistance"].get_double().get(attenuationDistance); error == SUCCESS) [[likely]] {
+				if (auto error =
+						volumeObject["attenuationDistance"].get_double().get(attenuationDistance);
+					error == SUCCESS) [[likely]] {
 					volume->attenuationDistance = static_cast<num>(attenuationDistance);
 				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
 				dom::array attenuationColor;
-				if (auto error = volumeObject["attenuationColor"].get_array().get(attenuationColor); error == SUCCESS) [[likely]] {
+				if (auto error = volumeObject["attenuationColor"].get_array().get(attenuationColor);
+					error == SUCCESS) [[likely]] {
 					std::size_t i = 0;
 					for (auto factor : attenuationColor) {
 						if (i >= volume->attenuationColor.size()) {
@@ -3111,11 +3227,15 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 					break;
 
 				dom::object normalRoughnessMetallic;
-				if (extensionField.value.get_object().get(normalRoughnessMetallic) != SUCCESS) [[unlikely]] {
+				if (extensionField.value.get_object().get(normalRoughnessMetallic) != SUCCESS)
+					[[unlikely]] {
 					return Error::InvalidGltf;
 				}
 				TextureInfo textureInfo = {};
-				if (auto error = parseTextureInfo(normalRoughnessMetallic, "normalRoughnessMetallicTexture", &textureInfo, config.extensions); error == Error::None) [[likely]] {
+				if (auto error =
+						parseTextureInfo(normalRoughnessMetallic, "normalRoughnessMetallicTexture",
+										 &textureInfo, config.extensions);
+					error == Error::None) [[likely]] {
 					material.packedNormalMetallicRoughnessTexture = std::move(textureInfo);
 				} else if (error != Error::MissingField) {
 					return error;
@@ -3127,24 +3247,33 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 					break;
 
 				dom::object occlusionRoughnessMetallic;
-				if (extensionField.value.get_object().get(occlusionRoughnessMetallic) != SUCCESS) [[unlikely]] {
+				if (extensionField.value.get_object().get(occlusionRoughnessMetallic) != SUCCESS)
+					[[unlikely]] {
 					return Error::InvalidGltf;
 				}
 				auto packedTextures = std::make_unique<MaterialPackedTextures>();
 				TextureInfo textureInfo = {};
-				if (auto error = parseTextureInfo(occlusionRoughnessMetallic, "occlusionRoughnessMetallicTexture", &textureInfo, config.extensions); error == Error::None) [[likely]] {
+				if (auto error = parseTextureInfo(occlusionRoughnessMetallic,
+												  "occlusionRoughnessMetallicTexture", &textureInfo,
+												  config.extensions);
+					error == Error::None) [[likely]] {
 					packedTextures->occlusionRoughnessMetallicTexture = std::move(textureInfo);
 				} else if (error != Error::MissingField) {
 					return error;
 				}
 
-				if (auto error = parseTextureInfo(occlusionRoughnessMetallic, "roughnessMetallicOcclusionTexture", &textureInfo, config.extensions); error == Error::None) [[likely]] {
+				if (auto error = parseTextureInfo(occlusionRoughnessMetallic,
+												  "roughnessMetallicOcclusionTexture", &textureInfo,
+												  config.extensions);
+					error == Error::None) [[likely]] {
 					packedTextures->roughnessMetallicOcclusionTexture = std::move(textureInfo);
 				} else if (error != Error::MissingField) {
 					return error;
 				}
 
-				if (auto error = parseTextureInfo(occlusionRoughnessMetallic, "normalTexture", &textureInfo, config.extensions); error == Error::None) [[likely]] {
+				if (auto error = parseTextureInfo(occlusionRoughnessMetallic, "normalTexture",
+												  &textureInfo, config.extensions);
+					error == Error::None) [[likely]] {
 					packedTextures->normalTexture = std::move(textureInfo);
 				} else if (error != Error::MissingField) {
 					return error;
@@ -3159,14 +3288,17 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 					break;
 
 				dom::object specularGlossinessObject;
-				auto specularGlossinessError = extensionField.value.get_object().get(specularGlossinessObject);
+				auto specularGlossinessError =
+					extensionField.value.get_object().get(specularGlossinessObject);
 				if (specularGlossinessError != SUCCESS) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 				auto specularGlossiness = std::make_unique<MaterialSpecularGlossiness>();
 
 				dom::array diffuseFactor;
-				if (auto error = specularGlossinessObject["diffuseFactor"].get_array().get(diffuseFactor); error == SUCCESS) [[likely]] {
+				if (auto error =
+						specularGlossinessObject["diffuseFactor"].get_array().get(diffuseFactor);
+					error == SUCCESS) [[likely]] {
 					std::size_t i = 0;
 					for (auto factor : diffuseFactor) {
 						if (i >= specularGlossiness->diffuseFactor.size()) {
@@ -3183,14 +3315,18 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 				}
 
 				TextureInfo diffuseTexture;
-				if (auto error = parseTextureInfo(specularGlossinessObject, "diffuseTexture", &diffuseTexture, config.extensions); error == Error::None) [[likely]] {
+				if (auto error = parseTextureInfo(specularGlossinessObject, "diffuseTexture",
+												  &diffuseTexture, config.extensions);
+					error == Error::None) [[likely]] {
 					specularGlossiness->diffuseTexture = std::move(diffuseTexture);
 				} else if (error != Error::MissingField) {
 					return error;
 				}
 
 				dom::array specularFactor;
-				if (auto error = specularGlossinessObject["specularFactor"].get_array().get(specularFactor); error == SUCCESS) [[likely]] {
+				if (auto error =
+						specularGlossinessObject["specularFactor"].get_array().get(specularFactor);
+					error == SUCCESS) [[likely]] {
 					std::size_t i = 0;
 					for (auto factor : specularFactor) {
 						if (i >= specularGlossiness->specularFactor.size()) {
@@ -3207,15 +3343,21 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 				}
 
 				double glossinessFactor;
-				if (auto error = specularGlossinessObject["glossinessFactor"].get_double().get(glossinessFactor); error == SUCCESS) [[likely]] {
+				if (auto error = specularGlossinessObject["glossinessFactor"].get_double().get(
+						glossinessFactor);
+					error == SUCCESS) [[likely]] {
 					specularGlossiness->glossinessFactor = static_cast<num>(glossinessFactor);
 				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
 				TextureInfo specularGlossinessTexture;
-				if (auto error = parseTextureInfo(specularGlossinessObject, "specularGlossinessTexture", &specularGlossinessTexture, config.extensions); error == Error::None) [[likely]] {
-					specularGlossiness->specularGlossinessTexture = std::move(specularGlossinessTexture);
+				if (auto error =
+						parseTextureInfo(specularGlossinessObject, "specularGlossinessTexture",
+										 &specularGlossinessTexture, config.extensions);
+					error == Error::None) [[likely]] {
+					specularGlossiness->specularGlossinessTexture =
+						std::move(specularGlossinessTexture);
 				} else if (error != Error::MissingField) {
 					return error;
 				}
@@ -3234,174 +3376,199 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 }
 
 fg::Error fg::Parser::parseMaterials(simdjson::dom::array& materials, Asset& asset) {
-    using namespace simdjson;
+	using namespace simdjson;
 
-    asset.materials.reserve(materials.size());
-    for (auto materialValue : materials) {
-        dom::object materialObject;
-        if (materialValue.get_object().get(materialObject) != SUCCESS) [[unlikely]] {
-            return Error::InvalidGltf;
-        }
-        Material material = {};
+	asset.materials.reserve(materials.size());
+	for (auto materialValue : materials) {
+		dom::object materialObject;
+		if (materialValue.get_object().get(materialObject) != SUCCESS) [[unlikely]] {
+			return Error::InvalidGltf;
+		}
+		Material material = {};
 
-        dom::array emissiveFactor;
-        if (auto error = materialObject["emissiveFactor"].get_array().get(emissiveFactor); error == SUCCESS) [[likely]] {
-            if (emissiveFactor.size() != 3) {
-                return Error::InvalidGltf;
-            }
-            for (auto i = 0U; i < 3; ++i) {
-                double val;
-                if (emissiveFactor.at(i).get_double().get(val) != SUCCESS) [[unlikely]] {
-                    return Error::InvalidGltf;
-                }
-                material.emissiveFactor[i] = static_cast<num>(val);
-            }
-        } else if (error != NO_SUCH_FIELD) [[unlikely]] {
-            return Error::InvalidGltf;
-        }
+		dom::array emissiveFactor;
+		if (auto error = materialObject["emissiveFactor"].get_array().get(emissiveFactor);
+			error == SUCCESS) [[likely]] {
+			if (emissiveFactor.size() != 3) {
+				return Error::InvalidGltf;
+			}
+			for (auto i = 0U; i < 3; ++i) {
+				double val;
+				if (emissiveFactor.at(i).get_double().get(val) != SUCCESS) [[unlikely]] {
+					return Error::InvalidGltf;
+				}
+				material.emissiveFactor[i] = static_cast<num>(val);
+			}
+		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
+			return Error::InvalidGltf;
+		}
 
-	    {
-		    NormalTextureInfo normalTextureInfo = {};
-		    if (auto error = parseTextureInfo(materialObject, "normalTexture", &normalTextureInfo, config.extensions, TextureInfoType::NormalTexture); error == Error::None) [[likely]] {
-			    material.normalTexture = std::move(normalTextureInfo);
-		    } else if (error != Error::MissingField) {
-			    return error;
-		    }
-	    }
+		{
+			NormalTextureInfo normalTextureInfo = {};
+			if (auto error = parseTextureInfo(materialObject, "normalTexture", &normalTextureInfo,
+											  config.extensions, TextureInfoType::NormalTexture);
+				error == Error::None) [[likely]] {
+				material.normalTexture = std::move(normalTextureInfo);
+			} else if (error != Error::MissingField) {
+				return error;
+			}
+		}
 
-	    {
+		{
 			OcclusionTextureInfo occlusionTextureInfo = {};
-	        if (auto error = parseTextureInfo(materialObject, "occlusionTexture", &occlusionTextureInfo, config.extensions, TextureInfoType::OcclusionTexture); error == Error::None) [[likely]] {
-	            material.occlusionTexture = std::move(occlusionTextureInfo);
-	        } else if (error != Error::MissingField) {
-	            return error;
-	        }
-	    }
-
-	    {
-		    TextureInfo textureInfo = {};
-	        if (auto error = parseTextureInfo(materialObject, "emissiveTexture", &textureInfo, config.extensions); error == Error::None) [[likely]] {
-	            material.emissiveTexture = std::move(textureInfo);
-	        } else if (error != Error::MissingField) {
-	            return error;
-	        }
-	    }
-
-        dom::object pbrMetallicRoughness;
-        if (materialObject["pbrMetallicRoughness"].get_object().get(pbrMetallicRoughness) == SUCCESS) [[likely]] {
-            PBRData pbr = {};
-
-            dom::array baseColorFactor;
-            if (pbrMetallicRoughness["baseColorFactor"].get_array().get(baseColorFactor) == SUCCESS) [[likely]] {
-                for (auto i = 0U; i < 4; ++i) {
-                    double val;
-                    if (baseColorFactor.at(i).get_double().get(val) != SUCCESS) [[unlikely]] {
-                        return Error::InvalidGltf;
-                    }
-                    pbr.baseColorFactor[i] = static_cast<num>(val);
-                }
-            }
-
-            double factor;
-            if (auto error = pbrMetallicRoughness["metallicFactor"].get_double().get(factor); error == SUCCESS) [[likely]] {
-                pbr.metallicFactor = static_cast<num>(factor);
-            } else if (error != NO_SUCH_FIELD) {
-				return Error::InvalidGltf;
+			if (auto error =
+					parseTextureInfo(materialObject, "occlusionTexture", &occlusionTextureInfo,
+									 config.extensions, TextureInfoType::OcclusionTexture);
+				error == Error::None) [[likely]] {
+				material.occlusionTexture = std::move(occlusionTextureInfo);
+			} else if (error != Error::MissingField) {
+				return error;
 			}
-            if (auto error = pbrMetallicRoughness["roughnessFactor"].get_double().get(factor); error == SUCCESS) [[likely]] {
-                pbr.roughnessFactor = static_cast<num>(factor);
-            } else if (error != NO_SUCH_FIELD) {
-				return Error::InvalidGltf;
+		}
+
+		{
+			TextureInfo textureInfo = {};
+			if (auto error = parseTextureInfo(materialObject, "emissiveTexture", &textureInfo,
+											  config.extensions);
+				error == Error::None) [[likely]] {
+				material.emissiveTexture = std::move(textureInfo);
+			} else if (error != Error::MissingField) {
+				return error;
+			}
+		}
+
+		dom::object pbrMetallicRoughness;
+		if (materialObject["pbrMetallicRoughness"].get_object().get(pbrMetallicRoughness) ==
+			SUCCESS) [[likely]] {
+			PBRData pbr = {};
+
+			dom::array baseColorFactor;
+			if (pbrMetallicRoughness["baseColorFactor"].get_array().get(baseColorFactor) == SUCCESS)
+				[[likely]] {
+				for (auto i = 0U; i < 4; ++i) {
+					double val;
+					if (baseColorFactor.at(i).get_double().get(val) != SUCCESS) [[unlikely]] {
+						return Error::InvalidGltf;
+					}
+					pbr.baseColorFactor[i] = static_cast<num>(val);
+				}
 			}
 
-	        TextureInfo textureInfo;
-            if (auto error = parseTextureInfo(pbrMetallicRoughness, "baseColorTexture", &textureInfo, config.extensions); error == Error::None) [[likely]] {
-                pbr.baseColorTexture = std::move(textureInfo);
-            } else if (error != Error::MissingField) {
-                return error;
-            }
+			double factor;
+			if (auto error = pbrMetallicRoughness["metallicFactor"].get_double().get(factor);
+				error == SUCCESS) [[likely]] {
+				pbr.metallicFactor = static_cast<num>(factor);
+			} else if (error != NO_SUCH_FIELD) {
+				return Error::InvalidGltf;
+			}
+			if (auto error = pbrMetallicRoughness["roughnessFactor"].get_double().get(factor);
+				error == SUCCESS) [[likely]] {
+				pbr.roughnessFactor = static_cast<num>(factor);
+			} else if (error != NO_SUCH_FIELD) {
+				return Error::InvalidGltf;
+			}
 
-            if (auto error = parseTextureInfo(pbrMetallicRoughness, "metallicRoughnessTexture", &textureInfo, config.extensions); error == Error::None) [[likely]] {
-                pbr.metallicRoughnessTexture = std::move(textureInfo);
-            } else if (error != Error::MissingField) {
-                return error;
-            }
+			TextureInfo textureInfo;
+			if (auto error = parseTextureInfo(pbrMetallicRoughness, "baseColorTexture",
+											  &textureInfo, config.extensions);
+				error == Error::None) [[likely]] {
+				pbr.baseColorTexture = std::move(textureInfo);
+			} else if (error != Error::MissingField) {
+				return error;
+			}
 
-            material.pbrData = std::move(pbr);
-        }
+			if (auto error = parseTextureInfo(pbrMetallicRoughness, "metallicRoughnessTexture",
+											  &textureInfo, config.extensions);
+				error == Error::None) [[likely]] {
+				pbr.metallicRoughnessTexture = std::move(textureInfo);
+			} else if (error != Error::MissingField) {
+				return error;
+			}
 
-        std::string_view alphaMode;
-        if (auto error = materialObject["alphaMode"].get_string().get(alphaMode); error == SUCCESS) [[likely]] {
-            if (alphaMode == "OPAQUE") {
-                material.alphaMode = AlphaMode::Opaque;
-            } else if (alphaMode == "MASK") {
-                material.alphaMode = AlphaMode::Mask;
-            } else if (alphaMode == "BLEND") {
-                material.alphaMode = AlphaMode::Blend;
-            } else {
-                return Error::InvalidGltf;
-            }
-        } else if (error != NO_SUCH_FIELD) [[unlikely]] {
-            return Error::InvalidGltf;
-        }
+			material.pbrData = std::move(pbr);
+		}
 
-        double alphaCutoff;
-        if (auto error = materialObject["alphaCutoff"].get_double().get(alphaCutoff); error == SUCCESS) [[likely]] {
-            material.alphaCutoff = static_cast<num>(alphaCutoff);
-        } else if (error != NO_SUCH_FIELD) [[unlikely]] {
-            return Error::InvalidGltf;
-        }
+		std::string_view alphaMode;
+		if (auto error = materialObject["alphaMode"].get_string().get(alphaMode); error == SUCCESS)
+			[[likely]] {
+			if (alphaMode == "OPAQUE") {
+				material.alphaMode = AlphaMode::Opaque;
+			} else if (alphaMode == "MASK") {
+				material.alphaMode = AlphaMode::Mask;
+			} else if (alphaMode == "BLEND") {
+				material.alphaMode = AlphaMode::Blend;
+			} else {
+				return Error::InvalidGltf;
+			}
+		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
+			return Error::InvalidGltf;
+		}
 
-        bool doubleSided;
-        if (auto error = materialObject["doubleSided"].get_bool().get(doubleSided); error == SUCCESS) [[likely]] {
-            material.doubleSided = doubleSided;
-        } else if (error != NO_SUCH_FIELD) [[unlikely]] {
-            return Error::InvalidGltf;
-        }
+		double alphaCutoff;
+		if (auto error = materialObject["alphaCutoff"].get_double().get(alphaCutoff);
+			error == SUCCESS) [[likely]] {
+			material.alphaCutoff = static_cast<num>(alphaCutoff);
+		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
+			return Error::InvalidGltf;
+		}
 
-        std::string_view name;
-        if (materialObject["name"].get_string().get(name) == SUCCESS) {
-	        material.name = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(material.name), resourceAllocator.get(), name);
-        }
+		bool doubleSided;
+		if (auto error = materialObject["doubleSided"].get_bool().get(doubleSided);
+			error == SUCCESS) [[likely]] {
+			material.doubleSided = doubleSided;
+		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
+			return Error::InvalidGltf;
+		}
 
-        dom::object extensionsObject;
-        if (auto extensionError = materialObject["extensions"].get_object().get(extensionsObject); extensionError == SUCCESS) {
+		std::string_view name;
+		if (materialObject["name"].get_string().get(name) == SUCCESS) {
+			material.name = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(material.name),
+															resourceAllocator.get(), name);
+		}
+
+		dom::object extensionsObject;
+		if (auto extensionError = materialObject["extensions"].get_object().get(extensionsObject);
+			extensionError == SUCCESS) {
 			parseMaterialExtensions(extensionsObject, material);
-        } else if (extensionError != NO_SUCH_FIELD) [[unlikely]] {
-            return Error::InvalidJson;
-        }
+		} else if (extensionError != NO_SUCH_FIELD) [[unlikely]] {
+			return Error::InvalidJson;
+		}
 
 		if (config.extrasCallback != nullptr) {
 			dom::object extrasObject;
-			if (auto extrasError = materialObject["extras"].get_object().get(extrasObject); extrasError == SUCCESS) {
-				config.extrasCallback(&extrasObject, asset.materials.size(), Category::Materials, config.userPointer);
+			if (auto extrasError = materialObject["extras"].get_object().get(extrasObject);
+				extrasError == SUCCESS) {
+				config.extrasCallback(&extrasObject, asset.materials.size(), Category::Materials,
+									  config.userPointer);
 			} else if (extrasError != NO_SUCH_FIELD) {
 				return Error::InvalidGltf;
 			}
 		}
 
 		asset.materials.emplace_back(std::move(material));
-    }
+	}
 
 	return Error::None;
 }
 
-fastgltf::Error fg::Parser::parsePrimitiveExtensions(const simdjson::dom::object& object, Primitive& primitive) {
+fastgltf::Error fg::Parser::parsePrimitiveExtensions(const simdjson::dom::object& object,
+													 Primitive& primitive) {
 	using namespace simdjson;
 
 	for (auto extension : object) {
 		switch (crcStringFunction(extension.key)) {
 			case force_consteval<crc32c(extensions::KHR_materials_variants)>: {
-				if (!hasBit(config.extensions, Extensions::KHR_materials_variants))
-					break;
+				if (!hasBit(config.extensions, Extensions::KHR_materials_variants)) break;
 
 				dom::object variantObject;
-				if (auto variantsError = extension.value.get_object().get(variantObject); variantsError != SUCCESS) {
+				if (auto variantsError = extension.value.get_object().get(variantObject);
+					variantsError != SUCCESS) {
 					return Error::InvalidGltf;
 				}
 
 				dom::array mappingsArray;
-				if (variantObject["mappings"].get_array().get(mappingsArray) != SUCCESS) [[unlikely]] {
+				if (variantObject["mappings"].get_array().get(mappingsArray) != SUCCESS)
+					[[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
@@ -3412,12 +3579,14 @@ fastgltf::Error fg::Parser::parsePrimitiveExtensions(const simdjson::dom::object
 					}
 
 					std::uint64_t materialIndex;
-					if (mappingObject["material"].get_uint64().get(materialIndex) != SUCCESS) [[unlikely]] {
+					if (mappingObject["material"].get_uint64().get(materialIndex) != SUCCESS)
+						[[unlikely]] {
 						return Error::InvalidGltf;
 					}
 
 					dom::array variantsArray;
-					if (mappingObject["variants"].get_array().get(variantsArray) != SUCCESS) [[unlikely]] {
+					if (mappingObject["variants"].get_array().get(variantsArray) != SUCCESS)
+						[[unlikely]] {
 						return Error::InvalidGltf;
 					}
 					for (auto variant : variantsArray) {
@@ -3434,27 +3603,31 @@ fastgltf::Error fg::Parser::parsePrimitiveExtensions(const simdjson::dom::object
 				break;
 			}
 			case force_consteval<crc32c(extensions::KHR_draco_mesh_compression)>: {
-				if (!hasBit(config.extensions, Extensions::KHR_draco_mesh_compression))
-					break;
+				if (!hasBit(config.extensions, Extensions::KHR_draco_mesh_compression)) break;
 
 				dom::object dracoObject;
-				if (auto dracoError = extension.value.get_object().get(dracoObject); dracoError != SUCCESS) {
+				if (auto dracoError = extension.value.get_object().get(dracoObject);
+					dracoError != SUCCESS) {
 					return Error::InvalidGltf;
 				}
 
 				auto dracoCompression = std::make_unique<DracoCompressedPrimitive>();
 
 				std::uint64_t value;
-				if (auto error = dracoObject["bufferView"].get_uint64().get(value); error != SUCCESS) [[unlikely]] {
+				if (auto error = dracoObject["bufferView"].get_uint64().get(value);
+					error != SUCCESS) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 				dracoCompression->bufferView = static_cast<std::size_t>(value);
 
 				dom::object attributesObject;
-				if (dracoObject["attributes"].get_object().get(attributesObject) != SUCCESS) [[unlikely]] {
+				if (dracoObject["attributes"].get_object().get(attributesObject) != SUCCESS)
+					[[unlikely]] {
 					return Error::InvalidGltf;
 				}
-				if (auto attributesError = parseAttributes(attributesObject, dracoCompression->attributes); attributesError != Error::None) {
+				if (auto attributesError =
+						parseAttributes(attributesObject, dracoCompression->attributes);
+					attributesError != Error::None) {
 					return attributesError;
 				}
 
@@ -3468,24 +3641,25 @@ fastgltf::Error fg::Parser::parsePrimitiveExtensions(const simdjson::dom::object
 }
 
 fg::Error fg::Parser::parseMeshes(simdjson::dom::array& meshes, Asset& asset) {
-    using namespace simdjson;
+	using namespace simdjson;
 
-    asset.meshes.reserve(meshes.size());
-    for (auto meshValue : meshes) {
-        // Required fields: "primitives"
-        dom::object meshObject;
-        if (meshValue.get_object().get(meshObject) != SUCCESS) [[unlikely]] {
-            return Error::InvalidGltf;
-        }
-        Mesh mesh = {};
+	asset.meshes.reserve(meshes.size());
+	for (auto meshValue : meshes) {
+		// Required fields: "primitives"
+		dom::object meshObject;
+		if (meshValue.get_object().get(meshObject) != SUCCESS) [[unlikely]] {
+			return Error::InvalidGltf;
+		}
+		Mesh mesh = {};
 
-        dom::array array;
-        auto meshError = getJsonArray(meshObject, "primitives", &array);
+		dom::array array;
+		auto meshError = getJsonArray(meshObject, "primitives", &array);
 		if (meshError != Error::None) {
 			return meshError == Error::MissingField ? Error::InvalidGltf : meshError;
 		}
 
-		mesh.primitives = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(mesh.primitives), resourceAllocator.get(), 0);
+		mesh.primitives =
+			FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(mesh.primitives), resourceAllocator.get(), 0);
 		mesh.primitives.reserve(array.size());
 		for (auto primitiveValue : array) {
 			// Required fields: "attributes"
@@ -3496,51 +3670,61 @@ fg::Error fg::Parser::parseMeshes(simdjson::dom::array& meshes, Asset& asset) {
 			}
 
 			dom::object attributesObject;
-			if (primitiveObject["attributes"].get_object().get(attributesObject) != SUCCESS) [[unlikely]] {
+			if (primitiveObject["attributes"].get_object().get(attributesObject) != SUCCESS)
+				[[unlikely]] {
 				return Error::InvalidGltf;
 			}
-			if (auto attributesError = parseAttributes(attributesObject, primitive.attributes); attributesError != Error::None) {
+			if (auto attributesError = parseAttributes(attributesObject, primitive.attributes);
+				attributesError != Error::None) {
 				return attributesError;
 			}
 
 			dom::array targets;
 			if (primitiveObject["targets"].get_array().get(targets) == SUCCESS) [[likely]] {
-				primitive.targets = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(primitive.targets), resourceAllocator.get(), 0);
+				primitive.targets = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(primitive.targets),
+																	resourceAllocator.get(), 0);
 				primitive.targets.reserve(targets.size());
 				for (auto targetValue : targets) {
 					if (targetValue.get_object().get(attributesObject) != SUCCESS) [[unlikely]] {
 						return Error::InvalidGltf;
 					}
 					auto& map = primitive.targets.emplace_back();
-					if (auto attributesError = parseAttributes(attributesObject, map); attributesError != Error::None) {
+					if (auto attributesError = parseAttributes(attributesObject, map);
+						attributesError != Error::None) {
 						return attributesError;
 					}
 				}
 			}
 
 			std::uint64_t value;
-			if (auto error = primitiveObject["mode"].get_uint64().get(value); error == SUCCESS) [[likely]] {
+			if (auto error = primitiveObject["mode"].get_uint64().get(value); error == SUCCESS)
+				[[likely]] {
 				primitive.type = static_cast<PrimitiveType>(value);
 			} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 				return Error::InvalidGltf;
 			}
 
-			if (auto error = primitiveObject["indices"].get_uint64().get(value); error == SUCCESS) [[likely]] {
+			if (auto error = primitiveObject["indices"].get_uint64().get(value); error == SUCCESS)
+				[[likely]] {
 				primitive.indicesAccessor = static_cast<std::size_t>(value);
 			} else if (error != NO_SUCH_FIELD) {
 				return Error::InvalidGltf;
 			}
 
-			if (auto error = primitiveObject["material"].get_uint64().get(value); error == SUCCESS) [[likely]] {
+			if (auto error = primitiveObject["material"].get_uint64().get(value); error == SUCCESS)
+				[[likely]] {
 				primitive.materialIndex = static_cast<std::size_t>(value);
 			} else if (error != NO_SUCH_FIELD) {
 				return Error::InvalidGltf;
 			}
 
-			if (hasBit(config.extensions, Extensions::KHR_materials_variants) || hasBit(config.extensions, Extensions::KHR_draco_mesh_compression)) {
+			if (hasBit(config.extensions, Extensions::KHR_materials_variants) ||
+				hasBit(config.extensions, Extensions::KHR_draco_mesh_compression)) {
 				dom::object extensionsObject;
-				if (auto error = primitiveObject["extensions"].get_object().get(extensionsObject); error == SUCCESS) {
-					if (auto extensionError = parsePrimitiveExtensions(extensionsObject, primitive); extensionError != Error::None)
+				if (auto error = primitiveObject["extensions"].get_object().get(extensionsObject);
+					error == SUCCESS) {
+					if (auto extensionError = parsePrimitiveExtensions(extensionsObject, primitive);
+						extensionError != Error::None)
 						return extensionError;
 				} else if (error != NO_SUCH_FIELD) {
 					return Error::InvalidGltf;
@@ -3550,195 +3734,210 @@ fg::Error fg::Parser::parseMeshes(simdjson::dom::array& meshes, Asset& asset) {
 			mesh.primitives.emplace_back(std::move(primitive));
 		}
 
-        if (meshError = getJsonArray(meshObject, "weights", &array); meshError == Error::None) [[likely]] {
-	        mesh.weights = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(mesh.weights), resourceAllocator.get(), 0);
-            mesh.weights.reserve(array.size());
-            for (auto weightValue : array) {
-                double val;
-                if (weightValue.get_double().get(val) != SUCCESS) [[unlikely]] {
-                    return Error::InvalidGltf;
-                }
-                mesh.weights.emplace_back(static_cast<num>(val));
-            }
-        } else if (meshError != Error::MissingField && meshError != Error::None) {
-            return Error::InvalidGltf;
-        }
+		if (meshError = getJsonArray(meshObject, "weights", &array); meshError == Error::None)
+			[[likely]] {
+			mesh.weights =
+				FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(mesh.weights), resourceAllocator.get(), 0);
+			mesh.weights.reserve(array.size());
+			for (auto weightValue : array) {
+				double val;
+				if (weightValue.get_double().get(val) != SUCCESS) [[unlikely]] {
+					return Error::InvalidGltf;
+				}
+				mesh.weights.emplace_back(static_cast<num>(val));
+			}
+		} else if (meshError != Error::MissingField && meshError != Error::None) {
+			return Error::InvalidGltf;
+		}
 
 		if (config.extrasCallback != nullptr) {
 			dom::object extrasObject;
-			if (auto extrasError = meshObject["extras"].get_object().get(extrasObject); extrasError == SUCCESS) {
-				config.extrasCallback(&extrasObject, asset.meshes.size(), Category::Meshes, config.userPointer);
+			if (auto extrasError = meshObject["extras"].get_object().get(extrasObject);
+				extrasError == SUCCESS) {
+				config.extrasCallback(&extrasObject, asset.meshes.size(), Category::Meshes,
+									  config.userPointer);
 			} else if (extrasError != NO_SUCH_FIELD) {
 				return Error::InvalidGltf;
 			}
 		}
 
 		std::string_view name;
-        if (meshObject["name"].get_string().get(name) == SUCCESS) {
-	        mesh.name = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(mesh.name), resourceAllocator.get(), name);
-        }
+		if (meshObject["name"].get_string().get(name) == SUCCESS) {
+			mesh.name =
+				FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(mesh.name), resourceAllocator.get(), name);
+		}
 
-        asset.meshes.emplace_back(std::move(mesh));
-    }
+		asset.meshes.emplace_back(std::move(mesh));
+	}
 
 	return Error::None;
 }
 
 fg::Error fg::Parser::parseNodes(simdjson::dom::array& nodes, Asset& asset) {
-    using namespace simdjson;
+	using namespace simdjson;
 
-    asset.nodes.reserve(nodes.size());
-    for (auto nodeValue : nodes) {
-        Node node = {};
-        dom::object nodeObject;
-        if (nodeValue.get_object().get(nodeObject) != SUCCESS) [[unlikely]] {
-            return Error::InvalidGltf;
-        }
-
-        std::uint64_t index;
-        if (auto error = nodeObject["mesh"].get_uint64().get(index); error == SUCCESS) {
-            node.meshIndex = static_cast<std::size_t>(index);
-        } else if (error != NO_SUCH_FIELD) [[unlikely]] {
-			return Error::InvalidGltf;
-		}
-        if (auto error = nodeObject["skin"].get_uint64().get(index); error == SUCCESS) {
-            node.skinIndex = static_cast<std::size_t>(index);
-        } else if (error != NO_SUCH_FIELD) [[unlikely]] {
-			return Error::InvalidGltf;
-		}
-        if (auto error = nodeObject["camera"].get_uint64().get(index); error == SUCCESS) {
-            node.cameraIndex = static_cast<std::size_t>(index);
-        } else if (error != NO_SUCH_FIELD) [[unlikely]] {
+	asset.nodes.reserve(nodes.size());
+	for (auto nodeValue : nodes) {
+		Node node = {};
+		dom::object nodeObject;
+		if (nodeValue.get_object().get(nodeObject) != SUCCESS) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
-        dom::array array;
-        auto childError = getJsonArray(nodeObject, "children", &array);
-        if (childError == Error::None) [[likely]] {
-	        node.children = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(node.children), resourceAllocator.get(), 0);
+		std::uint64_t index;
+		if (auto error = nodeObject["mesh"].get_uint64().get(index); error == SUCCESS) {
+			node.meshIndex = static_cast<std::size_t>(index);
+		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
+			return Error::InvalidGltf;
+		}
+		if (auto error = nodeObject["skin"].get_uint64().get(index); error == SUCCESS) {
+			node.skinIndex = static_cast<std::size_t>(index);
+		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
+			return Error::InvalidGltf;
+		}
+		if (auto error = nodeObject["camera"].get_uint64().get(index); error == SUCCESS) {
+			node.cameraIndex = static_cast<std::size_t>(index);
+		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
+			return Error::InvalidGltf;
+		}
+
+		dom::array array;
+		auto childError = getJsonArray(nodeObject, "children", &array);
+		if (childError == Error::None) [[likely]] {
+			node.children = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(node.children),
+															resourceAllocator.get(), 0);
 			node.children.reserve(array.size());
-            for (auto childValue : array) {
-                if (childValue.get_uint64().get(index) != SUCCESS) [[unlikely]] {
-                    return Error::InvalidGltf;
-                }
+			for (auto childValue : array) {
+				if (childValue.get_uint64().get(index) != SUCCESS) [[unlikely]] {
+					return Error::InvalidGltf;
+				}
 
-                node.children.emplace_back(static_cast<std::size_t>(index));
-            }
-        } else if (childError != Error::MissingField) {
-            return childError;
-        }
+				node.children.emplace_back(static_cast<std::size_t>(index));
+			}
+		} else if (childError != Error::MissingField) {
+			return childError;
+		}
 
-        auto weightsError = getJsonArray(nodeObject, "weights", &array);
-        if (weightsError != Error::MissingField) {
-            if (weightsError != Error::None) {
-	            node.weights = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(node.weights), resourceAllocator.get(), 0);
-                node.weights.reserve(array.size());
-                for (auto weightValue : array) {
-                    double val;
-                    if (weightValue.get_double().get(val) != SUCCESS) [[unlikely]] {
-                        return Error::InvalidGltf;
-                    }
-                    node.weights.emplace_back(static_cast<num>(val));
-                }
-            } else {
-                return Error::InvalidGltf;
-            }
-        }
+		auto weightsError = getJsonArray(nodeObject, "weights", &array);
+		if (weightsError != Error::MissingField) {
+			if (weightsError != Error::None) {
+				node.weights = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(node.weights),
+															   resourceAllocator.get(), 0);
+				node.weights.reserve(array.size());
+				for (auto weightValue : array) {
+					double val;
+					if (weightValue.get_double().get(val) != SUCCESS) [[unlikely]] {
+						return Error::InvalidGltf;
+					}
+					node.weights.emplace_back(static_cast<num>(val));
+				}
+			} else {
+				return Error::InvalidGltf;
+			}
+		}
 
-        auto error = nodeObject["matrix"].get_array().get(array);
-        if (error == SUCCESS) [[likely]] {
-            if (array.size() != 16) [[unlikely]] {
-                return Error::InvalidGltf;
-            }
-            math::fmat4x4 transformMatrix;
-            std::size_t i = 0, j = 0;
+		auto error = nodeObject["matrix"].get_array().get(array);
+		if (error == SUCCESS) [[likely]] {
+			if (array.size() != 16) [[unlikely]] {
+				return Error::InvalidGltf;
+			}
+			math::fmat4x4 transformMatrix;
+			std::size_t i = 0, j = 0;
 			for (auto num : array) {
-                double val;
-                if (num.get_double().get(val) != SUCCESS) [[unlikely]] {
-                    return Error::InvalidGltf;
-                }
+				double val;
+				if (num.get_double().get(val) != SUCCESS) [[unlikely]] {
+					return Error::InvalidGltf;
+				}
 				transformMatrix.col(i)[j++] = static_cast<fastgltf::num>(val);
 				if (j == 4) {
 					j = 0;
 					++i;
 				}
-            }
+			}
 
-            if (hasBit(options, Options::DecomposeNodeMatrices)) {
-                TRS trs = {};
-                math::decomposeTransformMatrix(transformMatrix, trs.scale, trs.rotation, trs.translation);
-                node.transform = trs;
-            } else {
-                node.transform = transformMatrix;
-            }
-        } else if (error == NO_SUCH_FIELD) {
-            TRS trs = {};
+			if (hasBit(options, Options::DecomposeNodeMatrices)) {
+				TRS trs = {};
+				math::decomposeTransformMatrix(transformMatrix, trs.scale, trs.rotation,
+											   trs.translation);
+				node.transform = trs;
+			} else {
+				node.transform = transformMatrix;
+			}
+		} else if (error == NO_SUCH_FIELD) {
+			TRS trs = {};
 
-            // There's no matrix, let's see if there's scale, rotation, or rotation fields.
-            if (auto scaleError = nodeObject["scale"].get_array().get(array); scaleError == SUCCESS) [[likely]] {
-                if (array.size() != 3) [[unlikely]] {
-                    return Error::InvalidGltf;
-                }
-                auto i = 0U;
-                for (auto num : array) {
-                    double val;
-                    if (num.get_double().get(val) != SUCCESS) [[unlikely]] {
-                        return Error::InvalidGltf;
-                    }
-                    trs.scale[i] = static_cast<fastgltf::num>(val);
-                    ++i;
-                }
-            } else if (scaleError != NO_SUCH_FIELD) [[unlikely]] {
-                return Error::InvalidJson;
-            }
+			// There's no matrix, let's see if there's scale, rotation, or rotation fields.
+			if (auto scaleError = nodeObject["scale"].get_array().get(array); scaleError == SUCCESS)
+				[[likely]] {
+				if (array.size() != 3) [[unlikely]] {
+					return Error::InvalidGltf;
+				}
+				auto i = 0U;
+				for (auto num : array) {
+					double val;
+					if (num.get_double().get(val) != SUCCESS) [[unlikely]] {
+						return Error::InvalidGltf;
+					}
+					trs.scale[i] = static_cast<fastgltf::num>(val);
+					++i;
+				}
+			} else if (scaleError != NO_SUCH_FIELD) [[unlikely]] {
+				return Error::InvalidJson;
+			}
 
-            if (auto translationError = nodeObject["translation"].get_array().get(array); translationError == SUCCESS) [[likely]] {
-                if (array.size() != 3) [[unlikely]] {
-                    return Error::InvalidGltf;
-                }
-                auto i = 0U;
-                for (auto num : array) {
-                    double val;
-                    if (num.get_double().get(val) != SUCCESS) [[unlikely]] {
-                        return Error::InvalidGltf;
-                    }
-                    trs.translation[i] = static_cast<fastgltf::num>(val);
-                    ++i;
-                }
-            } else if (translationError != NO_SUCH_FIELD) [[unlikely]] {
-                return Error::InvalidGltf;
-            }
+			if (auto translationError = nodeObject["translation"].get_array().get(array);
+				translationError == SUCCESS) [[likely]] {
+				if (array.size() != 3) [[unlikely]] {
+					return Error::InvalidGltf;
+				}
+				auto i = 0U;
+				for (auto num : array) {
+					double val;
+					if (num.get_double().get(val) != SUCCESS) [[unlikely]] {
+						return Error::InvalidGltf;
+					}
+					trs.translation[i] = static_cast<fastgltf::num>(val);
+					++i;
+				}
+			} else if (translationError != NO_SUCH_FIELD) [[unlikely]] {
+				return Error::InvalidGltf;
+			}
 
-            if (auto rotationError = nodeObject["rotation"].get_array().get(array); rotationError == SUCCESS) [[likely]] {
-                if (array.size() != 4) [[unlikely]] {
-                    return Error::InvalidGltf;
-                }
-                auto i = 0U;
-                for (auto num : array) {
-                    double val;
-                    if (num.get_double().get(val) != SUCCESS) [[unlikely]] {
-                        return Error::InvalidGltf;
-                    }
-                    trs.rotation[i] = static_cast<fastgltf::num>(val);
-                    ++i;
-                }
-            } else if (rotationError != NO_SUCH_FIELD) [[unlikely]] {
-                return Error::InvalidGltf;
-            }
+			if (auto rotationError = nodeObject["rotation"].get_array().get(array);
+				rotationError == SUCCESS) [[likely]] {
+				if (array.size() != 4) [[unlikely]] {
+					return Error::InvalidGltf;
+				}
+				auto i = 0U;
+				for (auto num : array) {
+					double val;
+					if (num.get_double().get(val) != SUCCESS) [[unlikely]] {
+						return Error::InvalidGltf;
+					}
+					trs.rotation[i] = static_cast<fastgltf::num>(val);
+					++i;
+				}
+			} else if (rotationError != NO_SUCH_FIELD) [[unlikely]] {
+				return Error::InvalidGltf;
+			}
 
-            node.transform = trs;
-        }
+			node.transform = trs;
+		}
 
-        dom::object extensionsObject;
-        if (nodeObject["extensions"].get_object().get(extensionsObject) == SUCCESS) [[likely]] {
+		dom::object extensionsObject;
+		if (nodeObject["extensions"].get_object().get(extensionsObject) == SUCCESS) [[likely]] {
 			if (hasBit(config.extensions, Extensions::KHR_lights_punctual)) {
 				dom::object lightsObject;
-				if (extensionsObject[extensions::KHR_lights_punctual].get_object().get(lightsObject) == SUCCESS) [[likely]] {
+				if (extensionsObject[extensions::KHR_lights_punctual].get_object().get(
+						lightsObject) == SUCCESS) [[likely]] {
 					std::uint64_t light;
-					if (auto lightError = lightsObject["light"].get_uint64().get(light); lightError == SUCCESS) [[likely]] {
+					if (auto lightError = lightsObject["light"].get_uint64().get(light);
+						lightError == SUCCESS) [[likely]] {
 						node.lightIndex = static_cast<std::size_t>(light);
 					} else {
-						return lightError == NO_SUCH_FIELD || lightError == INCORRECT_TYPE ? Error::InvalidGltf : Error::InvalidJson;
+						return lightError == NO_SUCH_FIELD || lightError == INCORRECT_TYPE
+								   ? Error::InvalidGltf
+								   : Error::InvalidJson;
 					}
 				} else if (error != NO_SUCH_FIELD) {
 					return Error::InvalidGltf;
@@ -3747,14 +3946,20 @@ fg::Error fg::Parser::parseNodes(simdjson::dom::array& nodes, Asset& asset) {
 
 			if (hasBit(config.extensions, Extensions::EXT_mesh_gpu_instancing)) {
 				dom::object gpuInstancingObject;
-				if (auto instancingError = extensionsObject[extensions::EXT_mesh_gpu_instancing].get_object().get(gpuInstancingObject); instancingError == SUCCESS) [[likely]] {
+				if (auto instancingError =
+						extensionsObject[extensions::EXT_mesh_gpu_instancing].get_object().get(
+							gpuInstancingObject);
+					instancingError == SUCCESS) [[likely]] {
 					dom::object attributesObject;
 
-					if (gpuInstancingObject["attributes"].get_object().get(attributesObject) != SUCCESS) [[unlikely]] {
+					if (gpuInstancingObject["attributes"].get_object().get(attributesObject) !=
+						SUCCESS) [[unlikely]] {
 						return Error::InvalidGltf;
 					}
 
-					if (auto attributesError = parseAttributes(attributesObject, node.instancingAttributes); attributesError != Error::None) {
+					if (auto attributesError =
+							parseAttributes(attributesObject, node.instancingAttributes);
+						attributesError != Error::None) {
 						return attributesError;
 					}
 				} else if (instancingError != NO_SUCH_FIELD) {
@@ -3765,76 +3970,89 @@ fg::Error fg::Parser::parseNodes(simdjson::dom::array& nodes, Asset& asset) {
 #if FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES
 			if (hasBit(config.extensions, Extensions::KHR_physics_rigid_bodies)) {
 				dom::object physicsRigidBodiesObject;
-				if (auto rigidBodiesError = extensionsObject[extensions::KHR_physics_rigid_bodies].get_object().get(physicsRigidBodiesObject); rigidBodiesError == SUCCESS) [[likely]] {
-					const auto rigidBodyError = parsePhysicsRigidBody(physicsRigidBodiesObject, node);
+				if (auto rigidBodiesError =
+						extensionsObject[extensions::KHR_physics_rigid_bodies].get_object().get(
+							physicsRigidBodiesObject);
+					rigidBodiesError == SUCCESS) [[likely]] {
+					const auto rigidBodyError =
+						parsePhysicsRigidBody(physicsRigidBodiesObject, node);
 					if (rigidBodyError != Error::None) {
 						return rigidBodyError;
 					}
-			    } else if (rigidBodiesError != NO_SUCH_FIELD) {
+				} else if (rigidBodiesError != NO_SUCH_FIELD) {
 					return Error::InvalidGltf;
-			    }
+				}
 			}
 #endif
-        }
+		}
 
 		if (config.extrasCallback != nullptr) {
 			dom::object extrasObject;
-			if (auto extrasError = nodeObject["extras"].get_object().get(extrasObject); extrasError == SUCCESS) {
-				config.extrasCallback(&extrasObject, asset.nodes.size(), Category::Nodes, config.userPointer);
+			if (auto extrasError = nodeObject["extras"].get_object().get(extrasObject);
+				extrasError == SUCCESS) {
+				config.extrasCallback(&extrasObject, asset.nodes.size(), Category::Nodes,
+									  config.userPointer);
 			} else if (extrasError != NO_SUCH_FIELD) {
 				return Error::InvalidGltf;
 			}
 		}
 
-        std::string_view name;
-        if (nodeObject["name"].get_string().get(name) == SUCCESS) {
-	        node.name = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(node.name), resourceAllocator.get(), name);
-        }
+		std::string_view name;
+		if (nodeObject["name"].get_string().get(name) == SUCCESS) {
+			node.name =
+				FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(node.name), resourceAllocator.get(), name);
+		}
 
-        asset.nodes.emplace_back(std::move(node));
-    }
+		asset.nodes.emplace_back(std::move(node));
+	}
 
 	return Error::None;
 }
 
 fg::Error fg::Parser::parseSamplers(const simdjson::dom::array& samplers, Asset& asset) {
-    using namespace simdjson;
+	using namespace simdjson;
 
-    std::uint64_t number;
-    asset.samplers.reserve(samplers.size());
-    for (auto samplerValue : samplers) {
-        Sampler sampler = {};
-        dom::object samplerObject;
-        if (samplerValue.get_object().get(samplerObject) != SUCCESS) [[unlikely]] {
-            return Error::InvalidGltf;
-        }
-
-        if (auto error = samplerObject["magFilter"].get_uint64().get(number); error == SUCCESS) [[likely]] {
-            sampler.magFilter = static_cast<Filter>(number);
-        } else if (error != NO_SUCH_FIELD) [[unlikely]] {
-			return Error::InvalidGltf;
-		}
-        if (auto error = samplerObject["minFilter"].get_uint64().get(number); error == SUCCESS) [[likely]] {
-            sampler.minFilter = static_cast<Filter>(number);
-        } else if (error != NO_SUCH_FIELD) [[unlikely]] {
+	std::uint64_t number;
+	asset.samplers.reserve(samplers.size());
+	for (auto samplerValue : samplers) {
+		Sampler sampler = {};
+		dom::object samplerObject;
+		if (samplerValue.get_object().get(samplerObject) != SUCCESS) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
-        if (auto error = samplerObject["wrapS"].get_uint64().get(number); error == SUCCESS) [[likely]] {
-            sampler.wrapS = static_cast<Wrap>(number);
-        } else if (error != NO_SUCH_FIELD) [[unlikely]] {
-            return Error::InvalidGltf;
-        }
-        if (auto error = samplerObject["wrapT"].get_uint64().get(number); error == SUCCESS) [[likely]] {
-            sampler.wrapT = static_cast<Wrap>(number);
-        } else if (error != NO_SUCH_FIELD) [[unlikely]] {
-            return Error::InvalidGltf;
-        }
+		if (auto error = samplerObject["magFilter"].get_uint64().get(number); error == SUCCESS)
+			[[likely]] {
+			sampler.magFilter = static_cast<Filter>(number);
+		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
+			return Error::InvalidGltf;
+		}
+		if (auto error = samplerObject["minFilter"].get_uint64().get(number); error == SUCCESS)
+			[[likely]] {
+			sampler.minFilter = static_cast<Filter>(number);
+		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
+			return Error::InvalidGltf;
+		}
+
+		if (auto error = samplerObject["wrapS"].get_uint64().get(number); error == SUCCESS)
+			[[likely]] {
+			sampler.wrapS = static_cast<Wrap>(number);
+		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
+			return Error::InvalidGltf;
+		}
+		if (auto error = samplerObject["wrapT"].get_uint64().get(number); error == SUCCESS)
+			[[likely]] {
+			sampler.wrapT = static_cast<Wrap>(number);
+		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
+			return Error::InvalidGltf;
+		}
 
 		if (config.extrasCallback != nullptr) {
 			dom::object extrasObject;
-			if (auto extrasError = samplerObject["extras"].get_object().get(extrasObject); extrasError == SUCCESS) {
-				config.extrasCallback(&extrasObject, asset.samplers.size(), Category::Samplers, config.userPointer);
+			if (auto extrasError = samplerObject["extras"].get_object().get(extrasObject);
+				extrasError == SUCCESS) {
+				config.extrasCallback(&extrasObject, asset.samplers.size(), Category::Samplers,
+									  config.userPointer);
 			} else if (extrasError != NO_SUCH_FIELD) {
 				return Error::InvalidGltf;
 			}
@@ -3842,172 +4060,189 @@ fg::Error fg::Parser::parseSamplers(const simdjson::dom::array& samplers, Asset&
 
 		std::string_view name;
 		if (samplerObject["name"].get_string().get(name) == SUCCESS) {
-			sampler.name = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(sampler.name), resourceAllocator.get(), name);
+			sampler.name = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(sampler.name),
+														   resourceAllocator.get(), name);
 		}
 
 		asset.samplers.emplace_back(std::move(sampler));
-    }
+	}
 
 	return Error::None;
 }
 
 fg::Error fg::Parser::parseScenes(const simdjson::dom::array& scenes, Asset& asset) {
-    using namespace simdjson;
+	using namespace simdjson;
 
-    asset.scenes.reserve(scenes.size());
-    for (auto sceneValue : scenes) {
-        // The scene object can be completely empty
-        Scene scene = {};
-        dom::object sceneObject;
-        if (sceneValue.get_object().get(sceneObject) != SUCCESS) [[unlikely]] {
-            return Error::InvalidGltf;
-        }
+	asset.scenes.reserve(scenes.size());
+	for (auto sceneValue : scenes) {
+		// The scene object can be completely empty
+		Scene scene = {};
+		dom::object sceneObject;
+		if (sceneValue.get_object().get(sceneObject) != SUCCESS) [[unlikely]] {
+			return Error::InvalidGltf;
+		}
 
-        std::string_view name;
-        if (sceneObject["name"].get_string().get(name) == SUCCESS) {
-	        scene.name = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(scene.name), resourceAllocator.get(), name);
-        }
+		std::string_view name;
+		if (sceneObject["name"].get_string().get(name) == SUCCESS) {
+			scene.name = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(scene.name),
+														 resourceAllocator.get(), name);
+		}
 
 		if (config.extrasCallback != nullptr) {
 			dom::object extrasObject;
-			if (auto extrasError = sceneObject["extras"].get_object().get(extrasObject); extrasError == SUCCESS) {
-				config.extrasCallback(&extrasObject, asset.scenes.size(), Category::Scenes, config.userPointer);
+			if (auto extrasError = sceneObject["extras"].get_object().get(extrasObject);
+				extrasError == SUCCESS) {
+				config.extrasCallback(&extrasObject, asset.scenes.size(), Category::Scenes,
+									  config.userPointer);
 			} else if (extrasError != NO_SUCH_FIELD) {
 				return Error::InvalidGltf;
 			}
 		}
 
 		// Parse the array of nodes.
-        dom::array nodes;
-        auto nodeError = getJsonArray(sceneObject, "nodes", &nodes);
-        if (nodeError == Error::None) [[likely]] {
-	        scene.nodeIndices = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(scene.nodeIndices), resourceAllocator.get(), 0);
+		dom::array nodes;
+		auto nodeError = getJsonArray(sceneObject, "nodes", &nodes);
+		if (nodeError == Error::None) [[likely]] {
+			scene.nodeIndices = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(scene.nodeIndices),
+																resourceAllocator.get(), 0);
 			scene.nodeIndices.reserve(nodes.size());
-            for (auto nodeValue : nodes) {
-                std::uint64_t index;
-                if (nodeValue.get_uint64().get(index) != SUCCESS) [[unlikely]] {
-                    return Error::InvalidGltf;
-                }
+			for (auto nodeValue : nodes) {
+				std::uint64_t index;
+				if (nodeValue.get_uint64().get(index) != SUCCESS) [[unlikely]] {
+					return Error::InvalidGltf;
+				}
 
-                scene.nodeIndices.emplace_back(static_cast<std::size_t>(index));
-            }
+				scene.nodeIndices.emplace_back(static_cast<std::size_t>(index));
+			}
 
-            asset.scenes.emplace_back(std::move(scene));
-        } else if (nodeError != Error::MissingField) {
-            return nodeError;
-        }
-    }
+			asset.scenes.emplace_back(std::move(scene));
+		} else if (nodeError != Error::MissingField) {
+			return nodeError;
+		}
+	}
 
 	return Error::None;
 }
 
 fg::Error fg::Parser::parseSkins(const simdjson::dom::array& skins, Asset& asset) {
-    using namespace simdjson;
+	using namespace simdjson;
 
-    asset.skins.reserve(skins.size());
-    for (auto skinValue : skins) {
-        Skin skin = {};
-        dom::object skinObject;
-        if (skinValue.get_object().get(skinObject) != SUCCESS) [[unlikely]] {
-            return Error::InvalidGltf;
-        }
-
-        std::uint64_t index;
-        if (auto error = skinObject["inverseBindMatrices"].get_uint64().get(index); error == SUCCESS) [[likely]] {
-            skin.inverseBindMatrices = static_cast<std::size_t>(index);
-        } else if (error != NO_SUCH_FIELD) {
-			return Error::InvalidGltf;
-		}
-        if (auto error = skinObject["skeleton"].get_uint64().get(index); error == SUCCESS) [[likely]] {
-            skin.skeleton = static_cast<std::size_t>(index);
-        } else if (error != NO_SUCH_FIELD) {
+	asset.skins.reserve(skins.size());
+	for (auto skinValue : skins) {
+		Skin skin = {};
+		dom::object skinObject;
+		if (skinValue.get_object().get(skinObject) != SUCCESS) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
-        dom::array jointsArray;
-        if (skinObject["joints"].get_array().get(jointsArray) != SUCCESS) [[unlikely]] {
-            return Error::InvalidGltf;
-        }
-		skin.joints = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(skin.joints), resourceAllocator.get(), 0);
-        skin.joints.reserve(jointsArray.size());
-        for (auto jointValue : jointsArray) {
-            if (jointValue.get_uint64().get(index) != SUCCESS) [[unlikely]] {
-                return Error::InvalidGltf;
-            }
-            skin.joints.emplace_back(index);
-        }
+		std::uint64_t index;
+		if (auto error = skinObject["inverseBindMatrices"].get_uint64().get(index);
+			error == SUCCESS) [[likely]] {
+			skin.inverseBindMatrices = static_cast<std::size_t>(index);
+		} else if (error != NO_SUCH_FIELD) {
+			return Error::InvalidGltf;
+		}
+		if (auto error = skinObject["skeleton"].get_uint64().get(index); error == SUCCESS)
+			[[likely]] {
+			skin.skeleton = static_cast<std::size_t>(index);
+		} else if (error != NO_SUCH_FIELD) {
+			return Error::InvalidGltf;
+		}
+
+		dom::array jointsArray;
+		if (skinObject["joints"].get_array().get(jointsArray) != SUCCESS) [[unlikely]] {
+			return Error::InvalidGltf;
+		}
+		skin.joints =
+			FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(skin.joints), resourceAllocator.get(), 0);
+		skin.joints.reserve(jointsArray.size());
+		for (auto jointValue : jointsArray) {
+			if (jointValue.get_uint64().get(index) != SUCCESS) [[unlikely]] {
+				return Error::InvalidGltf;
+			}
+			skin.joints.emplace_back(index);
+		}
 
 		if (config.extrasCallback != nullptr) {
 			dom::object extrasObject;
-			if (auto extrasError = skinObject["extras"].get_object().get(extrasObject); extrasError == SUCCESS) {
-				config.extrasCallback(&extrasObject, asset.skins.size(), Category::Skins, config.userPointer);
+			if (auto extrasError = skinObject["extras"].get_object().get(extrasObject);
+				extrasError == SUCCESS) {
+				config.extrasCallback(&extrasObject, asset.skins.size(), Category::Skins,
+									  config.userPointer);
 			} else if (extrasError != NO_SUCH_FIELD) {
 				return Error::InvalidGltf;
 			}
 		}
 
 		std::string_view name;
-        if (skinObject["name"].get_string().get(name) == SUCCESS) {
-	        skin.name = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(skin.name), resourceAllocator.get(), name);
-        }
-        asset.skins.emplace_back(std::move(skin));
-    }
+		if (skinObject["name"].get_string().get(name) == SUCCESS) {
+			skin.name =
+				FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(skin.name), resourceAllocator.get(), name);
+		}
+		asset.skins.emplace_back(std::move(skin));
+	}
 
 	return Error::None;
 }
 
 fg::Error fg::Parser::parseTextures(const simdjson::dom::array& textures, Asset& asset) {
-    using namespace simdjson;
+	using namespace simdjson;
 
-    asset.textures.reserve(textures.size());
-    for (auto textureValue : textures) {
-        Texture texture;
-        dom::object textureObject;
-        if (textureValue.get_object().get(textureObject) != SUCCESS) [[unlikely]] {
-            return Error::InvalidGltf;
-        }
-
-        std::uint64_t sourceIndex;
-        if (auto error = textureObject["source"].get_uint64().get(sourceIndex); error == SUCCESS) [[likely]] {
-            texture.imageIndex = static_cast<std::size_t>(sourceIndex);
-        } else if (error != NO_SUCH_FIELD) {
+	asset.textures.reserve(textures.size());
+	for (auto textureValue : textures) {
+		Texture texture;
+		dom::object textureObject;
+		if (textureValue.get_object().get(textureObject) != SUCCESS) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
-        dom::object extensionsObject;
-        if (auto error = textureObject["extensions"].get_object().get(extensionsObject); error == SUCCESS) [[likely]] {
+		std::uint64_t sourceIndex;
+		if (auto error = textureObject["source"].get_uint64().get(sourceIndex); error == SUCCESS)
+			[[likely]] {
+			texture.imageIndex = static_cast<std::size_t>(sourceIndex);
+		} else if (error != NO_SUCH_FIELD) {
+			return Error::InvalidGltf;
+		}
+
+		dom::object extensionsObject;
+		if (auto error = textureObject["extensions"].get_object().get(extensionsObject);
+			error == SUCCESS) [[likely]] {
 			if (!parseTextureExtensions(texture, extensionsObject, config.extensions)) {
 				return Error::InvalidGltf;
 			}
-        } else if (error != NO_SUCH_FIELD) {
+		} else if (error != NO_SUCH_FIELD) {
 			return Error::InvalidGltf;
 		}
 
-        // The index of the sampler used by this texture. When undefined, a sampler with
-        // repeat wrapping and auto filtering SHOULD be used.
-        std::uint64_t samplerIndex;
-        if (auto error = textureObject["sampler"].get_uint64().get(samplerIndex); error == SUCCESS) [[likely]] {
-            texture.samplerIndex = static_cast<std::size_t>(samplerIndex);
-        } else if (error != NO_SUCH_FIELD) {
+		// The index of the sampler used by this texture. When undefined, a sampler with
+		// repeat wrapping and auto filtering SHOULD be used.
+		std::uint64_t samplerIndex;
+		if (auto error = textureObject["sampler"].get_uint64().get(samplerIndex); error == SUCCESS)
+			[[likely]] {
+			texture.samplerIndex = static_cast<std::size_t>(samplerIndex);
+		} else if (error != NO_SUCH_FIELD) {
 			return Error::InvalidGltf;
 		}
 
 		if (config.extrasCallback != nullptr) {
 			dom::object extrasObject;
-			if (auto extrasError = textureObject["extras"].get_object().get(extrasObject); extrasError == SUCCESS) {
-				config.extrasCallback(&extrasObject, asset.textures.size(), Category::Textures, config.userPointer);
+			if (auto extrasError = textureObject["extras"].get_object().get(extrasObject);
+				extrasError == SUCCESS) {
+				config.extrasCallback(&extrasObject, asset.textures.size(), Category::Textures,
+									  config.userPointer);
 			} else if (extrasError != NO_SUCH_FIELD) {
 				return Error::InvalidGltf;
 			}
 		}
 
 		std::string_view name;
-        if (textureObject["name"].get_string().get(name) == SUCCESS) {
-			texture.name = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(texture.name), resourceAllocator.get(), name);
-        }
+		if (textureObject["name"].get_string().get(name) == SUCCESS) {
+			texture.name = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(texture.name),
+														   resourceAllocator.get(), name);
+		}
 
-        asset.textures.emplace_back(std::move(texture));
-    }
+		asset.textures.emplace_back(std::move(texture));
+	}
 
 	return Error::None;
 }
@@ -4022,7 +4257,7 @@ fg::Error fg::Parser::parseShapes(const simdjson::dom::array& shapes, Asset& ass
 
 		dom::object shapeObject;
 		if (shapeValue.get_object().get(shapeObject) != SUCCESS) [[unlikely]] {
-		    return Error::InvalidGltf;
+			return Error::InvalidGltf;
 		}
 
 		std::string_view shapeTypeName;
@@ -4038,11 +4273,11 @@ fg::Error fg::Parser::parseShapes(const simdjson::dom::array& shapes, Asset& ass
 
 			double radius;
 			if (error = sphereObject["radius"].get_double().get(radius); error == SUCCESS) {
-				shape = SphereShape{ static_cast<num>(radius) };
-			} else if(error != NO_SUCH_FIELD) [[unlikely]] {
+				shape = SphereShape{static_cast<num>(radius)};
+			} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 				return Error::InvalidGltf;
 			}
-		} else if(error != NO_SUCH_FIELD) [[unlikely]] {
+		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
@@ -4050,13 +4285,13 @@ fg::Error fg::Parser::parseShapes(const simdjson::dom::array& shapes, Asset& ass
 		if (auto error = shapeObject["box"].get_object().get(boxObject); error == SUCCESS) {
 			if (shapeTypeName != "box") [[unlikely]] {
 				return Error::InvalidGltf;
-		    }
+			}
 
 			dom::array sizeArray;
 			if (error = boxObject["size"].get_array().get(sizeArray); error == SUCCESS) {
-			    if (sizeArray.size() != 3) {
+				if (sizeArray.size() != 3) {
 					return Error::InvalidGltf;
-			    }
+				}
 
 				auto& box = shape.emplace<BoxShape>();
 				auto curIndex = 0;
@@ -4071,7 +4306,7 @@ fg::Error fg::Parser::parseShapes(const simdjson::dom::array& shapes, Asset& ass
 					curIndex++;
 				}
 			} else if (error != NO_SUCH_FIELD) [[unlikely]] {
-			    return Error::InvalidGltf;
+				return Error::InvalidGltf;
 			}
 		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 			return Error::InvalidGltf;
@@ -4093,7 +4328,8 @@ fg::Error fg::Parser::parseShapes(const simdjson::dom::array& shapes, Asset& ass
 			}
 
 			double radiusBottom;
-			if (error = capsuleObject["radiusBottom"].get_double().get(radiusBottom); error == SUCCESS) {
+			if (error = capsuleObject["radiusBottom"].get_double().get(radiusBottom);
+				error == SUCCESS) {
 				capsule.radiusBottom = static_cast<num>(radiusBottom);
 			} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 				return Error::InvalidGltf;
@@ -4111,7 +4347,8 @@ fg::Error fg::Parser::parseShapes(const simdjson::dom::array& shapes, Asset& ass
 		}
 
 		dom::object cylinderObject;
-		if (auto error = shapeObject["cylinder"].get_object().get(cylinderObject); error == SUCCESS) {
+		if (auto error = shapeObject["cylinder"].get_object().get(cylinderObject);
+			error == SUCCESS) {
 			if (shapeTypeName != "cylinder") [[unlikely]] {
 				return Error::InvalidGltf;
 			}
@@ -4126,7 +4363,8 @@ fg::Error fg::Parser::parseShapes(const simdjson::dom::array& shapes, Asset& ass
 			}
 
 			double radiusBottom;
-			if (error = cylinderObject["radiusBottom"].get_double().get(radiusBottom); error == SUCCESS) {
+			if (error = cylinderObject["radiusBottom"].get_double().get(radiusBottom);
+				error == SUCCESS) {
 				cylinder.radiusBottom = static_cast<num>(radiusBottom);
 			} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 				return Error::InvalidGltf;
@@ -4145,8 +4383,10 @@ fg::Error fg::Parser::parseShapes(const simdjson::dom::array& shapes, Asset& ass
 
 		if (config.extrasCallback != nullptr) {
 			dom::object extrasObject;
-			if (auto extrasError = shapeObject["extras"].get_object().get(extrasObject); extrasError == SUCCESS) {
-				config.extrasCallback(&extrasObject, asset.shapes.size() - 1, Category::Shapes, config.userPointer);
+			if (auto extrasError = shapeObject["extras"].get_object().get(extrasObject);
+				extrasError == SUCCESS) {
+				config.extrasCallback(&extrasObject, asset.shapes.size() - 1, Category::Shapes,
+									  config.userPointer);
 			} else if (extrasError != NO_SUCH_FIELD) [[unlikely]] {
 				return Error::InvalidGltf;
 			}
@@ -4158,7 +4398,8 @@ fg::Error fg::Parser::parseShapes(const simdjson::dom::array& shapes, Asset& ass
 #endif
 
 #if FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES
-fg::Error fg::Parser::parsePhysicsMaterials(const simdjson::dom::array& physicsMaterials, Asset& asset) {
+fg::Error fg::Parser::parsePhysicsMaterials(const simdjson::dom::array& physicsMaterials,
+											Asset& asset) {
 	using namespace simdjson;
 
 	asset.physicsMaterials.reserve(physicsMaterials.size());
@@ -4170,44 +4411,51 @@ fg::Error fg::Parser::parsePhysicsMaterials(const simdjson::dom::array& physicsM
 		}
 
 		double staticFriction;
-		if (auto error = materialObject["staticFriction"].get_double().get(staticFriction); error == SUCCESS) {
-		   material.staticFriction = static_cast<num>(staticFriction);
+		if (auto error = materialObject["staticFriction"].get_double().get(staticFriction);
+			error == SUCCESS) {
+			material.staticFriction = static_cast<num>(staticFriction);
 		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
 		double dynamicFriction;
-		if (auto error = materialObject["dynamicFriction"].get_double().get(dynamicFriction); error == SUCCESS) {
-		   material.dynamicFriction = static_cast<num>(dynamicFriction);
+		if (auto error = materialObject["dynamicFriction"].get_double().get(dynamicFriction);
+			error == SUCCESS) {
+			material.dynamicFriction = static_cast<num>(dynamicFriction);
 		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
 		double restitution;
-		if (auto error = materialObject["restitution"].get_double().get(restitution); error == SUCCESS) {
-		   material.restitution = static_cast<num>(restitution);
+		if (auto error = materialObject["restitution"].get_double().get(restitution);
+			error == SUCCESS) {
+			material.restitution = static_cast<num>(restitution);
 		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
 		std::string_view frictionCombine;
-		if (auto error = materialObject["frictionCombine"].get_string().get(frictionCombine); error == SUCCESS) {
+		if (auto error = materialObject["frictionCombine"].get_string().get(frictionCombine);
+			error == SUCCESS) {
 			material.frictionCombine = getCombineMode(frictionCombine);
 		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
 		std::string_view restitutionCombine;
-		if (auto error = materialObject["restitutionCombine"].get_string().get(restitutionCombine); error == SUCCESS) {
-		   material.restitutionCombine = getCombineMode(restitutionCombine);
+		if (auto error = materialObject["restitutionCombine"].get_string().get(restitutionCombine);
+			error == SUCCESS) {
+			material.restitutionCombine = getCombineMode(restitutionCombine);
 		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
 		if (config.extrasCallback != nullptr) {
 			dom::object extrasObject;
-			if (auto extrasError = materialObject["extras"].get_object().get(extrasObject); extrasError == SUCCESS) {
-				config.extrasCallback(&extrasObject, asset.physicsMaterials.size() - 1, Category::PhysicsMaterials, config.userPointer);
+			if (auto extrasError = materialObject["extras"].get_object().get(extrasObject);
+				extrasError == SUCCESS) {
+				config.extrasCallback(&extrasObject, asset.physicsMaterials.size() - 1,
+									  Category::PhysicsMaterials, config.userPointer);
 			} else if (extrasError != NO_SUCH_FIELD) [[unlikely]] {
 				return Error::InvalidGltf;
 			}
@@ -4217,7 +4465,8 @@ fg::Error fg::Parser::parsePhysicsMaterials(const simdjson::dom::array& physicsM
 	return Error::None;
 }
 
-fg::Error fg::Parser::parseCollisionFilters(const simdjson::dom::array& collisionFilters, Asset& asset) {
+fg::Error fg::Parser::parseCollisionFilters(const simdjson::dom::array& collisionFilters,
+											Asset& asset) {
 	using namespace simdjson;
 
 	asset.collisionFilters.reserve(collisionFilters.size());
@@ -4230,7 +4479,9 @@ fg::Error fg::Parser::parseCollisionFilters(const simdjson::dom::array& collisio
 		}
 
 		dom::array collisionSystems;
-		if (auto error = collisionFilterObject["collisionSystems"].get_array().get(collisionSystems); error == SUCCESS) {
+		if (auto error =
+				collisionFilterObject["collisionSystems"].get_array().get(collisionSystems);
+			error == SUCCESS) {
 			collisionFilter.collisionSystems.reserve(collisionSystems.size());
 			for (auto systemNameValue : collisionSystems) {
 				std::string_view systemName;
@@ -4244,13 +4495,16 @@ fg::Error fg::Parser::parseCollisionFilters(const simdjson::dom::array& collisio
 			return Error::InvalidGltf;
 		}
 
-	    // A glTF isn't allowed to have both
-		if (collisionFilterObject["collideWithSystems"].error() == SUCCESS && collisionFilterObject["notCollideWithSystems"].error() == SUCCESS) [[unlikely]] {
+		// A glTF isn't allowed to have both
+		if (collisionFilterObject["collideWithSystems"].error() == SUCCESS &&
+			collisionFilterObject["notCollideWithSystems"].error() == SUCCESS) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
 		dom::array collideWithSystems;
-		if (auto error = collisionFilterObject["collideWithSystems"].get_array().get(collideWithSystems); error == SUCCESS) {
+		if (auto error =
+				collisionFilterObject["collideWithSystems"].get_array().get(collideWithSystems);
+			error == SUCCESS) {
 			collisionFilter.collideWithSystems.reserve(collideWithSystems.size());
 			for (auto systemNameValue : collideWithSystems) {
 				std::string_view systemName;
@@ -4265,7 +4519,9 @@ fg::Error fg::Parser::parseCollisionFilters(const simdjson::dom::array& collisio
 		}
 
 		dom::array notCollideWithSystems;
-		if (auto error = collisionFilterObject["notCollideWithSystems"].get_array().get(notCollideWithSystems); error == SUCCESS) {
+		if (auto error = collisionFilterObject["notCollideWithSystems"].get_array().get(
+				notCollideWithSystems);
+			error == SUCCESS) {
 			collisionFilter.notCollideWithSystems.reserve(notCollideWithSystems.size());
 			for (auto systemNameValue : notCollideWithSystems) {
 				std::string_view systemName;
@@ -4281,8 +4537,10 @@ fg::Error fg::Parser::parseCollisionFilters(const simdjson::dom::array& collisio
 
 		if (config.extrasCallback != nullptr) {
 			dom::object extrasObject;
-			if (auto extrasError = collisionFilterObject["extras"].get_object().get(extrasObject); extrasError == SUCCESS) {
-				config.extrasCallback(&extrasObject, asset.collisionFilters.size() - 1, Category::CollisionFilters, config.userPointer);
+			if (auto extrasError = collisionFilterObject["extras"].get_object().get(extrasObject);
+				extrasError == SUCCESS) {
+				config.extrasCallback(&extrasObject, asset.collisionFilters.size() - 1,
+									  Category::CollisionFilters, config.userPointer);
 			} else if (extrasError != NO_SUCH_FIELD) [[unlikely]] {
 				return Error::InvalidGltf;
 			}
@@ -4293,11 +4551,11 @@ fg::Error fg::Parser::parseCollisionFilters(const simdjson::dom::array& collisio
 }
 
 fg::Error fg::Parser::parsePhysicsJoints(const simdjson::dom::array& physicsJoints, Asset& asset) {
-	using namespace simdjson; 
+	using namespace simdjson;
 
 	asset.physicsJoints.reserve(physicsJoints.size());
 	for (auto physicsJointValue : physicsJoints) {
-	    auto& physicsJoint = asset.physicsJoints.emplace_back();
+		auto& physicsJoint = asset.physicsJoints.emplace_back();
 
 		dom::object physicsJointObject;
 		if (physicsJointValue.get_object().get(physicsJointObject) != SUCCESS) [[unlikely]] {
@@ -4307,19 +4565,21 @@ fg::Error fg::Parser::parsePhysicsJoints(const simdjson::dom::array& physicsJoin
 		dom::array limitsArray;
 		if (physicsJointValue["limits"].get_array().get(limitsArray) == SUCCESS) {
 			physicsJoint.limits.reserve(limitsArray.size());
-            for (auto limitValue : limitsArray) {
+			for (auto limitValue : limitsArray) {
 				auto& limit = physicsJoint.limits.emplace_back();
 				dom::object limitObject;
 				if (limitValue.get_object().get(limitObject) != SUCCESS) [[unlikely]] {
-			        return Error::InvalidGltf;
-				}
-
-				if(limitObject["linearAxes"].error() == SUCCESS && limitObject["angularAxes"].error() == SUCCESS) [[unlikely]] {
-				    // A limit may only have one of these
 					return Error::InvalidGltf;
 				}
 
-				if (limitObject["linearAxes"].error() != SUCCESS && limitObject["angularAxes"].error() != SUCCESS) [[unlikely]] {
+				if (limitObject["linearAxes"].error() == SUCCESS &&
+					limitObject["angularAxes"].error() == SUCCESS) [[unlikely]] {
+					// A limit may only have one of these
+					return Error::InvalidGltf;
+				}
+
+				if (limitObject["linearAxes"].error() != SUCCESS &&
+					limitObject["angularAxes"].error() != SUCCESS) [[unlikely]] {
 					// A limit MUST have one of these
 					return Error::InvalidGltf;
 				}
@@ -4328,7 +4588,7 @@ fg::Error fg::Parser::parsePhysicsJoints(const simdjson::dom::array& physicsJoin
 				if (auto error = limitObject["min"].get_double().get(limitMin); error == SUCCESS) {
 					limit.min = static_cast<num>(limitMin);
 				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
-				    return Error::InvalidGltf;
+					return Error::InvalidGltf;
 				}
 
 				double limitMax;
@@ -4339,25 +4599,28 @@ fg::Error fg::Parser::parsePhysicsJoints(const simdjson::dom::array& physicsJoin
 				}
 
 				double stiffness;
-				if (auto error = limitObject["stiffness"].get_double().get(stiffness); error == SUCCESS) {
+				if (auto error = limitObject["stiffness"].get_double().get(stiffness);
+					error == SUCCESS) {
 					limit.stiffness = static_cast<num>(stiffness);
 				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
 				double damping;
-				if (auto error = limitObject["damping"].get_double().get(damping); error == SUCCESS) {
+				if (auto error = limitObject["damping"].get_double().get(damping);
+					error == SUCCESS) {
 					limit.damping = static_cast<num>(damping);
 				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
-				    return Error::InvalidGltf;
+					return Error::InvalidGltf;
 				}
 
 				dom::array linearAxesArray;
-				if (auto error = limitObject["linearAxes"].get_array().get(linearAxesArray); error == SUCCESS) {
+				if (auto error = limitObject["linearAxes"].get_array().get(linearAxesArray);
+					error == SUCCESS) {
 					limit.linearAxes.reserve(linearAxesArray.size());
-					for(auto axisValue : linearAxesArray) {
+					for (auto axisValue : linearAxesArray) {
 						std::uint64_t axis;
-						if(axisValue.get_uint64().get(axis) == SUCCESS && axis <= 2) [[likely]] {
+						if (axisValue.get_uint64().get(axis) == SUCCESS && axis <= 2) [[likely]] {
 							limit.linearAxes.emplace_back(static_cast<uint8_t>(axis));
 						} else {
 							return Error::InvalidGltf;
@@ -4368,7 +4631,8 @@ fg::Error fg::Parser::parsePhysicsJoints(const simdjson::dom::array& physicsJoin
 				}
 
 				dom::array angularAxesArray;
-				if (auto error = limitObject["angularAxes"].get_array().get(angularAxesArray); error == SUCCESS) {
+				if (auto error = limitObject["angularAxes"].get_array().get(angularAxesArray);
+					error == SUCCESS) {
 					limit.angularAxes.reserve(angularAxesArray.size());
 					for (auto axisValue : angularAxesArray) {
 						std::uint64_t axis;
@@ -4381,14 +4645,15 @@ fg::Error fg::Parser::parsePhysicsJoints(const simdjson::dom::array& physicsJoin
 				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
-            }
+			}
 		}
 
 		dom::array driveArray;
-		if (auto error = physicsJointValue["drives"].get_array().get(driveArray); error == SUCCESS) {
+		if (auto error = physicsJointValue["drives"].get_array().get(driveArray);
+			error == SUCCESS) {
 			physicsJoint.drives.reserve(driveArray.size());
 			for (auto driveValue : driveArray) {
-			    auto& drive = physicsJoint.drives.emplace_back();
+				auto& drive = physicsJoint.drives.emplace_back();
 				dom::object driveObject;
 				if (driveValue.get_object().get(driveObject) != SUCCESS) [[unlikely]] {
 					return Error::InvalidGltf;
@@ -4411,18 +4676,18 @@ fg::Error fg::Parser::parsePhysicsJoints(const simdjson::dom::array& physicsJoin
 					drive.mode = getDriveMode(mode);
 					if (drive.mode == DriveMode::Invalid) [[unlikely]] {
 						return Error::InvalidGltf;
-				    }
+					}
 				} else {
 					return Error::InvalidGltf;
 				}
 
 				uint64_t axis;
 				if (driveValue["axis"].get_uint64().get(axis) == SUCCESS) [[likely]] {
-				    if (axis < 3) {
+					if (axis < 3) {
 						drive.axis = static_cast<uint8_t>(axis);
-				    } else [[unlikely]] {
+					} else [[unlikely]] {
 						return Error::InvalidGltf;
-				    }
+					}
 				} else {
 					return Error::InvalidGltf;
 				}
@@ -4444,8 +4709,9 @@ fg::Error fg::Parser::parsePhysicsJoints(const simdjson::dom::array& physicsJoin
 				}
 
 				double positionTarget;
-				if (error = driveValue["positionTarget"].get_double().get(positionTarget); error == SUCCESS) {
-				    drive.positionTarget = static_cast<num>(positionTarget);
+				if (error = driveValue["positionTarget"].get_double().get(positionTarget);
+					error == SUCCESS) {
+					drive.positionTarget = static_cast<num>(positionTarget);
 				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
@@ -4465,7 +4731,8 @@ fg::Error fg::Parser::parsePhysicsJoints(const simdjson::dom::array& physicsJoin
 				}
 
 				double velocityTarget;
-				if (error = driveValue["velocityTarget"].get_double().get(velocityTarget); error == SUCCESS) {
+				if (error = driveValue["velocityTarget"].get_double().get(velocityTarget);
+					error == SUCCESS) {
 					drive.velocityTarget = static_cast<num>(velocityTarget);
 				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
@@ -4479,13 +4746,15 @@ fg::Error fg::Parser::parsePhysicsJoints(const simdjson::dom::array& physicsJoin
 				}
 			}
 		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
-    		return Error::InvalidGltf;
+			return Error::InvalidGltf;
 		}
 
 		if (config.extrasCallback != nullptr) {
 			dom::object extrasObject;
-			if (auto extrasError = physicsJointValue["extras"].get_object().get(extrasObject); extrasError == SUCCESS) {
-				config.extrasCallback(&extrasObject, asset.physicsJoints.size() - 1, Category::PhysicsJoints, config.userPointer);
+			if (auto extrasError = physicsJointValue["extras"].get_object().get(extrasObject);
+				extrasError == SUCCESS) {
+				config.extrasCallback(&extrasObject, asset.physicsJoints.size() - 1,
+									  Category::PhysicsJoints, config.userPointer);
 			} else if (extrasError != NO_SUCH_FIELD) [[unlikely]] {
 				return Error::InvalidGltf;
 			}
@@ -4495,14 +4764,16 @@ fg::Error fg::Parser::parsePhysicsJoints(const simdjson::dom::array& physicsJoin
 	return Error::None;
 }
 
-fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_rigid_bodies, Node& node) {
+fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_rigid_bodies,
+											Node& node) {
 	using namespace simdjson;
 
 	node.physicsRigidBody = std::make_unique<PhysicsRigidBody>();
 	auto& rigidBody = *node.physicsRigidBody;
 
 	dom::object motionObject;
-	if (auto error = khr_physics_rigid_bodies["motion"].get_object().get(motionObject); error == SUCCESS) {
+	if (auto error = khr_physics_rigid_bodies["motion"].get_object().get(motionObject);
+		error == SUCCESS) {
 		auto& motion = rigidBody.motion.emplace();
 
 		bool isKinematic;
@@ -4520,7 +4791,8 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 		}
 
 		dom::array centerOfMassArray;
-		if (error = motionObject["centerOfMass"].get_array().get(centerOfMassArray); error == SUCCESS) {
+		if (error = motionObject["centerOfMass"].get_array().get(centerOfMassArray);
+			error == SUCCESS) {
 			if (centerOfMassArray.size() != 3) [[unlikely]] {
 				return Error::InvalidGltf;
 			}
@@ -4539,7 +4811,8 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 		}
 
 		dom::array inertiaDiagonalArray;
-		if (error = motionObject["inertiaDiagonal"].get_array().get(inertiaDiagonalArray); error == SUCCESS) {
+		if (error = motionObject["inertiaDiagonal"].get_array().get(inertiaDiagonalArray);
+			error == SUCCESS) {
 			if (inertiaDiagonalArray.size() != 3) [[unlikely]] {
 				return Error::InvalidGltf;
 			}
@@ -4563,7 +4836,8 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 		}
 
 		dom::array inertialOrientationArray;
-		if (error = motionObject["inertialOrientation"].get_array().get(inertialOrientationArray); error == SUCCESS) {
+		if (error = motionObject["inertialOrientation"].get_array().get(inertialOrientationArray);
+			error == SUCCESS) {
 			if (inertialOrientationArray.size() != 4) [[unlikely]] {
 				return Error::InvalidGltf;
 			}
@@ -4587,7 +4861,8 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 		}
 
 		dom::array linearVelocityArray;
-		if (error = motionObject["linearVelocity"].get_array().get(linearVelocityArray); error == SUCCESS) {
+		if (error = motionObject["linearVelocity"].get_array().get(linearVelocityArray);
+			error == SUCCESS) {
 			if (linearVelocityArray.size() != 3) [[unlikely]] {
 				return Error::InvalidGltf;
 			}
@@ -4607,7 +4882,8 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 		}
 
 		dom::array angularVelocityArray;
-		if (error = motionObject["angularVelocity"].get_array().get(angularVelocityArray); error == SUCCESS) {
+		if (error = motionObject["angularVelocity"].get_array().get(angularVelocityArray);
+			error == SUCCESS) {
 			if (angularVelocityArray.size() != 3) [[unlikely]] {
 				return Error::InvalidGltf;
 			}
@@ -4626,7 +4902,8 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 		}
 
 		double gravityFactor;
-		if (error = motionObject["gravityFactor"].get_double().get(gravityFactor); error == SUCCESS) {
+		if (error = motionObject["gravityFactor"].get_double().get(gravityFactor);
+			error == SUCCESS) {
 			motion.gravityFactor = static_cast<num>(gravityFactor);
 		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 			return Error::InvalidGltf;
@@ -4637,13 +4914,15 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 	}
 
 	dom::object colliderObject;
-	if (auto error = khr_physics_rigid_bodies["collider"].get_object().get(colliderObject); error == SUCCESS) {
+	if (auto error = khr_physics_rigid_bodies["collider"].get_object().get(colliderObject);
+		error == SUCCESS) {
 		auto& collider = rigidBody.collider.emplace();
 
 		dom::object geometryObject;
 		if (colliderObject["geometry"].get_object().get(geometryObject) == SUCCESS) [[likely]] {
 			std::uint64_t shape;
-			if (error = geometryObject["shape"].get_uint64().get(shape); error == SUCCESS) [[likely]] {
+			if (error = geometryObject["shape"].get_uint64().get(shape); error == SUCCESS)
+				[[likely]] {
 				collider.geometry.shape = static_cast<std::size_t>(shape);
 			} else if (error != NO_SUCH_FIELD) {
 				return Error::InvalidGltf;
@@ -4665,14 +4944,16 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 		}
 
 		std::uint64_t physicsMaterial;
-		if (error = colliderObject["physicsMaterial"].get_uint64().get(physicsMaterial); error == SUCCESS) {
+		if (error = colliderObject["physicsMaterial"].get_uint64().get(physicsMaterial);
+			error == SUCCESS) {
 			collider.physicsMaterial = static_cast<std::size_t>(physicsMaterial);
 		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
 		std::uint64_t collisionFilter;
-		if (error = colliderObject["collisionFilter"].get_uint64().get(collisionFilter); error == SUCCESS) {
+		if (error = colliderObject["collisionFilter"].get_uint64().get(collisionFilter);
+			error == SUCCESS) {
 			collider.collisionFilter = static_cast<std::size_t>(collisionFilter);
 		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 			return Error::InvalidGltf;
@@ -4683,13 +4964,15 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 	}
 
 	dom::object triggerObject;
-	if (auto error = khr_physics_rigid_bodies["trigger"].get_object().get(triggerObject); error == SUCCESS) {
+	if (auto error = khr_physics_rigid_bodies["trigger"].get_object().get(triggerObject);
+		error == SUCCESS) {
 		dom::object geometryObject;
 		if (error = triggerObject["geometry"].get_object().get(geometryObject); error == SUCCESS) {
 			auto& geometryTrigger = rigidBody.trigger.emplace().emplace<GeometryTrigger>();
 
 			std::uint64_t shape;
-			if (error = geometryObject["shape"].get_uint64().get(shape); error == SUCCESS) [[likely]] {
+			if (error = geometryObject["shape"].get_uint64().get(shape); error == SUCCESS)
+				[[likely]] {
 				geometryTrigger.geometry.shape = static_cast<std::size_t>(shape);
 			} else if (error != NO_SUCH_FIELD) {
 				return Error::InvalidGltf;
@@ -4707,9 +4990,11 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 				return Error::InvalidGltf;
 			}
 
-			// The trigger can only have a collision filter if it has geometry, otherwise it defers to the nodes
+			// The trigger can only have a collision filter if it has geometry, otherwise it defers
+			// to the nodes
 			std::uint64_t collisionFilter;
-			if (error = triggerObject["collisionFilter"].get_uint64().get(collisionFilter); error == SUCCESS) {
+			if (error = triggerObject["collisionFilter"].get_uint64().get(collisionFilter);
+				error == SUCCESS) {
 				geometryTrigger.collisionFilter = static_cast<std::size_t>(collisionFilter);
 			} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 				return Error::InvalidGltf;
@@ -4737,13 +5022,14 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
-	    
+
 	} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 		return Error::InvalidGltf;
 	}
 
 	dom::object jointObject;
-	if (auto error = khr_physics_rigid_bodies["joint"].get_object().get(jointObject); error == SUCCESS) {
+	if (auto error = khr_physics_rigid_bodies["joint"].get_object().get(jointObject);
+		error == SUCCESS) {
 		auto& joint = rigidBody.joint.emplace();
 		std::uint64_t connectedNodeId;
 		if (jointObject["connectedNode"].get_uint64().get(connectedNodeId) == SUCCESS) [[likely]] {
@@ -4759,10 +5045,11 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 			return Error::InvalidGltf;
 		}
 
-		if (error = jointObject["enableCollision"].get_bool().get(joint.enableCollision); error != SUCCESS && error != NO_SUCH_FIELD) [[unlikely]] {
+		if (error = jointObject["enableCollision"].get_bool().get(joint.enableCollision);
+			error != SUCCESS && error != NO_SUCH_FIELD) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
-	    
+
 	} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 		return Error::InvalidGltf;
 	}
@@ -4787,122 +5074,128 @@ fg::GltfType fg::determineGltfFileType(GltfDataGetter& data) {
 	data.read(begin.data(), begin.size());
 	data.reset();
 	for (const auto& i : begin) {
-		if (static_cast<char>(i) == ' ')
-			continue;
-		if (static_cast<char>(i) == '{')
-			return GltfType::glTF;
+		if (static_cast<char>(i) == ' ') continue;
+		if (static_cast<char>(i) == '{') return GltfType::glTF;
 	}
 
 	return GltfType::Invalid;
 }
 
 fg::Parser::Parser(Extensions extensionsToLoad) noexcept {
-    std::call_once(crcInitialisation, initialiseCrc);
-    jsonParser = std::make_unique<simdjson::dom::parser>();
-    config.extensions = extensionsToLoad;
+	std::call_once(crcInitialisation, initialiseCrc);
+	jsonParser = std::make_unique<simdjson::dom::parser>();
+	config.extensions = extensionsToLoad;
 }
 
-fg::Parser::Parser(Parser&& other) noexcept : jsonParser(std::move(other.jsonParser)), config(other.config) {}
+fg::Parser::Parser(Parser&& other) noexcept
+	: jsonParser(std::move(other.jsonParser)), config(other.config) {}
 
 fg::Parser& fg::Parser::operator=(Parser&& other) noexcept {
-    jsonParser = std::move(other.jsonParser);
-    config = other.config;
-    return *this;
+	jsonParser = std::move(other.jsonParser);
+	config = other.config;
+	return *this;
 }
 
 fg::Parser::~Parser() = default;
 
-fg::Expected<fg::Asset> fg::Parser::loadGltf(GltfDataGetter& data, fs::path _directory, Options _options, Category categories) {
-    auto type = fastgltf::determineGltfFileType(data);
+fg::Expected<fg::Asset> fg::Parser::loadGltf(GltfDataGetter& data, fs::path _directory,
+											 Options _options, Category categories) {
+	auto type = fastgltf::determineGltfFileType(data);
 
-    if (type == fastgltf::GltfType::glTF) {
-        return loadGltfJson(data, std::move(_directory), _options, categories);
-    }
+	if (type == fastgltf::GltfType::glTF) {
+		return loadGltfJson(data, std::move(_directory), _options, categories);
+	}
 
-    if (type == fastgltf::GltfType::GLB) {
-        return loadGltfBinary(data, std::move(_directory), _options, categories);
-    }
+	if (type == fastgltf::GltfType::GLB) {
+		return loadGltfBinary(data, std::move(_directory), _options, categories);
+	}
 
-    return Error::InvalidFileData;
+	return Error::InvalidFileData;
 }
 
-fg::Expected<fg::Asset> fg::Parser::loadGltfJson(GltfDataGetter& data, fs::path _directory, Options _options, Category categories) {
-    using namespace simdjson;
+fg::Expected<fg::Asset> fg::Parser::loadGltfJson(GltfDataGetter& data, fs::path _directory,
+												 Options _options, Category categories) {
+	using namespace simdjson;
 
 	options = _options;
 	directory = std::move(_directory);
 
 #if !defined(__ANDROID__)
-    // If we never have to load the files ourselves, we're fine with the directory being invalid/blank.
-    if (std::error_code ec; hasBit(_options, Options::LoadExternalBuffers) && (!fs::is_directory(directory, ec) || ec)) {
-        return Error::InvalidPath;
-    }
+	// If we never have to load the files ourselves, we're fine with the directory being
+	// invalid/blank.
+	if (std::error_code ec; hasBit(_options, Options::LoadExternalBuffers) &&
+							(!fs::is_directory(directory, ec) || ec)) {
+		return Error::InvalidPath;
+	}
 #endif
 
 	data.reset();
 	auto jsonSpan = data.read(data.totalSize(), SIMDJSON_PADDING);
 	padded_string_view view(reinterpret_cast<const std::uint8_t*>(jsonSpan.data()),
-									  data.totalSize(),
-									  data.totalSize() + SIMDJSON_PADDING);
+							data.totalSize(), data.totalSize() + SIMDJSON_PADDING);
 	dom::object root;
-    if (auto error = jsonParser->parse(view).get(root); error != SUCCESS) [[unlikely]] {
-	    return Error::InvalidJson;
-    }
+	if (auto error = jsonParser->parse(view).get(root); error != SUCCESS) [[unlikely]] {
+		return Error::InvalidJson;
+	}
 
 	return parse(root, categories);
 }
 
-fg::Expected<fg::Asset> fg::Parser::loadGltfBinary(GltfDataGetter& data, fs::path _directory, Options _options, Category categories) {
-    using namespace simdjson;
+fg::Expected<fg::Asset> fg::Parser::loadGltfBinary(GltfDataGetter& data, fs::path _directory,
+												   Options _options, Category categories) {
+	using namespace simdjson;
 
 	options = _options;
 	directory = std::move(_directory);
 
-    // If we never have to load the files ourselves, we're fine with the directory being invalid/blank.
-    if (std::error_code ec; hasBit(options, Options::LoadExternalBuffers) && (!fs::is_directory(directory, ec) || ec)) {
-	    return Error::InvalidPath;
-    }
+	// If we never have to load the files ourselves, we're fine with the directory being
+	// invalid/blank.
+	if (std::error_code ec;
+		hasBit(options, Options::LoadExternalBuffers) && (!fs::is_directory(directory, ec) || ec)) {
+		return Error::InvalidPath;
+	}
 
 	data.reset();
 
-    auto header = readBinaryHeader(data);
-    if (header.magic != binaryGltfHeaderMagic) {
-	    return Error::InvalidGLB;
-    }
+	auto header = readBinaryHeader(data);
+	if (header.magic != binaryGltfHeaderMagic) {
+		return Error::InvalidGLB;
+	}
 	if (header.version != 2) {
 		return Error::UnsupportedVersion;
 	}
-    if (header.length > data.totalSize()) {
-	    return Error::InvalidGLB;
-    }
+	if (header.length > data.totalSize()) {
+		return Error::InvalidGLB;
+	}
 
-    // The glTF 2 spec specifies that in GLB files the order of chunks is predefined. Specifically,
-    //  1. JSON chunk
-    //  2. BIN chunk (optional)
-    auto jsonChunk = readBinaryChunk(data);
-    if (jsonChunk.chunkType != binaryGltfJsonChunkMagic || jsonChunk.chunkLength > data.totalSize() - sizeof(BinaryGltfHeader)) {
-	    return Error::InvalidGLB;
-    }
+	// The glTF 2 spec specifies that in GLB files the order of chunks is predefined. Specifically,
+	//  1. JSON chunk
+	//  2. BIN chunk (optional)
+	auto jsonChunk = readBinaryChunk(data);
+	if (jsonChunk.chunkType != binaryGltfJsonChunkMagic ||
+		jsonChunk.chunkLength > data.totalSize() - sizeof(BinaryGltfHeader)) {
+		return Error::InvalidGLB;
+	}
 
-    // Create a string view of the JSON chunk in the GLB data buffer. The documentation of parse()
-    // says the padding can be initialised to anything, apparently. Therefore, this should work.
+	// Create a string view of the JSON chunk in the GLB data buffer. The documentation of parse()
+	// says the padding can be initialised to anything, apparently. Therefore, this should work.
 	auto jsonSpan = data.read(jsonChunk.chunkLength, SIMDJSON_PADDING);
-    simdjson::padded_string_view jsonChunkView(reinterpret_cast<const std::uint8_t*>(jsonSpan.data()),
-                                               jsonChunk.chunkLength,
-                                               jsonChunk.chunkLength + SIMDJSON_PADDING);
+	simdjson::padded_string_view jsonChunkView(
+		reinterpret_cast<const std::uint8_t*>(jsonSpan.data()), jsonChunk.chunkLength,
+		jsonChunk.chunkLength + SIMDJSON_PADDING);
 
 	simdjson::dom::object root;
-    if (jsonParser->parse(jsonChunkView).get(root) != SUCCESS) [[unlikely]] {
-	    return Error::InvalidJson;
-    }
+	if (jsonParser->parse(jsonChunkView).get(root) != SUCCESS) [[unlikely]] {
+		return Error::InvalidJson;
+	}
 
-    // Is there enough room for another chunk header?
-    if (header.length > (data.bytesRead() + sizeof(BinaryGltfChunk))) {
-        auto binaryChunk = readBinaryChunk(data);
+	// Is there enough room for another chunk header?
+	if (header.length > (data.bytesRead() + sizeof(BinaryGltfChunk))) {
+		auto binaryChunk = readBinaryChunk(data);
 
-        if (binaryChunk.chunkType != binaryGltfDataChunkMagic) {
-	        return Error::InvalidGLB;
-        }
+		if (binaryChunk.chunkType != binaryGltfDataChunkMagic) {
+			return Error::InvalidGLB;
+		}
 
 		// TODO: Somehow allow skipping the binary part in the future?
 		if (binaryChunk.chunkLength != 0) {
@@ -4930,204 +5223,205 @@ fg::Expected<fg::Asset> fg::Parser::loadGltfBinary(GltfDataGetter& data, fs::pat
 				glbBuffer = std::move(vectorData);
 			}
 		}
-    }
+	}
 
 	return parse(root, categories);
 }
 
-void fg::Parser::setBufferAllocationCallback(BufferMapCallback* mapCallback, BufferUnmapCallback* unmapCallback) noexcept {
-	if (mapCallback == nullptr)
-		unmapCallback = nullptr;
+void fg::Parser::setBufferAllocationCallback(BufferMapCallback* mapCallback,
+											 BufferUnmapCallback* unmapCallback) noexcept {
+	if (mapCallback == nullptr) unmapCallback = nullptr;
 	config.mapCallback = mapCallback;
 	config.unmapCallback = unmapCallback;
 }
 
 void fg::Parser::setBase64DecodeCallback(Base64DecodeCallback* decodeCallback) noexcept {
-    config.decodeCallback = decodeCallback;
+	config.decodeCallback = decodeCallback;
 }
 
-void fg::Parser::setExtrasParseCallback(ExtrasParseCallback *extrasCallback) noexcept {
+void fg::Parser::setExtrasParseCallback(ExtrasParseCallback* extrasCallback) noexcept {
 	config.extrasCallback = extrasCallback;
 }
 
-void fg::Parser::setUserPointer(void* pointer) noexcept {
-    config.userPointer = pointer;
-}
+void fg::Parser::setUserPointer(void* pointer) noexcept { config.userPointer = pointer; }
 #pragma endregion
 
 #pragma region Exporter
 void fg::prettyPrintJson(std::string& json) {
-    std::size_t i = 0;
-    std::size_t depth = 0;
-    auto insertNewline = [&i, &depth, &json]() {
-        json.insert(i, 1, '\n');
-        json.insert(i + 1, depth, '\t');
-        i += 1 + depth;
-    };
+	std::size_t i = 0;
+	std::size_t depth = 0;
+	auto insertNewline = [&i, &depth, &json]() {
+		json.insert(i, 1, '\n');
+		json.insert(i + 1, depth, '\t');
+		i += 1 + depth;
+	};
 
-    while (i < json.size()) {
-        if (json[i] == '"') {
-            // Skip to the end of the string
-            do {
-                ++i;
-                if (json[i] == '"' && json[i - 1] != '\\') {
-                    break;
-                }
-            } while (true);
-            ++i; // Skip over the last "
-        }
+	while (i < json.size()) {
+		if (json[i] == '"') {
+			// Skip to the end of the string
+			do {
+				++i;
+				if (json[i] == '"' && json[i - 1] != '\\') {
+					break;
+				}
+			} while (true);
+			++i;  // Skip over the last "
+		}
 
-        switch (json[i]) {
-            case '{': case '[':
-                ++depth;
-                ++i; // Insert \n after the character
-                insertNewline();
-                break;
-            case '}': case ']':
-                --depth;
-                insertNewline();
-                ++i; // Insert \n before the character
-                break;
-            case ',':
-                ++i;  // Insert \n after the character
-                insertNewline();
-                break;
-            default:
-                ++i;
-                break;
-        }
-    }
+		switch (json[i]) {
+			case '{':
+			case '[':
+				++depth;
+				++i;  // Insert \n after the character
+				insertNewline();
+				break;
+			case '}':
+			case ']':
+				--depth;
+				insertNewline();
+				++i;  // Insert \n before the character
+				break;
+			case ',':
+				++i;  // Insert \n after the character
+				insertNewline();
+				break;
+			default: ++i; break;
+		}
+	}
 }
 
 namespace fastgltf {
-	static void escapeString(std::string& string) {
-		std::size_t i = 0;
-		do {
-			switch (string[i]) {
-				case '\"': {
-					constexpr std::string_view s = "\\\"";
-					string.replace(i, 1, s);
-					i += s.size();
-					break;
-				}
-				case '\\': {
-					constexpr std::string_view s = "\\\\";
-					string.replace(i, 1, s);
-					i += s.size();
-					break;
-				}
-				default:
-					break;
+static void escapeString(std::string& string) {
+	std::size_t i = 0;
+	do {
+		switch (string[i]) {
+			case '\"': {
+				constexpr std::string_view s = "\\\"";
+				string.replace(i, 1, s);
+				i += s.size();
+				break;
 			}
-			++i;
-		} while (i < string.size());
-	}
-
-	/**
-	 * Normalizes the path using lexically_normal, calls generic_string to always use forward slashes,
-	 * and escapes any necessary characters.
-	 */
-	static std::string normalizeAndFormatPath(const fs::path& path) {
-		auto string = path.lexically_normal().generic_string();
-		escapeString(string);
-		return string;
-	}
-
-	// replacement for std::to_string that uses simdjson's grisu2 implementation, which is
-	// (1) bidirectionally lossless (std::to_string is not)
-	// (2) quite a lot faster than std::to_chars and std::to_string.
-	template <typename T>
-	std::string to_string_fp(const T& value) {
-		static_assert(std::is_floating_point_v<T>, "T needs to be a floating point type");
-		char buffer[30] = {};
-
-		// TODO: Include a own copy of grisu2 instead of accessing functions from simdjson's internal namespace?
-		auto* end = simdjson::internal::to_chars(std::begin(buffer), std::end(buffer), static_cast<double>(value));
-		return {std::begin(buffer), end};
-	}
-
-    std::string to_string(const math::fvec2 value) {
-		return to_string_fp(value[0]) + ',' + to_string_fp(value[1]);
-	}
-
-	std::string to_string(const math::fvec3 value) {
-		return to_string_fp(value[0]) + ',' + to_string_fp(value[1]) + ',' + to_string_fp(value[2]);
-	}
-
-	std::string to_string(const math::fvec4 value) {
-		return to_string_fp(value[0]) + ',' + to_string_fp(value[1]) + ',' + to_string_fp(value[2]) + ',' + to_string_fp(value[3]);
-	}
-
-	void writeTextureInfo(std::string& json, const TextureInfo* info, const TextureInfoType type = TextureInfoType::Standard) {
-		json += '{';
-		json += "\"index\":" + std::to_string(info->textureIndex);
-		if (info->texCoordIndex != 0) {
-			json += ",\"texCoord\":" + std::to_string(info->texCoordIndex);
+			case '\\': {
+				constexpr std::string_view s = "\\\\";
+				string.replace(i, 1, s);
+				i += s.size();
+				break;
+			}
+			default: break;
 		}
-		if (type == TextureInfoType::NormalTexture) {
-			json += ",\"scale\":" + to_string_fp(reinterpret_cast<const NormalTextureInfo*>(info)->scale);
-		} else if (type == TextureInfoType::OcclusionTexture) {
-			json += ",\"strength\":" + to_string_fp(reinterpret_cast<const OcclusionTextureInfo*>(info)->strength);
-		}
+		++i;
+	} while (i < string.size());
+}
 
-		if (info->transform != nullptr) {
-			json += R"(,"extensions":{"KHR_texture_transform":{)";
-			const auto& transform = *info->transform;
-			if (transform.uvOffset[0] != 0.0 || transform.uvOffset[1] != 0.0) {
-				json += "\"offset\":[" + to_string_fp(transform.uvOffset[0]) + ',' + to_string_fp(transform.uvOffset[1]) + ']';
-			}
-			if (transform.rotation != 0.0) {
-				if (json.back() != '{') json += ',';
-				json += "\"rotation\":" + to_string_fp(transform.rotation);
-			}
-			if (transform.uvScale[0] != 1.0 || transform.uvScale[1] != 1.0) {
-				if (json.back() != '{') json += ',';
-				json += "\"scale\":[" + to_string_fp(transform.uvScale[0]) + ',' + to_string_fp(transform.uvScale[1]) + ']';
-			}
-			if (transform.texCoordIndex.has_value()) {
-				if (json.back() != '{') json += ',';
-				json += "\"texCoord\":" + std::to_string(transform.texCoordIndex.value());
-			}
-			json += "}}";
-		}
+/**
+ * Normalizes the path using lexically_normal, calls generic_string to always use forward slashes,
+ * and escapes any necessary characters.
+ */
+static std::string normalizeAndFormatPath(const fs::path& path) {
+	auto string = path.lexically_normal().generic_string();
+	escapeString(string);
+	return string;
+}
 
-		json += '}';
+// replacement for std::to_string that uses simdjson's grisu2 implementation, which is
+// (1) bidirectionally lossless (std::to_string is not)
+// (2) quite a lot faster than std::to_chars and std::to_string.
+template <typename T>
+std::string to_string_fp(const T& value) {
+	static_assert(std::is_floating_point_v<T>, "T needs to be a floating point type");
+	char buffer[30] = {};
+
+	// TODO: Include a own copy of grisu2 instead of accessing functions from simdjson's internal
+	// namespace?
+	auto* end = simdjson::internal::to_chars(std::begin(buffer), std::end(buffer),
+											 static_cast<double>(value));
+	return {std::begin(buffer), end};
+}
+
+std::string to_string(const math::fvec2 value) {
+	return to_string_fp(value[0]) + ',' + to_string_fp(value[1]);
+}
+
+std::string to_string(const math::fvec3 value) {
+	return to_string_fp(value[0]) + ',' + to_string_fp(value[1]) + ',' + to_string_fp(value[2]);
+}
+
+std::string to_string(const math::fvec4 value) {
+	return to_string_fp(value[0]) + ',' + to_string_fp(value[1]) + ',' + to_string_fp(value[2]) +
+		   ',' + to_string_fp(value[3]);
+}
+
+void writeTextureInfo(std::string& json, const TextureInfo* info,
+					  const TextureInfoType type = TextureInfoType::Standard) {
+	json += '{';
+	json += "\"index\":" + std::to_string(info->textureIndex);
+	if (info->texCoordIndex != 0) {
+		json += ",\"texCoord\":" + std::to_string(info->texCoordIndex);
 	}
-} // namespace fastgltf
+	if (type == TextureInfoType::NormalTexture) {
+		json +=
+			",\"scale\":" + to_string_fp(reinterpret_cast<const NormalTextureInfo*>(info)->scale);
+	} else if (type == TextureInfoType::OcclusionTexture) {
+		json += ",\"strength\":" +
+				to_string_fp(reinterpret_cast<const OcclusionTextureInfo*>(info)->strength);
+	}
+
+	if (info->transform != nullptr) {
+		json += R"(,"extensions":{"KHR_texture_transform":{)";
+		const auto& transform = *info->transform;
+		if (transform.uvOffset[0] != 0.0 || transform.uvOffset[1] != 0.0) {
+			json += "\"offset\":[" + to_string_fp(transform.uvOffset[0]) + ',' +
+					to_string_fp(transform.uvOffset[1]) + ']';
+		}
+		if (transform.rotation != 0.0) {
+			if (json.back() != '{') json += ',';
+			json += "\"rotation\":" + to_string_fp(transform.rotation);
+		}
+		if (transform.uvScale[0] != 1.0 || transform.uvScale[1] != 1.0) {
+			if (json.back() != '{') json += ',';
+			json += "\"scale\":[" + to_string_fp(transform.uvScale[0]) + ',' +
+					to_string_fp(transform.uvScale[1]) + ']';
+		}
+		if (transform.texCoordIndex.has_value()) {
+			if (json.back() != '{') json += ',';
+			json += "\"texCoord\":" + std::to_string(transform.texCoordIndex.value());
+		}
+		json += "}}";
+	}
+
+	json += '}';
+}
+}  // namespace fastgltf
 
 std::string fg::escapeString(std::string_view string) {
-    std::string ret(string);
+	std::string ret(string);
 	escapeString(ret);
-    return ret;
+	return ret;
 }
 
 void fg::Exporter::setBufferPath(fs::path folder) {
-    if (!folder.is_relative()) {
-        return;
-    }
-    bufferFolder = std::move(folder);
+	if (!folder.is_relative()) {
+		return;
+	}
+	bufferFolder = std::move(folder);
 }
 
 void fg::Exporter::setImagePath(fs::path folder) {
-    if (!folder.is_relative()) {
-        return;
-    }
-    imageFolder = std::move(folder);
+	if (!folder.is_relative()) {
+		return;
+	}
+	imageFolder = std::move(folder);
 }
 
 void fg::Exporter::setExtrasWriteCallback(ExtrasWriteCallback* callback) noexcept {
 	extrasWriteCallback = callback;
 }
 
-void fg::Exporter::setUserPointer(void* pointer) noexcept {
-	userPointer = pointer;
-}
+void fg::Exporter::setUserPointer(void* pointer) noexcept { userPointer = pointer; }
 
 void fg::Exporter::writeAccessors(const Asset& asset, std::string& json) {
-	if (asset.accessors.empty())
-		return;
-	if (json.back() == ']' || json.back() == '}')
-		json += ',';
+	if (asset.accessors.empty()) return;
+	if (json.back() == ']' || json.back() == '}') json += ',';
 
 	json += R"("accessors":[)";
 	for (auto it = asset.accessors.begin(); it != asset.accessors.end(); ++it) {
@@ -5149,8 +5443,7 @@ void fg::Exporter::writeAccessors(const Asset& asset, std::string& json) {
 			json += ",\"bufferView\":" + std::to_string(it->bufferViewIndex.value());
 		}
 
-		if (it->sparse.has_value())
-		{
+		if (it->sparse.has_value()) {
 			json += R"(,"sparse":{)";
 			const auto& sparse = *it->sparse;
 			json += "\"count\":" + std::to_string(sparse.count) + ',';
@@ -5160,7 +5453,8 @@ void fg::Exporter::writeAccessors(const Asset& asset, std::string& json) {
 				json += "\"byteOffset\":" + std::to_string(sparse.indicesByteOffset) + ',';
 			}
 			// only get the lower 13 bits
-			json += "\"componentType\":" + std::to_string(getGLComponentType(sparse.indexComponentType));
+			json += "\"componentType\":" +
+					std::to_string(getGLComponentType(sparse.indexComponentType));
 			json += "},";
 			json += "\"values\":{";
 			json += "\"bufferView\":" + std::to_string(sparse.valuesBufferView);
@@ -5170,9 +5464,10 @@ void fg::Exporter::writeAccessors(const Asset& asset, std::string& json) {
 			json += "}}";
 		}
 
-		auto writeMinMax = [&](const std::optional<AccessorBoundsArray>& ref, const std::string_view name) {
+		auto writeMinMax = [&](const std::optional<AccessorBoundsArray>& ref,
+							   const std::string_view name) {
 			if (!ref.has_value())
-				return; // This is valid, since min/max are only required on specific accessors.
+				return;  // This is valid, since min/max are only required on specific accessors.
 			json += ",\"" + std::string(name) + "\":[";
 
 			for (std::size_t i = 0; i < ref->size(); ++i) {
@@ -5181,8 +5476,7 @@ void fg::Exporter::writeAccessors(const Asset& asset, std::string& json) {
 				} else if (ref->isType<std::int64_t>()) {
 					json += std::to_string(ref->get<std::int64_t>(i));
 				}
-				if (i + 1 < ref->size())
-					json += ',';
+				if (i + 1 < ref->size()) json += ',';
 			}
 			json += ']';
 		};
@@ -5190,28 +5484,25 @@ void fg::Exporter::writeAccessors(const Asset& asset, std::string& json) {
 		writeMinMax(it->min, "min");
 
 		if (extrasWriteCallback != nullptr) {
-			auto extras = extrasWriteCallback(uabs(std::distance(asset.accessors.begin(), it)), fastgltf::Category::Accessors, userPointer);
+			auto extras = extrasWriteCallback(uabs(std::distance(asset.accessors.begin(), it)),
+											  fastgltf::Category::Accessors, userPointer);
 			if (extras.has_value()) {
 				json += std::string(",\"extras\":") + *extras;
 			}
 		}
 
-		if (!it->name.empty())
-			json += R"(,"name":")" + fg::escapeString(it->name) + '"';
+		if (!it->name.empty()) json += R"(,"name":")" + fg::escapeString(it->name) + '"';
 
 		json += '}';
-		if (uabs(std::distance(asset.accessors.begin(), it)) + 1 <asset.accessors.size())
+		if (uabs(std::distance(asset.accessors.begin(), it)) + 1 < asset.accessors.size())
 			json += ',';
 	}
 	json += ']';
 }
 
-void fg::Exporter::writeAnimations(const Asset& asset, std::string& json)
-{
-	if (asset.animations.empty())
-		return;
-	if (json.back() == ']' || json.back() == '}')
-		json += ',';
+void fg::Exporter::writeAnimations(const Asset& asset, std::string& json) {
+	if (asset.animations.empty()) return;
+	if (json.back() == ']' || json.back() == '}') json += ',';
 
 	json += R"("animations":[)";
 	for (auto it = asset.animations.begin(); it != asset.animations.end(); ++it) {
@@ -5227,18 +5518,10 @@ void fg::Exporter::writeAnimations(const Asset& asset, std::string& json)
 			}
 			json += R"("path":")";
 			switch (ci->path) {
-			case fg::AnimationPath::Translation:
-				json += "translation";
-				break;
-			case fg::AnimationPath::Rotation:
-				json += "rotation";
-				break;
-			case fg::AnimationPath::Scale:
-				json += "scale";
-				break;
-			case fg::AnimationPath::Weights:
-				json += "weights";
-				break;
+				case fg::AnimationPath::Translation: json += "translation"; break;
+				case fg::AnimationPath::Rotation:    json += "rotation"; break;
+				case fg::AnimationPath::Scale:       json += "scale"; break;
+				case fg::AnimationPath::Weights:     json += "weights"; break;
 			}
 			json += "\"}}";
 
@@ -5270,14 +5553,14 @@ void fg::Exporter::writeAnimations(const Asset& asset, std::string& json)
 		json += ']';
 
 		if (extrasWriteCallback != nullptr) {
-			auto extras = extrasWriteCallback(uabs(std::distance(asset.animations.begin(), it)), fastgltf::Category::Animations, userPointer);
+			auto extras = extrasWriteCallback(uabs(std::distance(asset.animations.begin(), it)),
+											  fastgltf::Category::Animations, userPointer);
 			if (extras.has_value()) {
 				json += std::string(",\"extras\":") + *extras;
 			}
 		}
 
-		if (!it->name.empty())
-			json += R"(,"name":")" + fg::escapeString(it->name) + '"';
+		if (!it->name.empty()) json += R"(,"name":")" + fg::escapeString(it->name) + '"';
 
 		json += '}';
 		if (uabs(std::distance(asset.animations.begin(), it)) + 1 < asset.animations.size())
@@ -5287,81 +5570,77 @@ void fg::Exporter::writeAnimations(const Asset& asset, std::string& json)
 }
 
 void fg::Exporter::writeBuffers(const Asset& asset, std::string& json) {
-	if (asset.buffers.empty())
-		return;
-	if (json.back() == ']' || json.back() == '}')
-		json += ',';
+	if (asset.buffers.empty()) return;
+	if (json.back() == ']' || json.back() == '}') json += ',';
 
 	json += "\"buffers\":[";
 	for (auto it = asset.buffers.begin(); it != asset.buffers.end(); ++it) {
 		json += '{';
 
-        auto bufferIdx = uabs(std::distance(asset.buffers.begin(), it));
-		std::visit(visitor {
-			[&](auto&) {
-				// Covers BufferView and CustomBuffer.
-				errorCode = Error::InvalidGltf;
-			},
-			[&]([[maybe_unused]] const sources::Array& vector) {
-                if (bufferIdx == 0 && exportingBinary) {
-                    bufferPaths.emplace_back(std::nullopt);
-                    return;
-                }
-                auto path = getBufferFilePath(asset, bufferIdx);
-                json += std::string(R"("uri":")") + fg::normalizeAndFormatPath(path) + '"' + ',';
-                bufferPaths.emplace_back(path);
-			},
-			[&]([[maybe_unused]] const sources::Vector& vector) {
-				if (bufferIdx == 0 && exportingBinary) {
-					bufferPaths.emplace_back(std::nullopt);
-					return;
-				}
-				auto path = getBufferFilePath(asset, bufferIdx);
-				json += std::string(R"("uri":")") + fg::normalizeAndFormatPath(path) + '"' + ',';
-				bufferPaths.emplace_back(path);
-			},
-			[&]([[maybe_unused]] const sources::ByteView& view) {
-				if (bufferIdx == 0 && exportingBinary) {
-					bufferPaths.emplace_back(std::nullopt);
-					return;
-				}
-                auto path = getBufferFilePath(asset, bufferIdx);
-                json += std::string(R"("uri":")") + fg::normalizeAndFormatPath(path) + '"' + ',';
-                bufferPaths.emplace_back(path);
-			},
-			[&](const sources::URI& uri) {
-				json += std::string(R"("uri":")") + fg::escapeString(uri.uri.string()) + '"' + ',';
-                bufferPaths.emplace_back(std::nullopt);
-			},
-			[&]([[maybe_unused]] const sources::Fallback& fallback) {
-				json += R"("extensions":{"EXT_meshopt_compression":{"fallback":true}},)";
+		auto bufferIdx = uabs(std::distance(asset.buffers.begin(), it));
+		std::visit(visitor{
+					   [&](auto&) {
+			// Covers BufferView and CustomBuffer.
+			errorCode = Error::InvalidGltf;
+		},
+					   [&]([[maybe_unused]] const sources::Array& vector) {
+			if (bufferIdx == 0 && exportingBinary) {
 				bufferPaths.emplace_back(std::nullopt);
-			},
-		}, it->data);
+				return;
+			}
+			auto path = getBufferFilePath(asset, bufferIdx);
+			json += std::string(R"("uri":")") + fg::normalizeAndFormatPath(path) + '"' + ',';
+			bufferPaths.emplace_back(path);
+		},
+					   [&]([[maybe_unused]] const sources::Vector& vector) {
+			if (bufferIdx == 0 && exportingBinary) {
+				bufferPaths.emplace_back(std::nullopt);
+				return;
+			}
+			auto path = getBufferFilePath(asset, bufferIdx);
+			json += std::string(R"("uri":")") + fg::normalizeAndFormatPath(path) + '"' + ',';
+			bufferPaths.emplace_back(path);
+		},
+					   [&]([[maybe_unused]] const sources::ByteView& view) {
+			if (bufferIdx == 0 && exportingBinary) {
+				bufferPaths.emplace_back(std::nullopt);
+				return;
+			}
+			auto path = getBufferFilePath(asset, bufferIdx);
+			json += std::string(R"("uri":")") + fg::normalizeAndFormatPath(path) + '"' + ',';
+			bufferPaths.emplace_back(path);
+		},
+					   [&](const sources::URI& uri) {
+			json += std::string(R"("uri":")") + fg::escapeString(uri.uri.string()) + '"' + ',';
+			bufferPaths.emplace_back(std::nullopt);
+		},
+					   [&]([[maybe_unused]] const sources::Fallback& fallback) {
+			json += R"("extensions":{"EXT_meshopt_compression":{"fallback":true}},)";
+			bufferPaths.emplace_back(std::nullopt);
+		},
+				   },
+				   it->data);
 
 		json += "\"byteLength\":" + std::to_string(it->byteLength);
 
 		if (extrasWriteCallback != nullptr) {
-			auto extras = extrasWriteCallback(uabs(std::distance(asset.buffers.begin(), it)), fastgltf::Category::Buffers, userPointer);
+			auto extras = extrasWriteCallback(uabs(std::distance(asset.buffers.begin(), it)),
+											  fastgltf::Category::Buffers, userPointer);
 			if (extras.has_value()) {
 				json += std::string(",\"extras\":") + *extras;
 			}
 		}
 
-		if (!it->name.empty())
-			json += R"(,"name":")" + fg::escapeString(it->name) + '"';
+		if (!it->name.empty()) json += R"(,"name":")" + fg::escapeString(it->name) + '"';
 		json += '}';
-		if (uabs(std::distance(asset.buffers.begin(), it)) + 1 <asset.buffers.size())
-			json += ',';
+		if (uabs(std::distance(asset.buffers.begin(), it)) + 1 < asset.buffers.size()) json += ',';
 	}
 	json += "]";
 }
 
 void fg::Exporter::writeBufferViews(const Asset& asset, std::string& json) {
-	if (asset.bufferViews.empty())
-		return;
-	if (json.back() == ']' || json.back() == '}')
-		json += ',';
+	if (asset.bufferViews.empty()) return;
+	if (json.back() == ']' || json.back() == '}') json += ',';
 
 	json += "\"bufferViews\":[";
 	for (auto it = asset.bufferViews.begin(); it != asset.bufferViews.end(); ++it) {
@@ -5382,176 +5661,169 @@ void fg::Exporter::writeBufferViews(const Asset& asset, std::string& json) {
 			json += ",\"target\":" + std::to_string(to_underlying(it->target.value()));
 		}
 
-        if (it->meshoptCompression != nullptr) {
-            json += R"(,"extensions":{"EXT_meshopt_compression":{)";
-            const auto& meshopt = *it->meshoptCompression;
-            json += "\"buffer\":" + std::to_string(meshopt.bufferIndex);
-            if (meshopt.byteOffset != 0) {
-                json += ",\"byteOffset\":" + std::to_string(meshopt.byteOffset);
-            }
-            json += ",\"byteLength\":" + std::to_string(meshopt.byteLength);
-            json += ",\"byteStride\":" + std::to_string(meshopt.byteStride);
-            json += ",\"count\":" + std::to_string(meshopt.count);
+		if (it->meshoptCompression != nullptr) {
+			json += R"(,"extensions":{"EXT_meshopt_compression":{)";
+			const auto& meshopt = *it->meshoptCompression;
+			json += "\"buffer\":" + std::to_string(meshopt.bufferIndex);
+			if (meshopt.byteOffset != 0) {
+				json += ",\"byteOffset\":" + std::to_string(meshopt.byteOffset);
+			}
+			json += ",\"byteLength\":" + std::to_string(meshopt.byteLength);
+			json += ",\"byteStride\":" + std::to_string(meshopt.byteStride);
+			json += ",\"count\":" + std::to_string(meshopt.count);
 
-            json += ",\"mode\":";
-            if (meshopt.mode == MeshoptCompressionMode::Attributes) {
-                json += "\"ATTRIBUTES\"";
-            } else if (meshopt.mode == MeshoptCompressionMode::Triangles) {
-                json += "\"TRIANGLES\"";
-            } else if (meshopt.mode == MeshoptCompressionMode::Indices) {
-                json += "\"INDICES\"";
-            }
-            if (meshopt.filter != MeshoptCompressionFilter::None) {
-                json += ",\"filter\":";
-                if (meshopt.filter == MeshoptCompressionFilter::Exponential) {
-                    json += "\"EXPONENTIAL\"";
-                } else if (meshopt.filter == MeshoptCompressionFilter::Quaternion) {
-                    json += "\"QUATERNION\"";
-                } else if (meshopt.filter == MeshoptCompressionFilter::Octahedral) {
-                    json += "\"OCTAHEDRAL\"";
-                }
-            }
-            json += "}}";
-        }
+			json += ",\"mode\":";
+			if (meshopt.mode == MeshoptCompressionMode::Attributes) {
+				json += "\"ATTRIBUTES\"";
+			} else if (meshopt.mode == MeshoptCompressionMode::Triangles) {
+				json += "\"TRIANGLES\"";
+			} else if (meshopt.mode == MeshoptCompressionMode::Indices) {
+				json += "\"INDICES\"";
+			}
+			if (meshopt.filter != MeshoptCompressionFilter::None) {
+				json += ",\"filter\":";
+				if (meshopt.filter == MeshoptCompressionFilter::Exponential) {
+					json += "\"EXPONENTIAL\"";
+				} else if (meshopt.filter == MeshoptCompressionFilter::Quaternion) {
+					json += "\"QUATERNION\"";
+				} else if (meshopt.filter == MeshoptCompressionFilter::Octahedral) {
+					json += "\"OCTAHEDRAL\"";
+				}
+			}
+			json += "}}";
+		}
 
 		if (extrasWriteCallback != nullptr) {
-			auto extras = extrasWriteCallback(uabs(std::distance(asset.bufferViews.begin(), it)), fastgltf::Category::BufferViews, userPointer);
+			auto extras = extrasWriteCallback(uabs(std::distance(asset.bufferViews.begin(), it)),
+											  fastgltf::Category::BufferViews, userPointer);
 			if (extras.has_value()) {
 				json += std::string(",\"extras\":") + *extras;
 			}
 		}
 
-		if (!it->name.empty())
-			json += R"(,"name":")" + fg::escapeString(it->name) + '"';
+		if (!it->name.empty()) json += R"(,"name":")" + fg::escapeString(it->name) + '"';
 
 		json += '}';
-		if (uabs(std::distance(asset.bufferViews.begin(), it)) + 1 <asset.bufferViews.size())
+		if (uabs(std::distance(asset.bufferViews.begin(), it)) + 1 < asset.bufferViews.size())
 			json += ',';
 	}
 	json += ']';
 }
 
 void fg::Exporter::writeCameras(const Asset& asset, std::string& json) {
-	if (asset.cameras.empty())
-		return;
-	if (json.back() == ']' || json.back() == '}')
-		json += ',';
+	if (asset.cameras.empty()) return;
+	if (json.back() == ']' || json.back() == '}') json += ',';
 
 	json += "\"cameras\":[";
 	for (auto it = asset.cameras.begin(); it != asset.cameras.end(); ++it) {
 		json += '{';
 
-		std::visit(visitor {
-			[](auto&) {},
-			[&](const Camera::Perspective& perspective) {
-				json += "\"perspective\":{";
+		std::visit(visitor{[](auto&) {},
+						   [&](const Camera::Perspective& perspective) {
+			json += "\"perspective\":{";
 
-				if (perspective.aspectRatio.has_value()) {
-					json += "\"aspectRatio\":" + to_string_fp(perspective.aspectRatio.value()) + ',';
-				}
-
-				json += "\"yfov\":" + to_string_fp(perspective.yfov) + ',';
-
-				if (perspective.zfar.has_value()) {
-					json += "\"zfar\":" + to_string_fp(perspective.zfar.value()) + ',';
-				}
-
-				json += "\"znear\":" + to_string_fp(perspective.znear);
-
-				json += R"(},"type":"perspective")";
-			},
-			[&](const Camera::Orthographic& orthographic) {
-				json += "\"orthographic\":{";
-				json += "\"xmag\":" + to_string_fp(orthographic.xmag) + ',';
-				json += "\"ymag\":" + to_string_fp(orthographic.ymag) + ',';
-				json += "\"zfar\":" + to_string_fp(orthographic.zfar) + ',';
-				json += "\"znear\":" + to_string_fp(orthographic.znear);
-				json += R"(},"type":"orthographic")";
+			if (perspective.aspectRatio.has_value()) {
+				json += "\"aspectRatio\":" + to_string_fp(perspective.aspectRatio.value()) + ',';
 			}
-		}, it->camera);
+
+			json += "\"yfov\":" + to_string_fp(perspective.yfov) + ',';
+
+			if (perspective.zfar.has_value()) {
+				json += "\"zfar\":" + to_string_fp(perspective.zfar.value()) + ',';
+			}
+
+			json += "\"znear\":" + to_string_fp(perspective.znear);
+
+			json += R"(},"type":"perspective")";
+		},
+						   [&](const Camera::Orthographic& orthographic) {
+			json += "\"orthographic\":{";
+			json += "\"xmag\":" + to_string_fp(orthographic.xmag) + ',';
+			json += "\"ymag\":" + to_string_fp(orthographic.ymag) + ',';
+			json += "\"zfar\":" + to_string_fp(orthographic.zfar) + ',';
+			json += "\"znear\":" + to_string_fp(orthographic.znear);
+			json += R"(},"type":"orthographic")";
+		}},
+				   it->camera);
 
 		if (extrasWriteCallback != nullptr) {
-			auto extras = extrasWriteCallback(uabs(std::distance(asset.cameras.begin(), it)), fastgltf::Category::Cameras, userPointer);
+			auto extras = extrasWriteCallback(uabs(std::distance(asset.cameras.begin(), it)),
+											  fastgltf::Category::Cameras, userPointer);
 			if (extras.has_value()) {
 				json += std::string(",\"extras\":") + *extras;
 			}
 		}
 
-		if (!it->name.empty())
-			json += R"(,"name":")" + fg::escapeString(it->name) + '"';
+		if (!it->name.empty()) json += R"(,"name":")" + fg::escapeString(it->name) + '"';
 
 		json += '}';
-		if (uabs(std::distance(asset.cameras.begin(), it)) + 1 <asset.cameras.size())
-			json += ',';
+		if (uabs(std::distance(asset.cameras.begin(), it)) + 1 < asset.cameras.size()) json += ',';
 	}
 	json += ']';
 }
 
 void fg::Exporter::writeImages(const Asset& asset, std::string& json) {
-	if (asset.images.empty())
-		return;
-	if (json.back() == ']' || json.back() == '}')
-		json += ',';
+	if (asset.images.empty()) return;
+	if (json.back() == ']' || json.back() == '}') json += ',';
 
 	json += "\"images\":[";
 	for (auto it = asset.images.begin(); it != asset.images.end(); ++it) {
 		json += '{';
 
-        auto imageIdx = uabs(std::distance(asset.images.begin(), it));
-		std::visit(visitor {
-			[&](auto&) {
-				errorCode = Error::InvalidGltf;
-			},
-            [&](const sources::BufferView& bufferView) {
-                json += std::string(R"("bufferView":)") + std::to_string(bufferView.bufferViewIndex) + ',';
-				json += std::string(R"("mimeType":")") + std::string(getMimeTypeString(bufferView.mimeType)) + '"';
-                imagePaths.emplace_back(std::nullopt);
-            },
-            [&](const sources::Array& vector) {
-                auto path = getImageFilePath(asset, imageIdx, vector.mimeType);
-                json += std::string(R"("uri":")") + fg::normalizeAndFormatPath(path) + '"';
-				if (vector.mimeType != MimeType::None) {
-					json += std::string(R"(,"mimeType":")") + std::string(getMimeTypeString(vector.mimeType)) + '"';
-				}
-                imagePaths.emplace_back(path);
-            },
-			[&](const sources::Vector& vector) {
-				auto path = getImageFilePath(asset, imageIdx, vector.mimeType);
-				json += std::string(R"("uri":")") + fg::normalizeAndFormatPath(path) + '"';
-				if (vector.mimeType != MimeType::None) {
-					json += std::string(R"(,"mimeType":")") + std::string(getMimeTypeString(vector.mimeType)) + '"';
-				}
-				imagePaths.emplace_back(path);
-			},
-			[&](const sources::URI& uri) {
-				json += std::string(R"("uri":")") + fg::escapeString(uri.uri.string()) + '"';
-                imagePaths.emplace_back(std::nullopt);
-			},
-		}, it->data);
-		if (errorCode != Error::None)
-			return;
+		auto imageIdx = uabs(std::distance(asset.images.begin(), it));
+		std::visit(visitor{
+					   [&](auto&) { errorCode = Error::InvalidGltf; },
+					   [&](const sources::BufferView& bufferView) {
+			json +=
+				std::string(R"("bufferView":)") + std::to_string(bufferView.bufferViewIndex) + ',';
+			json += std::string(R"("mimeType":")") +
+					std::string(getMimeTypeString(bufferView.mimeType)) + '"';
+			imagePaths.emplace_back(std::nullopt);
+		},
+					   [&](const sources::Array& vector) {
+			auto path = getImageFilePath(asset, imageIdx, vector.mimeType);
+			json += std::string(R"("uri":")") + fg::normalizeAndFormatPath(path) + '"';
+			if (vector.mimeType != MimeType::None) {
+				json += std::string(R"(,"mimeType":")") +
+						std::string(getMimeTypeString(vector.mimeType)) + '"';
+			}
+			imagePaths.emplace_back(path);
+		},
+					   [&](const sources::Vector& vector) {
+			auto path = getImageFilePath(asset, imageIdx, vector.mimeType);
+			json += std::string(R"("uri":")") + fg::normalizeAndFormatPath(path) + '"';
+			if (vector.mimeType != MimeType::None) {
+				json += std::string(R"(,"mimeType":")") +
+						std::string(getMimeTypeString(vector.mimeType)) + '"';
+			}
+			imagePaths.emplace_back(path);
+		},
+					   [&](const sources::URI& uri) {
+			json += std::string(R"("uri":")") + fg::escapeString(uri.uri.string()) + '"';
+			imagePaths.emplace_back(std::nullopt);
+		},
+				   },
+				   it->data);
+		if (errorCode != Error::None) return;
 
 		if (extrasWriteCallback != nullptr) {
-			auto extras = extrasWriteCallback(uabs(std::distance(asset.images.begin(), it)), fastgltf::Category::Images, userPointer);
+			auto extras = extrasWriteCallback(uabs(std::distance(asset.images.begin(), it)),
+											  fastgltf::Category::Images, userPointer);
 			if (extras.has_value()) {
 				json += std::string(",\"extras\":") + *extras;
 			}
 		}
 
-		if (!it->name.empty())
-			json += R"(,"name":")" + fg::escapeString(it->name) + '"';
+		if (!it->name.empty()) json += R"(,"name":")" + fg::escapeString(it->name) + '"';
 		json += '}';
-		if (uabs(std::distance(asset.images.begin(), it)) + 1 <asset.images.size())
-			json += ',';
+		if (uabs(std::distance(asset.images.begin(), it)) + 1 < asset.images.size()) json += ',';
 	}
 	json += ']';
 }
 
 void fg::Exporter::writeLights(const Asset& asset, std::string& json) {
-	if (asset.lights.empty())
-		return;
-	if (json.back() == ']' || json.back() == '}')
-		json += ',';
+	if (asset.lights.empty()) return;
+	if (json.back() == ']' || json.back() == '}') json += ',';
 
 	json += R"("KHR_lights_punctual":{"lights":[)";
 	for (auto it = asset.lights.begin(); it != asset.lights.end(); ++it) {
@@ -5560,7 +5832,8 @@ void fg::Exporter::writeLights(const Asset& asset, std::string& json) {
 		// [1.0f, 1.0f, 1.0f] is the default.
 		if (!(it->color[0] == 1.0f && it->color[1] == 1.0f && it->color[2] == 1.0f)) {
 			json += R"("color":[)";
-			json += to_string_fp(it->color[0]) + ',' + to_string_fp(it->color[1]) + ',' + to_string_fp(it->color[2]);
+			json += to_string_fp(it->color[0]) + ',' + to_string_fp(it->color[1]) + ',' +
+					to_string_fp(it->color[2]);
 			json += "],";
 		}
 
@@ -5595,20 +5868,16 @@ void fg::Exporter::writeLights(const Asset& asset, std::string& json) {
 				json += R"("outerConeAngle":)" + to_string_fp(it->outerConeAngle.value()) + ',';
 		}
 
-		if (!it->name.empty())
-			json += R"(,"name":")" + fg::escapeString(it->name) + '"';
+		if (!it->name.empty()) json += R"(,"name":")" + fg::escapeString(it->name) + '"';
 		json += '}';
-		if (uabs(std::distance(asset.lights.begin(), it)) + 1 <asset.lights.size())
-			json += ',';
+		if (uabs(std::distance(asset.lights.begin(), it)) + 1 < asset.lights.size()) json += ',';
 	}
 	json += "]}";
 }
 
 void fg::Exporter::writeMaterials(const Asset& asset, std::string& json) {
-	if (asset.materials.empty())
-		return;
-	if (json.back() == ']' || json.back() == '}')
-		json += ',';
+	if (asset.materials.empty()) return;
+	if (json.back() == ']' || json.back() == '}') json += ',';
 
 	json += "\"materials\":[";
 	for (auto it = asset.materials.begin(); it != asset.materials.end(); ++it) {
@@ -5617,8 +5886,10 @@ void fg::Exporter::writeMaterials(const Asset& asset, std::string& json) {
 		json += "\"pbrMetallicRoughness\":{";
 		if (it->pbrData.baseColorFactor != math::nvec4(1)) {
 			json += R"("baseColorFactor":[)";
-			json += to_string_fp(it->pbrData.baseColorFactor[0]) + ',' + to_string_fp(it->pbrData.baseColorFactor[1]) + ',' +
-				to_string_fp(it->pbrData.baseColorFactor[2]) + ',' + to_string_fp(it->pbrData.baseColorFactor[3]);
+			json += to_string_fp(it->pbrData.baseColorFactor[0]) + ',' +
+					to_string_fp(it->pbrData.baseColorFactor[1]) + ',' +
+					to_string_fp(it->pbrData.baseColorFactor[2]) + ',' +
+					to_string_fp(it->pbrData.baseColorFactor[3]);
 			json += "]";
 		}
 
@@ -5655,7 +5926,8 @@ void fg::Exporter::writeMaterials(const Asset& asset, std::string& json) {
 		if (it->occlusionTexture.has_value()) {
 			if (json.back() != ',') json += ',';
 			json += "\"occlusionTexture\":";
-			writeTextureInfo(json, &it->occlusionTexture.value(), TextureInfoType::OcclusionTexture);
+			writeTextureInfo(json, &it->occlusionTexture.value(),
+							 TextureInfoType::OcclusionTexture);
 		}
 
 		if (it->emissiveTexture.has_value()) {
@@ -5667,7 +5939,8 @@ void fg::Exporter::writeMaterials(const Asset& asset, std::string& json) {
 		if (it->emissiveFactor != math::nvec3(0)) {
 			if (json.back() != ',') json += ',';
 			json += R"("emissiveFactor":[)";
-			json += to_string_fp(it->emissiveFactor[0]) + ',' + to_string_fp(it->emissiveFactor[1]) + ',' + to_string_fp(it->emissiveFactor[2]);
+			json += to_string_fp(it->emissiveFactor[0]) + ',' +
+					to_string_fp(it->emissiveFactor[1]) + ',' + to_string_fp(it->emissiveFactor[2]);
 			json += "],";
 		}
 
@@ -5697,11 +5970,13 @@ void fg::Exporter::writeMaterials(const Asset& asset, std::string& json) {
 		if (it->anisotropy) {
 			json += R"("KHR_materials_anisotropy":{)";
 			if (it->anisotropy->anisotropyStrength != 0.0f) {
-				json += R"("anisotropyStrength":)" + to_string_fp(it->anisotropy->anisotropyStrength);
+				json +=
+					R"("anisotropyStrength":)" + to_string_fp(it->anisotropy->anisotropyStrength);
 			}
 			if (it->anisotropy->anisotropyRotation != 0.0f) {
 				if (json.back() != '{') json += ',';
-				json += R"("anisotropyRotation":)" + to_string_fp(it->anisotropy->anisotropyRotation);
+				json +=
+					R"("anisotropyRotation":)" + to_string_fp(it->anisotropy->anisotropyRotation);
 			}
 			if (it->anisotropy->anisotropyTexture.has_value()) {
 				if (json.back() != '{') json += ',';
@@ -5724,7 +5999,8 @@ void fg::Exporter::writeMaterials(const Asset& asset, std::string& json) {
 			}
 			if (it->clearcoat->clearcoatRoughnessFactor != 0.0f) {
 				if (json.back() != '{') json += ',';
-				json += R"("clearcoatRoughnessFactor":)" + to_string_fp(it->clearcoat->clearcoatRoughnessFactor);
+				json += R"("clearcoatRoughnessFactor":)" +
+						to_string_fp(it->clearcoat->clearcoatRoughnessFactor);
 			}
 			if (it->clearcoat->clearcoatRoughnessTexture.has_value()) {
 				if (json.back() != '{') json += ',';
@@ -5734,7 +6010,8 @@ void fg::Exporter::writeMaterials(const Asset& asset, std::string& json) {
 			if (it->clearcoat->clearcoatNormalTexture.has_value()) {
 				if (json.back() != '{') json += ',';
 				json += "\"clearcoatNormalTexture\":";
-				writeTextureInfo(json, &it->clearcoat->clearcoatNormalTexture.value(), TextureInfoType::NormalTexture);
+				writeTextureInfo(json, &it->clearcoat->clearcoatNormalTexture.value(),
+								 TextureInfoType::NormalTexture);
 			}
 			json += '}';
 		}
@@ -5743,36 +6020,42 @@ void fg::Exporter::writeMaterials(const Asset& asset, std::string& json) {
 			if (json.back() == '}') json += ',';
 			json += R"("KHR_materials_diffuse_transmission":{)";
 			if (it->diffuseTransmission->diffuseTransmissionFactor != 0.0f) {
-				json += R"("diffuseTransmissionFactor":)" + to_string_fp(it->diffuseTransmission->diffuseTransmissionFactor);
+				json += R"("diffuseTransmissionFactor":)" +
+						to_string_fp(it->diffuseTransmission->diffuseTransmissionFactor);
 			}
 			if (it->diffuseTransmission->diffuseTransmissionTexture.has_value()) {
 				if (json.back() != '{') json += ',';
 				json += R"("diffuseTransmissionTexture":)";
-				writeTextureInfo(json, &it->diffuseTransmission->diffuseTransmissionTexture.value());
+				writeTextureInfo(json,
+								 &it->diffuseTransmission->diffuseTransmissionTexture.value());
 			}
 			if (it->diffuseTransmission->diffuseTransmissionColorFactor != math::nvec3(1)) {
 				if (json.back() != '{') json += ',';
 				json += R"("diffuseTransmissionColorFactor":[)";
-				json += to_string_fp(it->diffuseTransmission->diffuseTransmissionColorFactor[0]) + ',' +
-						to_string_fp(it->diffuseTransmission->diffuseTransmissionColorFactor[1]) + ',' +
-						to_string_fp(it->diffuseTransmission->diffuseTransmissionColorFactor[2]) + ']';
+				json +=
+					to_string_fp(it->diffuseTransmission->diffuseTransmissionColorFactor[0]) + ',' +
+					to_string_fp(it->diffuseTransmission->diffuseTransmissionColorFactor[1]) + ',' +
+					to_string_fp(it->diffuseTransmission->diffuseTransmissionColorFactor[2]) + ']';
 			}
 			if (it->diffuseTransmission->diffuseTransmissionColorTexture.has_value()) {
 				if (json.back() != '{') json += ',';
 				json += "\"diffuseTransmissionColorTexture\":";
-				writeTextureInfo(json, &it->diffuseTransmission->diffuseTransmissionColorTexture.value());
+				writeTextureInfo(json,
+								 &it->diffuseTransmission->diffuseTransmissionColorTexture.value());
 			}
 			json += '}';
 		}
 
 		if (it->dispersion != 0.0f) {
 			if (json.back() == '}') json += ',';
-			json += R"("KHR_materials_dispersion":{"dispersion":)" + to_string_fp(it->dispersion) + '}';
+			json +=
+				R"("KHR_materials_dispersion":{"dispersion":)" + to_string_fp(it->dispersion) + '}';
 		}
 
 		if (it->emissiveStrength != 1.0f) {
 			if (json.back() == '}') json += ',';
-			json += R"("KHR_materials_emissive_strength":{"emissiveStrength":)" + to_string_fp(it->emissiveStrength) + '}';
+			json += R"("KHR_materials_emissive_strength":{"emissiveStrength":)" +
+					to_string_fp(it->emissiveStrength) + '}';
 		}
 
 		if (it->ior != 1.5f) {
@@ -5784,7 +6067,8 @@ void fg::Exporter::writeMaterials(const Asset& asset, std::string& json) {
 			if (json.back() == '}') json += ',';
 			json += R"("KHR_materials_iridescence":{)";
 			if (it->iridescence->iridescenceFactor != 0.0f) {
-				json += R"("iridescenceFactor":)" + to_string_fp(it->iridescence->iridescenceFactor);
+				json +=
+					R"("iridescenceFactor":)" + to_string_fp(it->iridescence->iridescenceFactor);
 			}
 			if (it->iridescence->iridescenceTexture.has_value()) {
 				if (json.back() != '{') json += ',';
@@ -5797,11 +6081,13 @@ void fg::Exporter::writeMaterials(const Asset& asset, std::string& json) {
 			}
 			if (it->iridescence->iridescenceThicknessMinimum != 100.0f) {
 				if (json.back() != '{') json += ',';
-				json += R"("iridescenceThicknessMinimum":)" + to_string_fp(it->iridescence->iridescenceThicknessMinimum);
+				json += R"("iridescenceThicknessMinimum":)" +
+						to_string_fp(it->iridescence->iridescenceThicknessMinimum);
 			}
 			if (it->iridescence->iridescenceThicknessMaximum != 400.0f) {
 				if (json.back() != '{') json += ',';
-				json += R"("iridescenceThicknessMaximum":)" + to_string_fp(it->iridescence->iridescenceThicknessMaximum);
+				json += R"("iridescenceThicknessMaximum":)" +
+						to_string_fp(it->iridescence->iridescenceThicknessMaximum);
 			}
 			if (it->iridescence->iridescenceThicknessTexture.has_value()) {
 				if (json.back() != '{') json += ',';
@@ -5815,10 +6101,9 @@ void fg::Exporter::writeMaterials(const Asset& asset, std::string& json) {
 			if (json.back() == '}') json += ',';
 			json += R"("KHR_materials_sheen":{)";
 			if (it->sheen->sheenColorFactor != math::nvec3(0)) {
-				json += R"("sheenColorFactor":[)" +
-					to_string_fp(it->sheen->sheenColorFactor[0]) + ',' +
-					to_string_fp(it->sheen->sheenColorFactor[1]) + ',' +
-					to_string_fp(it->sheen->sheenColorFactor[2]) + ']';
+				json += R"("sheenColorFactor":[)" + to_string_fp(it->sheen->sheenColorFactor[0]) +
+						',' + to_string_fp(it->sheen->sheenColorFactor[1]) + ',' +
+						to_string_fp(it->sheen->sheenColorFactor[2]) + ']';
 			}
 			if (it->sheen->sheenColorTexture.has_value()) {
 				if (json.back() != '{') json += ',';
@@ -5827,7 +6112,8 @@ void fg::Exporter::writeMaterials(const Asset& asset, std::string& json) {
 			}
 			if (it->sheen->sheenRoughnessFactor != 0.0f) {
 				if (json.back() != '{') json += ',';
-				json += R"("sheenRoughnessFactor":)" + to_string_fp(it->sheen->sheenRoughnessFactor);
+				json +=
+					R"("sheenRoughnessFactor":)" + to_string_fp(it->sheen->sheenRoughnessFactor);
 			}
 			if (it->sheen->sheenRoughnessTexture.has_value()) {
 				if (json.back() != '{') json += ',';
@@ -5863,8 +6149,7 @@ void fg::Exporter::writeMaterials(const Asset& asset, std::string& json) {
 			json += '}';
 		}
 #if FASTGLTF_ENABLE_DEPRECATED_EXT
-		if (it->specularGlossiness)
-		{
+		if (it->specularGlossiness) {
 			if (json.back() == '}') json += ',';
 			json += R"("KHR_materials_pbrSpecularGlossiness":{)";
 			if (it->specularGlossiness->diffuseFactor != math::nvec4(1)) {
@@ -5888,7 +6173,8 @@ void fg::Exporter::writeMaterials(const Asset& asset, std::string& json) {
 			}
 			if (it->specularGlossiness->glossinessFactor != 1.0) {
 				if (json.back() != '{') json += ',';
-				json += R"("glossinessFactor":)" + to_string_fp(it->specularGlossiness->glossinessFactor);
+				json += R"("glossinessFactor":)" +
+						to_string_fp(it->specularGlossiness->glossinessFactor);
 			}
 			if (it->specularGlossiness->specularGlossinessTexture.has_value()) {
 				if (json.back() != '{') json += ',';
@@ -5903,7 +6189,8 @@ void fg::Exporter::writeMaterials(const Asset& asset, std::string& json) {
 			if (json.back() == '}') json += ',';
 			json += R"("KHR_materials_transmission":{)";
 			if (it->transmission->transmissionFactor != 0.0f) {
-				json += R"("transmissionFactor":)" + to_string_fp(it->transmission->transmissionFactor);
+				json +=
+					R"("transmissionFactor":)" + to_string_fp(it->transmission->transmissionFactor);
 			}
 			if (it->transmission->transmissionTexture.has_value()) {
 				if (json.back() != '{') json += ',';
@@ -5935,9 +6222,8 @@ void fg::Exporter::writeMaterials(const Asset& asset, std::string& json) {
 			}
 			if (it->volume->attenuationColor != math::nvec3(1)) {
 				if (json.back() != '{') json += ',';
-				json += R"("attenuationColor":[)" +
-						to_string_fp(it->volume->attenuationColor[0]) + ',' +
-						to_string_fp(it->volume->attenuationColor[1]) + ',' +
+				json += R"("attenuationColor":[)" + to_string_fp(it->volume->attenuationColor[0]) +
+						',' + to_string_fp(it->volume->attenuationColor[1]) + ',' +
 						to_string_fp(it->volume->attenuationColor[2]) + ']';
 			}
 			json += '}';
@@ -5953,17 +6239,22 @@ void fg::Exporter::writeMaterials(const Asset& asset, std::string& json) {
 		if (it->packedOcclusionRoughnessMetallicTextures) {
 			if (json.back() == '}') json += ',';
 			json += R"("MSFT_packing_occlusionRoughnessMetallic":{)";
-			if (it->packedOcclusionRoughnessMetallicTextures->occlusionRoughnessMetallicTexture.has_value()) {
+			if (it->packedOcclusionRoughnessMetallicTextures->occlusionRoughnessMetallicTexture
+					.has_value()) {
 				json += R"("occlusionRoughnessMetallicTexture":)";
-				writeTextureInfo(json, &it->packedOcclusionRoughnessMetallicTextures->occlusionRoughnessMetallicTexture.value());
+				writeTextureInfo(json, &it->packedOcclusionRoughnessMetallicTextures
+											->occlusionRoughnessMetallicTexture.value());
 			}
-			if (it->packedOcclusionRoughnessMetallicTextures->roughnessMetallicOcclusionTexture.has_value()) {
+			if (it->packedOcclusionRoughnessMetallicTextures->roughnessMetallicOcclusionTexture
+					.has_value()) {
 				json += R"("roughnessMetallicOcclusionTexture":)";
-				writeTextureInfo(json, &it->packedOcclusionRoughnessMetallicTextures->roughnessMetallicOcclusionTexture.value());
+				writeTextureInfo(json, &it->packedOcclusionRoughnessMetallicTextures
+											->roughnessMetallicOcclusionTexture.value());
 			}
 			if (it->packedOcclusionRoughnessMetallicTextures->normalTexture.has_value()) {
 				json += R"("normalTexture":)";
-				writeTextureInfo(json, &it->packedOcclusionRoughnessMetallicTextures->normalTexture.value());
+				writeTextureInfo(
+					json, &it->packedOcclusionRoughnessMetallicTextures->normalTexture.value());
 			}
 			json += '}';
 		}
@@ -5971,10 +6262,10 @@ void fg::Exporter::writeMaterials(const Asset& asset, std::string& json) {
 		json += '}';
 
 		if (extrasWriteCallback != nullptr) {
-			auto extras = extrasWriteCallback(uabs(std::distance(asset.materials.begin(), it)), fastgltf::Category::Materials, userPointer);
+			auto extras = extrasWriteCallback(uabs(std::distance(asset.materials.begin(), it)),
+											  fastgltf::Category::Materials, userPointer);
 			if (extras.has_value()) {
-				if (json.back() != '{')
-					json += ',';
+				if (json.back() != '{') json += ',';
 				json += std::string("\"extras\":") + *extras;
 			}
 		}
@@ -5984,66 +6275,67 @@ void fg::Exporter::writeMaterials(const Asset& asset, std::string& json) {
 			json += R"("name":")" + fg::escapeString(it->name) + '"';
 		}
 		json += '}';
-		if (uabs(std::distance(asset.materials.begin(), it)) + 1 <asset.materials.size())
+		if (uabs(std::distance(asset.materials.begin(), it)) + 1 < asset.materials.size())
 			json += ',';
 	}
 	json += ']';
 }
 
 void fg::Exporter::writeMeshes(const Asset& asset, std::string& json) {
-	if (asset.meshes.empty())
-		return;
-	if (json.back() == ']' || json.back() == '}')
-		json += ',';
+	if (asset.meshes.empty()) return;
+	if (json.back() == ']' || json.back() == '}') json += ',';
 
 	json += "\"meshes\":[";
 	for (auto it = asset.meshes.begin(); it != asset.meshes.end(); ++it) {
 		json += '{';
 
-        if (!it->primitives.empty()) {
-            json += R"("primitives":[)";
-            auto itp = it->primitives.begin();
-            while (itp != it->primitives.end()) {
-                json += '{';
+		if (!it->primitives.empty()) {
+			json += R"("primitives":[)";
+			auto itp = it->primitives.begin();
+			while (itp != it->primitives.end()) {
+				json += '{';
 
-                {
-                    json += R"("attributes":{)";
-                    for (auto ita = itp->attributes.begin(); ita != itp->attributes.end(); ++ita) {
-                        json += '"' + std::string(ita->name) + "\":" + std::to_string(ita->accessorIndex);
-                        if (uabs(std::distance(itp->attributes.begin(), ita)) + 1 <itp->attributes.size())
-                            json += ',';
-                    }
-                    json += '}';
-                }
+				{
+					json += R"("attributes":{)";
+					for (auto ita = itp->attributes.begin(); ita != itp->attributes.end(); ++ita) {
+						json += '"' + std::string(ita->name) +
+								"\":" + std::to_string(ita->accessorIndex);
+						if (uabs(std::distance(itp->attributes.begin(), ita)) + 1 <
+							itp->attributes.size())
+							json += ',';
+					}
+					json += '}';
+				}
 
-                if (itp->indicesAccessor.has_value()) {
-                    json += R"(,"indices":)" + std::to_string(itp->indicesAccessor.value());
-                }
+				if (itp->indicesAccessor.has_value()) {
+					json += R"(,"indices":)" + std::to_string(itp->indicesAccessor.value());
+				}
 
-                if (itp->materialIndex.has_value()) {
-                    json += R"(,"material":)" + std::to_string(itp->materialIndex.value());
-                }
+				if (itp->materialIndex.has_value()) {
+					json += R"(,"material":)" + std::to_string(itp->materialIndex.value());
+				}
 
-            	if (!itp->targets.empty())
-            	{
-            		json  += R"(,"targets":[)";
-            		for (auto itt = itp->targets.begin(); itt != itp->targets.end(); ++itt) {
+				if (!itp->targets.empty()) {
+					json += R"(,"targets":[)";
+					for (auto itt = itp->targets.begin(); itt != itp->targets.end(); ++itt) {
 						json += '{';
 						for (auto ita = itt->begin(); ita != itt->end(); ++ita) {
-							json += '"' + std::string(ita->name) + "\":" + std::to_string(ita->accessorIndex);
+							json += '"' + std::string(ita->name) +
+									"\":" + std::to_string(ita->accessorIndex);
 							if (uabs(std::distance(itt->begin(), ita)) + 1 < itt->size())
 								json += ',';
 						}
 						json += '}';
-						if (uabs(std::distance(itp->targets.begin(), itt)) + 1 < itp->targets.size())
+						if (uabs(std::distance(itp->targets.begin(), itt)) + 1 <
+							itp->targets.size())
 							json += ',';
 					}
-            		json += ']';
-            	}
+					json += ']';
+				}
 
-                if (itp->type != PrimitiveType::Triangles) {
-                    json += R"(,"mode":)" + std::to_string(to_underlying(itp->type));
-                }
+				if (itp->type != PrimitiveType::Triangles) {
+					json += R"(,"mode":)" + std::to_string(to_underlying(itp->type));
+				}
 
 				const bool hasExtensions = !itp->mappings.empty() || itp->dracoCompression;
 				if (hasExtensions) {
@@ -6051,26 +6343,30 @@ void fg::Exporter::writeMeshes(const Asset& asset, std::string& json) {
 				}
 				if (!itp->mappings.empty()) {
 					json += R"("KHR_materials_variants":{"mappings":[)";
-					// TODO: We should optimise to avoid writing multiple objects for the same material index
+					// TODO: We should optimise to avoid writing multiple objects for the same
+					// material index
 					for (std::size_t i = 0; i < asset.materialVariants.size(); ++i) {
-						if (!itp->mappings[i].has_value())
-							continue;
-						if (json.back() == '}')
-							json += ',';
-						json += "{\"material\":" + std::to_string(itp->mappings[i].value()) + ",\"variants\":[" + std::to_string(i) + "]}";
+						if (!itp->mappings[i].has_value()) continue;
+						if (json.back() == '}') json += ',';
+						json += "{\"material\":" + std::to_string(itp->mappings[i].value()) +
+								",\"variants\":[" + std::to_string(i) + "]}";
 					}
 					json += "]}";
 				}
 				if (itp->dracoCompression) {
-					if (!itp->mappings.empty())
-						json += ',';
+					if (!itp->mappings.empty()) json += ',';
 
 					json += R"("KHR_draco_mesh_compression":{)";
-					json += R"("bufferView":)" + std::to_string(itp->dracoCompression->bufferView) + ',';
+					json += R"("bufferView":)" + std::to_string(itp->dracoCompression->bufferView) +
+							',';
 					json += R"("attributes":{)";
-					for (auto ita = itp->dracoCompression->attributes.begin(); ita != itp->dracoCompression->attributes.end(); ++ita) {
-						json += '"' + std::string(ita->name) + "\":" + std::to_string(ita->accessorIndex);
-						if (uabs(std::distance(itp->dracoCompression->attributes.begin(), ita)) + 1 < itp->dracoCompression->attributes.size())
+					for (auto ita = itp->dracoCompression->attributes.begin();
+						 ita != itp->dracoCompression->attributes.end(); ++ita) {
+						json += '"' + std::string(ita->name) +
+								"\":" + std::to_string(ita->accessorIndex);
+						if (uabs(std::distance(itp->dracoCompression->attributes.begin(), ita)) +
+								1 <
+							itp->dracoCompression->attributes.size())
 							json += ',';
 					}
 					json += "}}";
@@ -6088,45 +6384,39 @@ void fg::Exporter::writeMeshes(const Asset& asset, std::string& json) {
 		}
 
 		if (!it->weights.empty()) {
-			if (json.back() != '{')
-				json += ',';
+			if (json.back() != '{') json += ',';
 			json += R"("weights":[)";
 			auto itw = it->weights.begin();
 			while (itw != it->weights.end()) {
 				json += to_string_fp(*itw);
 				++itw;
-				if (uabs(std::distance(it->weights.begin(), itw)) < it->weights.size())
-					json += ',';
+				if (uabs(std::distance(it->weights.begin(), itw)) < it->weights.size()) json += ',';
 			}
 			json += ']';
 		}
 
 		if (extrasWriteCallback != nullptr) {
-			auto extras = extrasWriteCallback(uabs(std::distance(asset.meshes.begin(), it)), fastgltf::Category::Meshes, userPointer);
+			auto extras = extrasWriteCallback(uabs(std::distance(asset.meshes.begin(), it)),
+											  fastgltf::Category::Meshes, userPointer);
 			if (extras.has_value()) {
-				if (json.back() != '{')
-					json += ',';
+				if (json.back() != '{') json += ',';
 				json += std::string("\"extras\":") + *extras;
 			}
 		}
 
 		if (!it->name.empty()) {
-            if (json.back() != '{')
-                json += ',';
-            json += R"("name":")" + fg::escapeString(it->name) + '"';
-        }
+			if (json.back() != '{') json += ',';
+			json += R"("name":")" + fg::escapeString(it->name) + '"';
+		}
 		json += '}';
-		if (uabs(std::distance(asset.meshes.begin(), it)) + 1 <asset.meshes.size())
-			json += ',';
+		if (uabs(std::distance(asset.meshes.begin(), it)) + 1 < asset.meshes.size()) json += ',';
 	}
 	json += ']';
 }
 
 void fg::Exporter::writeNodes(const Asset& asset, std::string& json) {
-	if (asset.nodes.empty())
-		return;
-	if (json.back() == ']' || json.back() == '}')
-		json += ',';
+	if (asset.nodes.empty()) return;
+	if (json.back() == ']' || json.back() == '}') json += ',';
 
 	json += "\"nodes\":[";
 	for (auto it = asset.nodes.begin(); it != asset.nodes.end(); ++it) {
@@ -6136,19 +6426,16 @@ void fg::Exporter::writeNodes(const Asset& asset, std::string& json) {
 			json += R"("mesh":)" + std::to_string(it->meshIndex.value());
 		}
 		if (it->cameraIndex.has_value()) {
-			if (json.back() != '{')
-				json += ',';
+			if (json.back() != '{') json += ',';
 			json += R"("camera":)" + std::to_string(it->cameraIndex.value());
 		}
 		if (it->skinIndex.has_value()) {
-			if (json.back() != '{')
-				json += ',';
+			if (json.back() != '{') json += ',';
 			json += R"("skin":)" + std::to_string(it->skinIndex.value());
 		}
 
 		if (!it->children.empty()) {
-			if (json.back() != '{')
-				json += ',';
+			if (json.back() != '{') json += ',';
 			json += R"("children":[)";
 			auto itc = it->children.begin();
 			while (itc != it->children.end()) {
@@ -6161,72 +6448,72 @@ void fg::Exporter::writeNodes(const Asset& asset, std::string& json) {
 		}
 
 		if (!it->weights.empty()) {
-			if (json.back() != '{')
-				json += ',';
+			if (json.back() != '{') json += ',';
 			json += R"("weights":[)";
 			auto itw = it->weights.begin();
 			while (itw != it->weights.end()) {
 				json += to_string_fp(*itw);
 				++itw;
-				if (uabs(std::distance(it->weights.begin(), itw)) < it->weights.size())
-					json += ',';
+				if (uabs(std::distance(it->weights.begin(), itw)) < it->weights.size()) json += ',';
 			}
 			json += ']';
 		}
 
-		visit_exhaustive(visitor {
-			[&](const TRS& trs) {
-				if (trs.rotation != math::fquat(0.f, 0.f, 0.f, 1.f)) {
-					if (json.back() != '{')
-						json += ',';
-					json += R"("rotation":[)";
-					json += to_string_fp(trs.rotation[0]) + ',' + to_string_fp(trs.rotation[1]) + ',' + to_string_fp(trs.rotation[2]) + ',' + to_string_fp(trs.rotation[3]);
-					json += "]";
-				}
+		visit_exhaustive(visitor{
+							 [&](const TRS& trs) {
+			if (trs.rotation != math::fquat(0.f, 0.f, 0.f, 1.f)) {
+				if (json.back() != '{') json += ',';
+				json += R"("rotation":[)";
+				json += to_string_fp(trs.rotation[0]) + ',' + to_string_fp(trs.rotation[1]) + ',' +
+						to_string_fp(trs.rotation[2]) + ',' + to_string_fp(trs.rotation[3]);
+				json += "]";
+			}
 
-				if (trs.scale != math::fvec3(1.f)) {
-					if (json.back() != '{')
-						json += ',';
-					json += R"("scale":[)";
-					json += to_string_fp(trs.scale[0]) + ',' + to_string_fp(trs.scale[1]) + ',' + to_string_fp(trs.scale[2]);
-					json += "]";
-				}
+			if (trs.scale != math::fvec3(1.f)) {
+				if (json.back() != '{') json += ',';
+				json += R"("scale":[)";
+				json += to_string_fp(trs.scale[0]) + ',' + to_string_fp(trs.scale[1]) + ',' +
+						to_string_fp(trs.scale[2]);
+				json += "]";
+			}
 
-				if (trs.translation != math::fvec3(0.f)) {
-					if (json.back() != '{')
+			if (trs.translation != math::fvec3(0.f)) {
+				if (json.back() != '{') json += ',';
+				json += R"("translation":[)";
+				json += to_string_fp(trs.translation[0]) + ',' + to_string_fp(trs.translation[1]) +
+						',' + to_string_fp(trs.translation[2]);
+				json += "]";
+			}
+		},
+							 [&](const math::fmat4x4& matrix) {
+			if (json.back() != '{') json += ',';
+			json += R"("matrix":[)";
+			for (std::size_t i = 0; i < matrix.columns(); ++i) {
+				for (std::size_t j = 0; j < matrix.rows(); ++j) {
+					json += to_string_fp(matrix.col(i)[j]);
+					if (i * matrix.columns() + j + 1 < matrix.columns() * matrix.rows()) {
 						json += ',';
-					json += R"("translation":[)";
-					json += to_string_fp(trs.translation[0]) + ',' + to_string_fp(trs.translation[1]) + ',' + to_string_fp(trs.translation[2]);
-					json += "]";
-				}
-			},
-			[&](const math::fmat4x4& matrix) {
-				if (json.back() != '{')
-					json += ',';
-				json += R"("matrix":[)";
-				for (std::size_t i = 0; i < matrix.columns(); ++i) {
-					for (std::size_t j = 0; j < matrix.rows(); ++j) {
-						json += to_string_fp(matrix.col(i)[j]);
-						if (i * matrix.columns() + j + 1 < matrix.columns() * matrix.rows()) {
-							json += ',';
-						}
 					}
 				}
-				json += ']';
-			},
-		}, it->transform);
+			}
+			json += ']';
+		},
+						 },
+						 it->transform);
 
-	    if (!it->instancingAttributes.empty() || it->lightIndex.has_value()
+		if (!it->instancingAttributes.empty() || it->lightIndex.has_value()
 #if FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES
 			|| it->physicsRigidBody
 #endif
-			) {
+		) {
 			if (json.back() != '{') json += ',';
 			json += R"("extensions":{)";
 			if (!it->instancingAttributes.empty()) {
 				json += R"("EXT_mesh_gpu_instancing":{"attributes":{)";
-				for (auto ait = it->instancingAttributes.begin(); ait != it->instancingAttributes.end(); ++ait) {
-					json += '"' + std::string(ait->name) + "\":" + std::to_string(ait->accessorIndex);
+				for (auto ait = it->instancingAttributes.begin();
+					 ait != it->instancingAttributes.end(); ++ait) {
+					json +=
+						'"' + std::string(ait->name) + "\":" + std::to_string(ait->accessorIndex);
 					if (uabs(std::distance(it->instancingAttributes.begin(), ait)) + 1 <
 						it->instancingAttributes.size())
 						json += ',';
@@ -6235,7 +6522,8 @@ void fg::Exporter::writeNodes(const Asset& asset, std::string& json) {
 			}
 			if (it->lightIndex.has_value()) {
 				if (json.back() != '{') json += ',';
-				json += R"("KHR_lights_punctual":{"light":)" + std::to_string(it->lightIndex.value()) + '}';
+				json += R"("KHR_lights_punctual":{"light":)" +
+						std::to_string(it->lightIndex.value()) + '}';
 			}
 
 #if FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES
@@ -6250,14 +6538,16 @@ void fg::Exporter::writeNodes(const Asset& asset, std::string& json) {
 					}
 					json += R"(,"centerOfMass":[)" + to_string(motion.centerOfMass) + ']';
 					if (motion.inertialDiagonal.has_value()) {
-						json += R"(,"inertialDiagonal":[)" + to_string(*motion.inertialDiagonal) + ']';
+						json +=
+							R"(,"inertialDiagonal":[)" + to_string(*motion.inertialDiagonal) + ']';
 					}
 					if (motion.inertialOrientation.has_value()) {
-						json += R"(,"inertialOrientation":[)" + to_string(*motion.inertialOrientation) + ']';
+						json += R"(,"inertialOrientation":[)" +
+								to_string(*motion.inertialOrientation) + ']';
 					}
-					json += R"(,"linearVelocity":)" + to_string(motion.linearVelocity)
-				        + R"(],"angularVelocity":[)" + to_string(motion.angularVelocity)
-				        + R"(],"gravityFactor":[)" + to_string_fp(motion.gravityFactor) + '}';
+					json += R"(,"linearVelocity":)" + to_string(motion.linearVelocity) +
+							R"(],"angularVelocity":[)" + to_string(motion.angularVelocity) +
+							R"(],"gravityFactor":[)" + to_string_fp(motion.gravityFactor) + '}';
 				}
 
 				if (it->physicsRigidBody->trigger.has_value()) {
@@ -6265,38 +6555,41 @@ void fg::Exporter::writeNodes(const Asset& asset, std::string& json) {
 					const auto& trigger = *it->physicsRigidBody->trigger;
 					json += R"("trigger":{)";
 					visit_exhaustive(visitor{
-						[&](const GeometryTrigger& geometry) {
-							json += R"("geometry":{)";
-							if (geometry.geometry.shape.has_value()) {
-								json += R"("shape":)" + std::to_string(*geometry.geometry.shape) + ',';
-							} else if(geometry.geometry.node.has_value()) {
-								json += R"("node":)" + std::to_string(*geometry.geometry.node) + ',';
-							}
-							json += R"("convexHull":)" + std::to_string(geometry.geometry.convexHull) + '}';
+										 [&](const GeometryTrigger& geometry) {
+						json += R"("geometry":{)";
+						if (geometry.geometry.shape.has_value()) {
+							json += R"("shape":)" + std::to_string(*geometry.geometry.shape) + ',';
+						} else if (geometry.geometry.node.has_value()) {
+							json += R"("node":)" + std::to_string(*geometry.geometry.node) + ',';
+						}
+						json +=
+							R"("convexHull":)" + std::to_string(geometry.geometry.convexHull) + '}';
 
-							if (geometry.collisionFilter.has_value()) {
-								json += R"(,"collisionFilter":)" + std::to_string(*geometry.collisionFilter);
-							}
-						},
-						[&](const NodeTrigger& node) {
-							json += R"("nodes":[)";
-							for (auto it = node.nodes.begin(); it != node.nodes.end(); ++it) {
-								json += std::to_string(*it);
-								if (uabs(std::distance(node.nodes.begin(), it)) + 1 < node.nodes.size())
-									json += ',';
-							}
-							json += ']';
-						},
-						}, trigger);
+						if (geometry.collisionFilter.has_value()) {
+							json += R"(,"collisionFilter":)" +
+									std::to_string(*geometry.collisionFilter);
+						}
+					},
+										 [&](const NodeTrigger& node) {
+						json += R"("nodes":[)";
+						for (auto it = node.nodes.begin(); it != node.nodes.end(); ++it) {
+							json += std::to_string(*it);
+							if (uabs(std::distance(node.nodes.begin(), it)) + 1 < node.nodes.size())
+								json += ',';
+						}
+						json += ']';
+					},
+									 },
+									 trigger);
 					json += '}';
 				}
 
 				if (it->physicsRigidBody->joint.has_value()) {
 					if (json.back() != '{') json += ',';
 					const auto& joint = *it->physicsRigidBody->joint;
-					json += R"("joint":{"connectedNode":)" + std::to_string(joint.connectedNode)
-				        + R"(,"joint":)" + std::to_string(joint.joint)
-				        + R"(,"enableCollision":)" + std::to_string(joint.enableCollision) + '}';
+					json += R"("joint":{"connectedNode":)" + std::to_string(joint.connectedNode) +
+							R"(,"joint":)" + std::to_string(joint.joint) +
+							R"(,"enableCollision":)" + std::to_string(joint.enableCollision) + '}';
 				}
 
 				if (it->physicsRigidBody->collider.has_value()) {
@@ -6313,10 +6606,12 @@ void fg::Exporter::writeNodes(const Asset& asset, std::string& json) {
 					json += R"("convexHull":)" + std::to_string(collider.geometry.convexHull) + '}';
 
 					if (collider.physicsMaterial.has_value()) {
-						json += R"(,"physicsMaterial":)" + std::to_string(*collider.physicsMaterial);
+						json +=
+							R"(,"physicsMaterial":)" + std::to_string(*collider.physicsMaterial);
 					}
 					if (collider.collisionFilter) {
-						json += R"(,"collisionFilter":)" + std::to_string(*collider.collisionFilter);
+						json +=
+							R"(,"collisionFilter":)" + std::to_string(*collider.collisionFilter);
 					}
 					json += '}';
 				}
@@ -6327,31 +6622,27 @@ void fg::Exporter::writeNodes(const Asset& asset, std::string& json) {
 		}
 
 		if (extrasWriteCallback != nullptr) {
-			auto extras = extrasWriteCallback(uabs(std::distance(asset.nodes.begin(), it)), fastgltf::Category::Nodes, userPointer);
+			auto extras = extrasWriteCallback(uabs(std::distance(asset.nodes.begin(), it)),
+											  fastgltf::Category::Nodes, userPointer);
 			if (extras.has_value()) {
-				if (json.back() != '{')
-					json += ',';
+				if (json.back() != '{') json += ',';
 				json += std::string("\"extras\":") + *extras;
 			}
 		}
 
 		if (!it->name.empty()) {
-			if (json.back() != '{')
-				json += ',';
+			if (json.back() != '{') json += ',';
 			json += R"("name":")" + fg::escapeString(it->name) + '"';
 		}
 		json += '}';
-		if (uabs(std::distance(asset.nodes.begin(), it)) + 1 <asset.nodes.size())
-			json += ',';
+		if (uabs(std::distance(asset.nodes.begin(), it)) + 1 < asset.nodes.size()) json += ',';
 	}
 	json += ']';
 }
 
 void fg::Exporter::writeSamplers(const Asset& asset, std::string& json) {
-	if (asset.samplers.empty())
-		return;
-	if (json.back() == ']' || json.back() == '}')
-		json += ',';
+	if (asset.samplers.empty()) return;
+	if (json.back() == ']' || json.back() == '}') json += ',';
 
 	json += "\"samplers\":[";
 	for (auto it = asset.samplers.begin(); it != asset.samplers.end(); ++it) {
@@ -6374,10 +6665,10 @@ void fg::Exporter::writeSamplers(const Asset& asset, std::string& json) {
 		}
 
 		if (extrasWriteCallback != nullptr) {
-			auto extras = extrasWriteCallback(uabs(std::distance(asset.samplers.begin(), it)), fastgltf::Category::Samplers, userPointer);
+			auto extras = extrasWriteCallback(uabs(std::distance(asset.samplers.begin(), it)),
+											  fastgltf::Category::Samplers, userPointer);
 			if (extras.has_value()) {
-				if (json.back() != '{')
-					json += ',';
+				if (json.back() != '{') json += ',';
 				json += std::string("\"extras\":") + *extras;
 			}
 		}
@@ -6387,17 +6678,15 @@ void fg::Exporter::writeSamplers(const Asset& asset, std::string& json) {
 			json += R"("name":")" + fg::escapeString(it->name) + '"';
 		}
 		json += '}';
-		if (uabs(std::distance(asset.samplers.begin(), it)) + 1 <asset.samplers.size())
+		if (uabs(std::distance(asset.samplers.begin(), it)) + 1 < asset.samplers.size())
 			json += ',';
 	}
 	json += ']';
 }
 
 void fg::Exporter::writeScenes(const Asset& asset, std::string& json) {
-	if (asset.scenes.empty())
-		return;
-	if (json.back() == ']' || json.back() == '}')
-		json += ',';
+	if (asset.scenes.empty()) return;
+	if (json.back() == ']' || json.back() == '}') json += ',';
 
 	if (asset.defaultScene.has_value()) {
 		json += "\"scene\":" + std::to_string(asset.defaultScene.value()) + ',';
@@ -6418,35 +6707,32 @@ void fg::Exporter::writeScenes(const Asset& asset, std::string& json) {
 		json += ']';
 
 		if (extrasWriteCallback != nullptr) {
-			auto extras = extrasWriteCallback(uabs(std::distance(asset.scenes.begin(), it)), fastgltf::Category::Scenes, userPointer);
+			auto extras = extrasWriteCallback(uabs(std::distance(asset.scenes.begin(), it)),
+											  fastgltf::Category::Scenes, userPointer);
 			if (extras.has_value()) {
-				if (json.back() != '{')
-					json += ',';
+				if (json.back() != '{') json += ',';
 				json += std::string("\"extras\":") + *extras;
 			}
 		}
 
-		if (!it->name.empty())
-			json += R"(,"name":")" + fg::escapeString(it->name) + '"';
+		if (!it->name.empty()) json += R"(,"name":")" + fg::escapeString(it->name) + '"';
 		json += '}';
-		if (uabs(std::distance(asset.scenes.begin(), it)) + 1 <asset.scenes.size())
-			json += ',';
+		if (uabs(std::distance(asset.scenes.begin(), it)) + 1 < asset.scenes.size()) json += ',';
 	}
 	json += ']';
 }
 
 void fg::Exporter::writeSkins(const Asset& asset, std::string& json) {
-	if (asset.skins.empty())
-		return;
-	if (json.back() == ']' || json.back() == '}')
-		json += ',';
+	if (asset.skins.empty()) return;
+	if (json.back() == ']' || json.back() == '}') json += ',';
 
 	json += "\"skins\":[";
 	for (auto it = asset.skins.begin(); it != asset.skins.end(); ++it) {
 		json += '{';
 
 		if (it->inverseBindMatrices.has_value())
-			json += R"("inverseBindMatrices":)" + std::to_string(it->inverseBindMatrices.value()) + ',';
+			json +=
+				R"("inverseBindMatrices":)" + std::to_string(it->inverseBindMatrices.value()) + ',';
 
 		if (it->skeleton.has_value())
 			json += R"("skeleton":)" + std::to_string(it->skeleton.value()) + ',';
@@ -6456,34 +6742,29 @@ void fg::Exporter::writeSkins(const Asset& asset, std::string& json) {
 		while (itj != it->joints.end()) {
 			json += std::to_string(*itj);
 			++itj;
-			if (uabs(std::distance(it->joints.begin(), itj)) < it->joints.size())
-				json += ',';
+			if (uabs(std::distance(it->joints.begin(), itj)) < it->joints.size()) json += ',';
 		}
 		json += ']';
 
 		if (extrasWriteCallback != nullptr) {
-			auto extras = extrasWriteCallback(uabs(std::distance(asset.skins.begin(), it)), fastgltf::Category::Skins, userPointer);
+			auto extras = extrasWriteCallback(uabs(std::distance(asset.skins.begin(), it)),
+											  fastgltf::Category::Skins, userPointer);
 			if (extras.has_value()) {
-				if (json.back() != '{')
-					json += ',';
+				if (json.back() != '{') json += ',';
 				json += std::string("\"extras\":") + *extras;
 			}
 		}
 
-		if (!it->name.empty())
-			json += R"(,"name":")" + fg::escapeString(it->name) + '"';
+		if (!it->name.empty()) json += R"(,"name":")" + fg::escapeString(it->name) + '"';
 		json += '}';
-		if (uabs(std::distance(asset.skins.begin(), it)) + 1 <asset.skins.size())
-			json += ',';
+		if (uabs(std::distance(asset.skins.begin(), it)) + 1 < asset.skins.size()) json += ',';
 	}
 	json += ']';
 }
 
 void fg::Exporter::writeTextures(const Asset& asset, std::string& json) {
-	if (asset.textures.empty())
-		return;
-	if (json.back() == ']' || json.back() == '}')
-		json += ',';
+	if (asset.textures.empty()) return;
+	if (json.back() == ']' || json.back() == '}') json += ',';
 
 	json += "\"textures\":[";
 	for (auto it = asset.textures.begin(); it != asset.textures.end(); ++it) {
@@ -6497,36 +6778,39 @@ void fg::Exporter::writeTextures(const Asset& asset, std::string& json) {
 			json += R"("source":)" + std::to_string(it->imageIndex.value());
 		}
 
-		if (it->basisuImageIndex.has_value() || it->ddsImageIndex.has_value() || it->webpImageIndex.has_value()) {
+		if (it->basisuImageIndex.has_value() || it->ddsImageIndex.has_value() ||
+			it->webpImageIndex.has_value()) {
 			if (json.back() != '{') json += ',';
 			json += R"("extensions":{)";
 			if (it->basisuImageIndex.has_value()) {
-				json += R"("KHR_texture_basisu":{"source":)" + std::to_string(it->basisuImageIndex.value()) + '}';
+				json += R"("KHR_texture_basisu":{"source":)" +
+						std::to_string(it->basisuImageIndex.value()) + '}';
 			}
 			if (it->ddsImageIndex.has_value()) {
 				if (json.back() == '}') json += ',';
-				json += R"("MSFT_texture_dds":{"source":)" + std::to_string(it->ddsImageIndex.value()) + '}';
+				json += R"("MSFT_texture_dds":{"source":)" +
+						std::to_string(it->ddsImageIndex.value()) + '}';
 			}
 			if (it->webpImageIndex.has_value()) {
 				if (json.back() == '}') json += ',';
-				json += R"("EXT_texture_webp":{"source":)" + std::to_string(it->webpImageIndex.value()) + '}';
+				json += R"("EXT_texture_webp":{"source":)" +
+						std::to_string(it->webpImageIndex.value()) + '}';
 			}
 			json += "}";
 		}
 
 		if (extrasWriteCallback != nullptr) {
-			auto extras = extrasWriteCallback(uabs(std::distance(asset.textures.begin(), it)), fastgltf::Category::Textures, userPointer);
+			auto extras = extrasWriteCallback(uabs(std::distance(asset.textures.begin(), it)),
+											  fastgltf::Category::Textures, userPointer);
 			if (extras.has_value()) {
-				if (json.back() != '{')
-					json += ',';
+				if (json.back() != '{') json += ',';
 				json += std::string("\"extras\":") + *extras;
 			}
 		}
 
-		if (!it->name.empty())
-			json += R"(,"name":")" + fg::escapeString(it->name) + '"';
+		if (!it->name.empty()) json += R"(,"name":")" + fg::escapeString(it->name) + '"';
 		json += '}';
-		if (uabs(std::distance(asset.textures.begin(), it)) + 1 <asset.textures.size())
+		if (uabs(std::distance(asset.textures.begin(), it)) + 1 < asset.textures.size())
 			json += ',';
 	}
 	json += ']';
@@ -6546,28 +6830,28 @@ void fg::Exporter::writeShapes(const Asset& asset, std::string& json) {
 		const auto& shape = *it;
 		json += '{';
 
-		visit_exhaustive(visitor{
-			[&](const SphereShape& sphere) {
-				json += R"("type":"sphere","sphere":{"radius":)" + to_string_fp(sphere.radius) + '}';
-			},
-			[&](const BoxShape& box) {
-			    json += R"("type":"box","box":{"size":[)" + to_string(box.size) + "]}";
-			},
-			[&](const CylinderShape& cylinder) {
-				json += R"("type":"cylinder","cylinder":{"height":)" + to_string_fp(cylinder.height)
-					+ R"(,"radiusBottom":)" + to_string_fp(cylinder.radiusBottom) + R"(,"radiusTop":)"
-					+ to_string_fp(cylinder.radiusTop) + "}";;
-			},
-			[&](const CapsuleShape& capsule) {
-				json += R"("type":"capsule","capsule":{"height":)" + to_string_fp(capsule.height)
-					+ R"(,"radiusBottom":)" + to_string_fp(capsule.radiusBottom)
-					+ R"(,"radiusTop":)" + to_string_fp(capsule.radiusTop) + '}';
-			}
-			},
-			shape);
+		visit_exhaustive(visitor{[&](const SphereShape& sphere) {
+			json += R"("type":"sphere","sphere":{"radius":)" + to_string_fp(sphere.radius) + '}';
+		},
+								 [&](const BoxShape& box) {
+			json += R"("type":"box","box":{"size":[)" + to_string(box.size) + "]}";
+		},
+								 [&](const CylinderShape& cylinder) {
+			json += R"("type":"cylinder","cylinder":{"height":)" + to_string_fp(cylinder.height) +
+					R"(,"radiusBottom":)" + to_string_fp(cylinder.radiusBottom) +
+					R"(,"radiusTop":)" + to_string_fp(cylinder.radiusTop) + "}";
+			;
+		},
+								 [&](const CapsuleShape& capsule) {
+			json += R"("type":"capsule","capsule":{"height":)" + to_string_fp(capsule.height) +
+					R"(,"radiusBottom":)" + to_string_fp(capsule.radiusBottom) +
+					R"(,"radiusTop":)" + to_string_fp(capsule.radiusTop) + '}';
+		}},
+						 shape);
 
 		if (extrasWriteCallback != nullptr) {
-			auto extras = extrasWriteCallback(uabs(std::distance(asset.shapes.begin(), it)), fastgltf::Category::Shapes, userPointer);
+			auto extras = extrasWriteCallback(uabs(std::distance(asset.shapes.begin(), it)),
+											  fastgltf::Category::Shapes, userPointer);
 			if (extras.has_value()) {
 				if (json.back() != '{') {
 					json += ',';
@@ -6582,15 +6866,15 @@ void fg::Exporter::writeShapes(const Asset& asset, std::string& json) {
 			json += ',';
 		}
 	}
-	json += "]}";    
+	json += "]}";
 }
 #endif
 
 #if FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES
 void fg::Exporter::writePhysicsMaterials(const Asset& asset, std::string& json) {
-    if (asset.physicsMaterials.empty()) {
-        return;
-    }
+	if (asset.physicsMaterials.empty()) {
+		return;
+	}
 	if (json.back() == ']' || json.back() == '}') {
 		json += ',';
 	}
@@ -6600,42 +6884,28 @@ void fg::Exporter::writePhysicsMaterials(const Asset& asset, std::string& json) 
 	for (auto it = asset.physicsMaterials.begin(); it != asset.physicsMaterials.end(); ++it) {
 		const auto& material = *it;
 
-		json += R"({"staticFriction":)" + to_string_fp(material.staticFriction)
-	        + R"(,"dynamicFriction":)" + to_string_fp(material.dynamicFriction)
-	        + R"(,"restitution":)" + to_string_fp(material.restitution)
-	        + R"(,"frictionCombine":)";
+		json += R"({"staticFriction":)" + to_string_fp(material.staticFriction) +
+				R"(,"dynamicFriction":)" + to_string_fp(material.dynamicFriction) +
+				R"(,"restitution":)" + to_string_fp(material.restitution) +
+				R"(,"frictionCombine":)";
 		switch (material.frictionCombine) {
-        case CombineMode::Average:
-			json += R"("average")";
-            break;
-        case CombineMode::Minimum:
-			json += R"("minimum")";
-            break;
-        case CombineMode::Maximum:
-			json += R"("maximum")";
-            break;
-        case CombineMode::Multiply:
-			json += R"("multiply")";
-            break;
-        }
+			case CombineMode::Average:  json += R"("average")"; break;
+			case CombineMode::Minimum:  json += R"("minimum")"; break;
+			case CombineMode::Maximum:  json += R"("maximum")"; break;
+			case CombineMode::Multiply: json += R"("multiply")"; break;
+		}
 		json += R"(,"restitutionCombine":)";
 		switch (material.restitutionCombine) {
-		case CombineMode::Average:
-			json += R"("average")";
-			break;
-		case CombineMode::Minimum:
-			json += R"("minimum")";
-			break;
-		case CombineMode::Maximum:
-			json += R"("maximum")";
-			break;
-		case CombineMode::Multiply:
-			json += R"("multiply")";
-			break;
+			case CombineMode::Average:  json += R"("average")"; break;
+			case CombineMode::Minimum:  json += R"("minimum")"; break;
+			case CombineMode::Maximum:  json += R"("maximum")"; break;
+			case CombineMode::Multiply: json += R"("multiply")"; break;
 		}
 
 		if (extrasWriteCallback != nullptr) {
-			auto extras = extrasWriteCallback(uabs(std::distance(asset.physicsMaterials.begin(), it)), fastgltf::Category::PhysicsMaterials, userPointer);
+			auto extras =
+				extrasWriteCallback(uabs(std::distance(asset.physicsMaterials.begin(), it)),
+									fastgltf::Category::PhysicsMaterials, userPointer);
 			if (extras.has_value()) {
 				if (json.back() != '{') {
 					json += ',';
@@ -6646,7 +6916,8 @@ void fg::Exporter::writePhysicsMaterials(const Asset& asset, std::string& json) 
 
 		json += '}';
 
-		if (uabs(std::distance(asset.physicsMaterials.begin(), it)) + 1 < asset.physicsMaterials.size()) {
+		if (uabs(std::distance(asset.physicsMaterials.begin(), it)) + 1 <
+			asset.physicsMaterials.size()) {
 			json += ',';
 		}
 	}
@@ -6671,12 +6942,14 @@ void fg::Exporter::writeCollisionFilters(const Asset& asset, std::string& json) 
 
 		if (!filter.collisionSystems.empty()) {
 			json += R"("collisionSystems":[)";
-			for (auto systemIt = filter.collisionSystems.begin(); systemIt != filter.collisionSystems.end(); ++systemIt) {
+			for (auto systemIt = filter.collisionSystems.begin();
+				 systemIt != filter.collisionSystems.end(); ++systemIt) {
 				json += '"';
 				json += *systemIt;
 				json += '"';
 
-				if (uabs(std::distance(filter.collisionSystems.begin(), systemIt)) + 1 < filter.collisionSystems.size()) {
+				if (uabs(std::distance(filter.collisionSystems.begin(), systemIt)) + 1 <
+					filter.collisionSystems.size()) {
 					json += ',';
 				}
 			}
@@ -6688,12 +6961,14 @@ void fg::Exporter::writeCollisionFilters(const Asset& asset, std::string& json) 
 
 		if (!filter.collideWithSystems.empty()) {
 			json += R"("collideWithSystems":[)";
-			for (auto systemIt = filter.collideWithSystems.begin(); systemIt != filter.collideWithSystems.end(); ++systemIt) {
+			for (auto systemIt = filter.collideWithSystems.begin();
+				 systemIt != filter.collideWithSystems.end(); ++systemIt) {
 				json += '"';
 				json += *systemIt;
 				json += '"';
 
-				if (uabs(std::distance(filter.collideWithSystems.begin(), systemIt)) + 1 < filter.collideWithSystems.size()) {
+				if (uabs(std::distance(filter.collideWithSystems.begin(), systemIt)) + 1 <
+					filter.collideWithSystems.size()) {
 					json += ',';
 				}
 			}
@@ -6705,12 +6980,14 @@ void fg::Exporter::writeCollisionFilters(const Asset& asset, std::string& json) 
 
 		if (!filter.notCollideWithSystems.empty()) {
 			json += R"("notCollideWithSystems":[)";
-			for (auto systemIt = filter.notCollideWithSystems.begin(); systemIt != filter.notCollideWithSystems.end(); ++systemIt) {
+			for (auto systemIt = filter.notCollideWithSystems.begin();
+				 systemIt != filter.notCollideWithSystems.end(); ++systemIt) {
 				json += '"';
 				json += *systemIt;
 				json += '"';
 
-				if (uabs(std::distance(filter.notCollideWithSystems.begin(), systemIt)) + 1 < filter.notCollideWithSystems.size()) {
+				if (uabs(std::distance(filter.notCollideWithSystems.begin(), systemIt)) + 1 <
+					filter.notCollideWithSystems.size()) {
 					json += ',';
 				}
 			}
@@ -6718,7 +6995,9 @@ void fg::Exporter::writeCollisionFilters(const Asset& asset, std::string& json) 
 		}
 
 		if (extrasWriteCallback != nullptr) {
-			auto extras = extrasWriteCallback(uabs(std::distance(asset.collisionFilters.begin(), it)), fastgltf::Category::Shapes, userPointer);
+			auto extras =
+				extrasWriteCallback(uabs(std::distance(asset.collisionFilters.begin(), it)),
+									fastgltf::Category::Shapes, userPointer);
 			if (extras.has_value()) {
 				if (json.back() != '{') {
 					json += ',';
@@ -6729,7 +7008,8 @@ void fg::Exporter::writeCollisionFilters(const Asset& asset, std::string& json) 
 
 		json += '}';
 
-		if (uabs(std::distance(asset.collisionFilters.begin(), it)) + 1 < asset.collisionFilters.size()) {
+		if (uabs(std::distance(asset.collisionFilters.begin(), it)) + 1 <
+			asset.collisionFilters.size()) {
 			json += ',';
 		}
 	}
@@ -6760,10 +7040,12 @@ void fg::Exporter::writePhysicsJoints(const Asset& asset, std::string& json) {
 				json += '{';
 				if (!limit.linearAxes.empty()) {
 					json += R"("linearAxes":[)";
-					for (auto axisIt = limit.linearAxes.begin(); axisIt != limit.linearAxes.end(); ++axisIt) {
+					for (auto axisIt = limit.linearAxes.begin(); axisIt != limit.linearAxes.end();
+						 ++axisIt) {
 						json += std::to_string(*axisIt);
 
-						if (uabs(std::distance(limit.linearAxes.begin(), axisIt)) + 1 < limit.linearAxes.size()) {
+						if (uabs(std::distance(limit.linearAxes.begin(), axisIt)) + 1 <
+							limit.linearAxes.size()) {
 							json += ',';
 						}
 					}
@@ -6771,10 +7053,12 @@ void fg::Exporter::writePhysicsJoints(const Asset& asset, std::string& json) {
 				}
 				if (!limit.angularAxes.empty()) {
 					json += R"("angularAxes":[)";
-					for (auto axisIt = limit.angularAxes.begin(); axisIt != limit.angularAxes.end(); ++axisIt) {
+					for (auto axisIt = limit.angularAxes.begin(); axisIt != limit.angularAxes.end();
+						 ++axisIt) {
 						json += std::to_string(*axisIt);
 
-						if (uabs(std::distance(limit.angularAxes.begin(), axisIt)) + 1 < limit.angularAxes.size()) {
+						if (uabs(std::distance(limit.angularAxes.begin(), axisIt)) + 1 <
+							limit.angularAxes.size()) {
 							json += ',';
 						}
 					}
@@ -6789,7 +7073,7 @@ void fg::Exporter::writePhysicsJoints(const Asset& asset, std::string& json) {
 				if (limit.stiffness) {
 					json += R"("stiffness":)" + to_string_fp(*limit.stiffness) + ',';
 				}
-			    json += R"("damping":)" + to_string_fp(limit.damping);
+				json += R"("damping":)" + to_string_fp(limit.damping);
 				json += '}';
 
 				if (uabs(std::distance(joint.limits.begin(), limitIt)) + 1 < joint.limits.size()) {
@@ -6798,7 +7082,7 @@ void fg::Exporter::writePhysicsJoints(const Asset& asset, std::string& json) {
 			}
 			json += ']';
 
-			if(!joint.drives.empty()) {
+			if (!joint.drives.empty()) {
 				json += ',';
 			}
 		}
@@ -6809,31 +7093,23 @@ void fg::Exporter::writePhysicsJoints(const Asset& asset, std::string& json) {
 				const auto& drive = *driveIt;
 
 				json += R"({"type":)";
-				switch(drive.type) {
-                case DriveType::Linear:
-					json += R"("linear")";
-                    break;
-                case DriveType::Angular:
-					json += R"("angular")";
-                    break;
-                }
+				switch (drive.type) {
+					case DriveType::Linear:  json += R"("linear")"; break;
+					case DriveType::Angular: json += R"("angular")"; break;
+				}
 
 				json += R"(,"mode":)";
 				switch (drive.mode) {
-				case DriveMode::Force:
-					json += R"("force")";
-					break;
-				case DriveMode::Acceleration:
-					json += R"("acceleration")";
-					break;
+					case DriveMode::Force:        json += R"("force")"; break;
+					case DriveMode::Acceleration: json += R"("acceleration")"; break;
 				}
 
-				json += R"(,"axis":)" + std::to_string(drive.axis)
-			        + R"(,"maxForce":)" + to_string_fp(drive.maxForce)
-			        + R"(,"positionTarget":)" + to_string_fp(drive.positionTarget)
-			        + R"(,"velocityTarget":)" + to_string_fp(drive.velocityTarget)
-			        + R"(,"stiffness":)" + to_string_fp(drive.stiffness)
-			        + R"(,"damping":)" + to_string_fp(drive.damping);
+				json += R"(,"axis":)" + std::to_string(drive.axis) + R"(,"maxForce":)" +
+						to_string_fp(drive.maxForce) + R"(,"positionTarget":)" +
+						to_string_fp(drive.positionTarget) + R"(,"velocityTarget":)" +
+						to_string_fp(drive.velocityTarget) + R"(,"stiffness":)" +
+						to_string_fp(drive.stiffness) + R"(,"damping":)" +
+						to_string_fp(drive.damping);
 
 				json += '}';
 
@@ -6846,7 +7122,8 @@ void fg::Exporter::writePhysicsJoints(const Asset& asset, std::string& json) {
 		}
 
 		if (extrasWriteCallback != nullptr) {
-			auto extras = extrasWriteCallback(uabs(std::distance(asset.physicsJoints.begin(), it)), fastgltf::Category::PhysicsJoints, userPointer);
+			auto extras = extrasWriteCallback(uabs(std::distance(asset.physicsJoints.begin(), it)),
+											  fastgltf::Category::PhysicsJoints, userPointer);
 			if (extras.has_value()) {
 				if (json.back() != '{') {
 					json += ',';
@@ -6867,101 +7144,91 @@ void fg::Exporter::writePhysicsJoints(const Asset& asset, std::string& json) {
 #endif
 
 void fg::Exporter::writeExtensions(const fastgltf::Asset& asset, std::string& json) {
-	if (json.back() == ']' || json.back() == '}')
-		json += ',';
-    json += "\"extensions\":{";
+	if (json.back() == ']' || json.back() == '}') json += ',';
+	json += "\"extensions\":{";
 
-    writeLights(asset, json);
+	writeLights(asset, json);
 
 #if FASTGLTF_ENABLE_KHR_IMPLICIT_SHAPES
 	writeShapes(asset, json);
 #endif
 
 #if FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES
-	if (!asset.physicsMaterials.empty() || !asset.collisionFilters.empty() || !asset.physicsJoints.empty()) {
+	if (!asset.physicsMaterials.empty() || !asset.collisionFilters.empty() ||
+		!asset.physicsJoints.empty()) {
 		if (json.back() == ']' || json.back() == '}') {
 			json += ',';
 		}
-        json += R"("KHR_physics_rigid_bodies":{)";
-        writePhysicsMaterials(asset, json);
-        writeCollisionFilters(asset, json);
-        writePhysicsJoints(asset, json);
-        json += '}';
-    }
+		json += R"("KHR_physics_rigid_bodies":{)";
+		writePhysicsMaterials(asset, json);
+		writeCollisionFilters(asset, json);
+		writePhysicsJoints(asset, json);
+		json += '}';
+	}
 #endif
 
 	if (!asset.materialVariants.empty()) {
-		if (json.back() != '{')
-			json += ',';
+		if (json.back() != '{') json += ',';
 		json += R"("KHR_materials_variants":{"variants":[)";
 		for (const auto& variant : asset.materialVariants) {
-			if (json.back() == '}')
-				json += ',';
+			if (json.back() == '}') json += ',';
 			json += R"({"name":")" + variant + "\"}";
 		}
 		json += "]}";
 	}
 
-    json += '}';
+	json += '}';
 }
 
 fs::path fg::Exporter::getBufferFilePath(const Asset& asset, std::size_t index) {
-    const auto& bufferName = asset.buffers[index].name;
-    if (bufferName.empty()) {
-        return bufferFolder / ("buffer" + std::to_string(index) + ".bin");
-    }
+	const auto& bufferName = asset.buffers[index].name;
+	if (bufferName.empty()) {
+		return bufferFolder / ("buffer" + std::to_string(index) + ".bin");
+	}
 	return bufferFolder / (bufferName + ".bin");
 }
 
 fs::path fg::Exporter::getImageFilePath(const Asset& asset, std::size_t index, MimeType mimeType) {
-    std::string_view extension;
-    switch (mimeType) {
-        case MimeType::JPEG:
-            extension = ".jpeg";
-            break;
-        case MimeType::PNG:
-            extension = ".png";
-            break;
-		case MimeType::KTX2:
-			extension = ".ktx2";
-			break;
-		case MimeType::DDS:
-			extension = ".dds";
-			break;
+	std::string_view extension;
+	switch (mimeType) {
+		case MimeType::JPEG:        extension = ".jpeg"; break;
+		case MimeType::PNG:         extension = ".png"; break;
+		case MimeType::KTX2:        extension = ".ktx2"; break;
+		case MimeType::DDS:         extension = ".dds"; break;
 		default:
 		case MimeType::None:
 		case MimeType::GltfBuffer:
-		case MimeType::OctetStream:
-			extension = ".bin";
-			break;
-    }
+		case MimeType::OctetStream: extension = ".bin"; break;
+	}
 
-    const auto& imageName = asset.images[index].name;
+	const auto& imageName = asset.images[index].name;
 	if (imageName.empty()) {
 		return imageFolder / ("image" + std::to_string(index) + std::string(extension));
 	}
 	return imageFolder / (std::string(imageName) + std::string(extension));
 }
 
-std::string fg::Exporter::writeJson(const fastgltf::Asset &asset) {
-    // Fairly rudimentary approach of just composing the JSON string using a std::string.
-    std::string outputString;
+std::string fg::Exporter::writeJson(const fastgltf::Asset& asset) {
+	// Fairly rudimentary approach of just composing the JSON string using a std::string.
+	std::string outputString;
 
-    outputString += "{";
+	outputString += "{";
 
-    // Write asset info
-    outputString += "\"asset\":{";
-    if (asset.assetInfo.has_value()) {
-        if (!asset.assetInfo->copyright.empty())
-            outputString += R"("copyright":")" + fg::escapeString(asset.assetInfo->copyright) + "\",";
-        if (!asset.assetInfo->generator.empty())
-            outputString += R"("generator":")" + fg::escapeString(asset.assetInfo->generator) + "\",";
-        outputString += R"("version":")" + asset.assetInfo->gltfVersion + '"';
-    } else {
-        outputString += R"("generator":"fastgltf",)";
-        outputString += R"("version":"2.0")";
-    }
-    outputString += '}';
+	// Write asset info
+	outputString += "\"asset\":{";
+	if (asset.assetInfo.has_value()) {
+		if (!asset.assetInfo->copyright.empty())
+			outputString +=
+				R"("copyright":")" + fg::escapeString(asset.assetInfo->copyright) + "\",";
+		if (!asset.assetInfo->generator.empty())
+			outputString +=
+				R"("generator":")" + fg::escapeString(asset.assetInfo->generator) + "\",";
+		outputString += R"("version":")" + asset.assetInfo->gltfVersion + '"';
+	} else {
+		outputString += R"("generator":"fastgltf",)";
+		outputString += R"("version":"2.0")";
+	}
+	outputString += '}';
 
 	// Write extension usage info
 	if (!asset.extensionsUsed.empty()) {
@@ -6969,7 +7236,8 @@ std::string fg::Exporter::writeJson(const fastgltf::Asset &asset) {
 		outputString += "\"extensionsUsed\":[";
 		for (auto it = asset.extensionsUsed.begin(); it != asset.extensionsUsed.end(); ++it) {
 			outputString += '\"' + *it + '\"';
-			if (uabs(std::distance(asset.extensionsUsed.begin(), it)) + 1 <asset.extensionsUsed.size())
+			if (uabs(std::distance(asset.extensionsUsed.begin(), it)) + 1 <
+				asset.extensionsUsed.size())
 				outputString += ',';
 		}
 		outputString += ']';
@@ -6977,106 +7245,116 @@ std::string fg::Exporter::writeJson(const fastgltf::Asset &asset) {
 	if (!asset.extensionsRequired.empty()) {
 		if (outputString.back() != '{') outputString += ',';
 		outputString += "\"extensionsRequired\":[";
-		for (auto it = asset.extensionsRequired.begin(); it != asset.extensionsRequired.end(); ++it) {
+		for (auto it = asset.extensionsRequired.begin(); it != asset.extensionsRequired.end();
+			 ++it) {
 			outputString += '\"' + *it + '\"';
-			if (uabs(std::distance(asset.extensionsRequired.begin(), it)) + 1 <asset.extensionsRequired.size())
+			if (uabs(std::distance(asset.extensionsRequired.begin(), it)) + 1 <
+				asset.extensionsRequired.size())
 				outputString += ',';
 		}
 		outputString += ']';
 	}
 
-    writeAccessors(asset, outputString);
-    writeAnimations(asset, outputString);
-    writeBuffers(asset, outputString);
-    writeBufferViews(asset, outputString);
-    writeCameras(asset, outputString);
-    writeImages(asset, outputString);
-    writeMaterials(asset, outputString);
-    writeMeshes(asset, outputString);
-    writeNodes(asset, outputString);
-    writeSamplers(asset, outputString);
-    writeScenes(asset, outputString);
-    writeSkins(asset, outputString);
-    writeTextures(asset, outputString);
-    writeExtensions(asset, outputString);
+	writeAccessors(asset, outputString);
+	writeAnimations(asset, outputString);
+	writeBuffers(asset, outputString);
+	writeBufferViews(asset, outputString);
+	writeCameras(asset, outputString);
+	writeImages(asset, outputString);
+	writeMaterials(asset, outputString);
+	writeMeshes(asset, outputString);
+	writeNodes(asset, outputString);
+	writeSamplers(asset, outputString);
+	writeScenes(asset, outputString);
+	writeSkins(asset, outputString);
+	writeTextures(asset, outputString);
+	writeExtensions(asset, outputString);
 
-    outputString += "}";
+	outputString += "}";
 
-    if (hasBit(options, ExportOptions::PrettyPrintJson)) {
-        prettyPrintJson(outputString);
-    }
+	if (hasBit(options, ExportOptions::PrettyPrintJson)) {
+		prettyPrintJson(outputString);
+	}
 
-    return outputString;
+	return outputString;
 }
 
-fg::Expected<fg::ExportResult<std::string>> fg::Exporter::writeGltfJson(const Asset& asset, ExportOptions _options) {
-    bufferPaths.clear();
-    imagePaths.clear();
-    options = _options;
+fg::Expected<fg::ExportResult<std::string>> fg::Exporter::writeGltfJson(const Asset& asset,
+																		ExportOptions _options) {
+	bufferPaths.clear();
+	imagePaths.clear();
+	options = _options;
 	exportingBinary = false;
 
-    if (hasBit(options, ExportOptions::ValidateAsset)) {
-        if (const auto validation = validate(asset); validation != Error::None) {
-            return validation;
-        }
-    }
+	if (hasBit(options, ExportOptions::ValidateAsset)) {
+		if (const auto validation = validate(asset); validation != Error::None) {
+			return validation;
+		}
+	}
 
-    // Fairly rudimentary approach of just composing the JSON string using a std::string.
-    std::string outputString = writeJson(asset);
-    if (errorCode != Error::None) {
+	// Fairly rudimentary approach of just composing the JSON string using a std::string.
+	std::string outputString = writeJson(asset);
+	if (errorCode != Error::None) {
 		return errorCode;
-    }
+	}
 
-    ExportResult<std::string> result;
-    result.output = std::move(outputString);
-    result.bufferPaths = std::move(bufferPaths);
-    result.imagePaths = std::move(imagePaths);
-    return result;
+	ExportResult<std::string> result;
+	result.output = std::move(outputString);
+	result.bufferPaths = std::move(bufferPaths);
+	result.imagePaths = std::move(imagePaths);
+	return result;
 }
 
-fg::Expected<fg::ExportResult<std::vector<std::byte>>> fg::Exporter::writeGltfBinary(const Asset& asset, ExportOptions _options) {
-    bufferPaths.clear();
-    imagePaths.clear();
-    options = _options;
+fg::Expected<fg::ExportResult<std::vector<std::byte>>> fg::Exporter::writeGltfBinary(
+	const Asset& asset, ExportOptions _options) {
+	bufferPaths.clear();
+	imagePaths.clear();
+	options = _options;
 	exportingBinary = true;
 
-    options &= (~ExportOptions::PrettyPrintJson);
+	options &= (~ExportOptions::PrettyPrintJson);
 
-    ExportResult<std::vector<std::byte>> result;
-    auto json = writeJson(asset);
-    if (errorCode != Error::None) {
+	ExportResult<std::vector<std::byte>> result;
+	auto json = writeJson(asset);
+	if (errorCode != Error::None) {
 		return errorCode;
-    }
+	}
 
-    result.bufferPaths = std::move(bufferPaths);
-    result.imagePaths = std::move(imagePaths);
+	result.bufferPaths = std::move(bufferPaths);
+	result.imagePaths = std::move(imagePaths);
 
 	// TODO: Add ExportOption enumeration for disabling this?
-    const bool withEmbeddedBuffer = !asset.buffers.empty()
-			// We only support writing Vectors and ByteViews as embedded buffers
-			&& (std::holds_alternative<sources::Array>(asset.buffers.front().data) || std::holds_alternative<sources::ByteView>(asset.buffers.front().data) || std::holds_alternative<sources::Vector>(asset.buffers.front().data))
-			&& asset.buffers.front().byteLength < std::numeric_limits<decltype(BinaryGltfChunk::chunkLength)>::max();
+	const bool withEmbeddedBuffer =
+		!asset.buffers.empty()
+		// We only support writing Vectors and ByteViews as embedded buffers
+		&& (std::holds_alternative<sources::Array>(asset.buffers.front().data) ||
+			std::holds_alternative<sources::ByteView>(asset.buffers.front().data) ||
+			std::holds_alternative<sources::Vector>(asset.buffers.front().data)) &&
+		asset.buffers.front().byteLength <
+			std::numeric_limits<decltype(BinaryGltfChunk::chunkLength)>::max();
 
-    std::size_t binarySize = 0;
-    binarySize += sizeof(BinaryGltfHeader); // glTF header
-    binarySize += sizeof(BinaryGltfChunk) + alignUp(json.size(), 4); // JSON chunk
-    if (withEmbeddedBuffer) {
-        binarySize += sizeof(BinaryGltfChunk) + alignUp(asset.buffers.front().byteLength, 4); // BIN chunk
-    }
+	std::size_t binarySize = 0;
+	binarySize += sizeof(BinaryGltfHeader);                           // glTF header
+	binarySize += sizeof(BinaryGltfChunk) + alignUp(json.size(), 4);  // JSON chunk
+	if (withEmbeddedBuffer) {
+		binarySize +=
+			sizeof(BinaryGltfChunk) + alignUp(asset.buffers.front().byteLength, 4);  // BIN chunk
+	}
 
 	// A GLB is limited to 2^32 bytes since the length field in the file header is a 32-bit integer.
-	if (binarySize >= static_cast<std::size_t>(std::numeric_limits<decltype(BinaryGltfHeader::length)>::max())) {
+	if (binarySize >=
+		static_cast<std::size_t>(std::numeric_limits<decltype(BinaryGltfHeader::length)>::max())) {
 		return Error::InvalidGLB;
 	}
 
-    result.output.resize(binarySize);
-    auto write = [output = result.output.data()](const void* data, std::size_t size) mutable {
-        std::memcpy(output, data, size);
-        output += size;
-    };
+	result.output.resize(binarySize);
+	auto write = [output = result.output.data()](const void* data, std::size_t size) mutable {
+		std::memcpy(output, data, size);
+		output += size;
+	};
 
 	// Write glTF header
-	BinaryGltfHeader header {};
+	BinaryGltfHeader header{};
 	header.magic = binaryGltfHeaderMagic;
 	header.version = 2;
 	header.length = static_cast<std::uint32_t>(binarySize);
@@ -7084,121 +7362,118 @@ fg::Expected<fg::ExportResult<std::vector<std::byte>>> fg::Exporter::writeGltfBi
 	write(headerBytes.data(), headerBytes.size());
 
 	// Write JSON chunk
-	BinaryGltfChunk jsonChunk {};
+	BinaryGltfChunk jsonChunk{};
 	jsonChunk.chunkType = binaryGltfJsonChunkMagic;
 	jsonChunk.chunkLength = static_cast<std::uint32_t>(alignUp(json.size(), 4));
 	auto chunkBytes = writeBinaryChunk(jsonChunk);
 	write(chunkBytes.data(), chunkBytes.size());
 
-    write(json.data(), json.size());
+	write(json.data(), json.size());
 
-    // 4 bytes padding with space character (0x20)
-    for (std::size_t i = json.size(); i % 4 != 0; ++i) {
-        static constexpr std::uint8_t space = 0x20U;
-        write(&space, sizeof space);
-    }
+	// 4 bytes padding with space character (0x20)
+	for (std::size_t i = json.size(); i % 4 != 0; ++i) {
+		static constexpr std::uint8_t space = 0x20U;
+		write(&space, sizeof space);
+	}
 
-    if (withEmbeddedBuffer) {
-        const auto& buffer = asset.buffers.front();
+	if (withEmbeddedBuffer) {
+		const auto& buffer = asset.buffers.front();
 
-        // Write BIN chunk
-        BinaryGltfChunk dataChunk {};
-        dataChunk.chunkType = binaryGltfDataChunkMagic;
-        dataChunk.chunkLength = static_cast<std::uint32_t>(alignUp(buffer.byteLength, 4));
+		// Write BIN chunk
+		BinaryGltfChunk dataChunk{};
+		dataChunk.chunkType = binaryGltfDataChunkMagic;
+		dataChunk.chunkLength = static_cast<std::uint32_t>(alignUp(buffer.byteLength, 4));
 		chunkBytes = writeBinaryChunk(dataChunk);
 		write(chunkBytes.data(), chunkBytes.size());
 
-		std::visit(visitor {
-			[](auto&) {},
-			[&](const sources::Array& vector) {
-				write(vector.bytes.data(), buffer.byteLength);
-			},
-			[&](const sources::Vector& vector) {
-				write(vector.bytes.data(), buffer.byteLength);
-			},
-			[&](const sources::ByteView& byteView) {
-				write(byteView.bytes.data(), buffer.byteLength);
-			},
-		}, buffer.data);
+		std::visit(visitor{
+					   [](auto&) {},
+					   [&](const sources::Array& vector) {
+			write(vector.bytes.data(), buffer.byteLength);
+		},
+					   [&](const sources::Vector& vector) {
+			write(vector.bytes.data(), buffer.byteLength);
+		},
+					   [&](const sources::ByteView& byteView) {
+			write(byteView.bytes.data(), buffer.byteLength);
+		},
+				   },
+				   buffer.data);
 
-        // 4 bytes padding with zeros
-        for (std::size_t i = buffer.byteLength; i % 4 != 0; ++i) {
-            static constexpr std::uint8_t zero = 0x0U;
-            write(&zero, sizeof zero);
-        }
-    }
+		// 4 bytes padding with zeros
+		for (std::size_t i = buffer.byteLength; i % 4 != 0; ++i) {
+			static constexpr std::uint8_t zero = 0x0U;
+			write(&zero, sizeof zero);
+		}
+	}
 
-    return result;
+	return result;
 }
 
 namespace fastgltf {
-	bool writeFile(const DataSource& dataSource, const fs::path& baseFolder, const fs::path& filePath) {
-		// Get the final normalized path. TODO: Perhaps move these filesystem checks to the parent function?
-		auto finalPath = (baseFolder / filePath).lexically_normal();
-		if (std::error_code ec; !fs::exists(finalPath.parent_path(), ec) || ec) {
-			// If the parent folder of the destination file does not exist, we'll create it.
-			fs::create_directory(finalPath.parent_path(), ec);
-			if (ec) {
-				return false;
-			}
+bool writeFile(const DataSource& dataSource, const fs::path& baseFolder, const fs::path& filePath) {
+	// Get the final normalized path. TODO: Perhaps move these filesystem checks to the parent
+	// function?
+	auto finalPath = (baseFolder / filePath).lexically_normal();
+	if (std::error_code ec; !fs::exists(finalPath.parent_path(), ec) || ec) {
+		// If the parent folder of the destination file does not exist, we'll create it.
+		fs::create_directory(finalPath.parent_path(), ec);
+		if (ec) {
+			return false;
 		}
-
-		return std::visit(visitor {
-			[](auto&) {
-				return false;
-			},
-			[&](const sources::Array& vector) {
-				std::ofstream file(finalPath, std::ios::out | std::ios::binary);
-				if (!file.is_open())
-					return false;
-				file.write(reinterpret_cast<const char *>(vector.bytes.data()),
-						   static_cast<std::streamsize>(vector.bytes.size()));
-				file.close();
-				return file.good();
-			},
-			[&](const sources::Vector& vector) {
-				std::ofstream file(finalPath, std::ios::out | std::ios::binary);
-				if (!file.is_open())
-					return false;
-				file.write(reinterpret_cast<const char *>(vector.bytes.data()),
-						   static_cast<std::streamsize>(vector.bytes.size()));
-				file.close();
-				return file.good();
-			},
-			[&](const sources::ByteView& view) {
-				std::ofstream file(finalPath, std::ios::out | std::ios::binary);
-				if (!file.is_open())
-					return false;
-				file.write(reinterpret_cast<const char *>(view.bytes.data()),
-						   static_cast<std::streamsize>(view.bytes.size()));
-				file.close();
-				return file.good();
-			},
-		}, dataSource);
 	}
 
-	template<typename T>
-	bool writeFiles(const Asset& asset, ExportResult<T> &result, const fs::path& baseFolder) {
-		for (std::size_t i = 0; i < asset.buffers.size(); ++i) {
-			auto& path = result.bufferPaths[i];
-			if (path.has_value()) {
-				if (!writeFile(asset.buffers[i].data, baseFolder, path.value()))
-					return false;
-			}
-		}
+	return std::visit(visitor{
+						  [](auto&) { return false; },
+						  [&](const sources::Array& vector) {
+		std::ofstream file(finalPath, std::ios::out | std::ios::binary);
+		if (!file.is_open()) return false;
+		file.write(reinterpret_cast<const char*>(vector.bytes.data()),
+				   static_cast<std::streamsize>(vector.bytes.size()));
+		file.close();
+		return file.good();
+	},
+						  [&](const sources::Vector& vector) {
+		std::ofstream file(finalPath, std::ios::out | std::ios::binary);
+		if (!file.is_open()) return false;
+		file.write(reinterpret_cast<const char*>(vector.bytes.data()),
+				   static_cast<std::streamsize>(vector.bytes.size()));
+		file.close();
+		return file.good();
+	},
+						  [&](const sources::ByteView& view) {
+		std::ofstream file(finalPath, std::ios::out | std::ios::binary);
+		if (!file.is_open()) return false;
+		file.write(reinterpret_cast<const char*>(view.bytes.data()),
+				   static_cast<std::streamsize>(view.bytes.size()));
+		file.close();
+		return file.good();
+	},
+					  },
+					  dataSource);
+}
 
-		for (std::size_t i = 0; i < asset.images.size(); ++i) {
-			auto& path = result.imagePaths[i];
-			if (path.has_value()) {
-				if (!writeFile(asset.images[i].data, baseFolder, path.value()))
-					return false;
-			}
+template <typename T>
+bool writeFiles(const Asset& asset, ExportResult<T>& result, const fs::path& baseFolder) {
+	for (std::size_t i = 0; i < asset.buffers.size(); ++i) {
+		auto& path = result.bufferPaths[i];
+		if (path.has_value()) {
+			if (!writeFile(asset.buffers[i].data, baseFolder, path.value())) return false;
 		}
-		return true;
 	}
-} // namespace fastgltf
 
-fg::Error fg::FileExporter::writeGltfJson(const Asset& asset, const fs::path& target, const ExportOptions _options) {
+	for (std::size_t i = 0; i < asset.images.size(); ++i) {
+		auto& path = result.imagePaths[i];
+		if (path.has_value()) {
+			if (!writeFile(asset.images[i].data, baseFolder, path.value())) return false;
+		}
+	}
+	return true;
+}
+}  // namespace fastgltf
+
+fg::Error fg::FileExporter::writeGltfJson(const Asset& asset, const fs::path& target,
+										  const ExportOptions _options) {
 	if (std::error_code ec; !fs::exists(target.parent_path(), ec) || ec) {
 		fs::create_directory(target.parent_path(), ec);
 		if (ec) {
@@ -7208,26 +7483,27 @@ fg::Error fg::FileExporter::writeGltfJson(const Asset& asset, const fs::path& ta
 
 	auto expected = Exporter::writeGltfJson(asset, _options);
 
-    if (!expected) {
-        return expected.error();
-    }
-    auto& result = expected.get();
+	if (!expected) {
+		return expected.error();
+	}
+	auto& result = expected.get();
 
-    std::ofstream file(target, std::ios::out);
-    if (!file.is_open()) {
-        return fg::Error::InvalidPath;
-    }
+	std::ofstream file(target, std::ios::out);
+	if (!file.is_open()) {
+		return fg::Error::InvalidPath;
+	}
 
-    file << result.output;
-    file.close();
+	file << result.output;
+	file.close();
 
 	if (!writeFiles(asset, result, target.parent_path())) {
 		return Error::FailedWritingFiles;
 	}
-    return Error::None;
+	return Error::None;
 }
 
-fg::Error fg::FileExporter::writeGltfBinary(const Asset& asset, const fs::path& target, const ExportOptions _options) {
+fg::Error fg::FileExporter::writeGltfBinary(const Asset& asset, const fs::path& target,
+											const ExportOptions _options) {
 	if (std::error_code ec; !fs::exists(target.parent_path(), ec) || ec) {
 		fs::create_directory(target.parent_path(), ec);
 		if (ec) {
@@ -7235,28 +7511,28 @@ fg::Error fg::FileExporter::writeGltfBinary(const Asset& asset, const fs::path& 
 		}
 	}
 
-    auto expected = Exporter::writeGltfBinary(asset, _options);
+	auto expected = Exporter::writeGltfBinary(asset, _options);
 
-    if (!expected) {
-        return expected.error();
-    }
-    auto& result = expected.get();
+	if (!expected) {
+		return expected.error();
+	}
+	auto& result = expected.get();
 
-    std::ofstream file(target, std::ios::out | std::ios::binary);
-    if (!file.is_open()) {
-        return Error::InvalidPath;
-    }
+	std::ofstream file(target, std::ios::out | std::ios::binary);
+	if (!file.is_open()) {
+		return Error::InvalidPath;
+	}
 
-    file.write(reinterpret_cast<const char*>(result.output.data()),
-               static_cast<std::streamsize>(result.output.size()));
+	file.write(reinterpret_cast<const char*>(result.output.data()),
+			   static_cast<std::streamsize>(result.output.size()));
 
 	if (!writeFiles(asset, result, target.parent_path())) {
 		return Error::FailedWritingFiles;
 	}
-    return Error::None;
+	return Error::None;
 }
 #pragma endregion
 
 #ifdef _MSC_VER
-#pragma warning(pop)
+#	pragma warning(pop)
 #endif

--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -242,11 +242,11 @@ namespace fastgltf {
 		using namespace simdjson;
 
 		dom::object source;
-		if (element.get(source) != simdjson::SUCCESS) FASTGLTF_UNLIKELY {
+		if (element.get(source) != simdjson::SUCCESS) [[unlikely]] {
 			return false;
 		}
 		std::uint64_t imageIndex;
-		if (source["source"].get_uint64().get(imageIndex) != simdjson::SUCCESS) FASTGLTF_UNLIKELY {
+		if (source["source"].get_uint64().get(imageIndex) != simdjson::SUCCESS) [[unlikely]] {
 			return false;
 		}
 
@@ -293,7 +293,7 @@ namespace fastgltf {
 		if (error == NO_SUCH_FIELD) {
 			return Error::MissingField;
 		}
-		if (error == SUCCESS) FASTGLTF_LIKELY {
+		if (error == SUCCESS) [[likely]] {
 			return Error::None;
 		}
 		return Error::InvalidJson;
@@ -312,70 +312,70 @@ namespace fastgltf {
 		dom::object child;
 		if (auto childErr = object[key].get_object().get(child); childErr == NO_SUCH_FIELD) {
 			return Error::MissingField;
-		} else if (childErr != SUCCESS) FASTGLTF_UNLIKELY {
+		} else if (childErr != SUCCESS) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
 		std::uint64_t index;
-		if (child["index"].get_uint64().get(index) == SUCCESS) FASTGLTF_LIKELY {
+		if (child["index"].get_uint64().get(index) == SUCCESS) [[likely]] {
 			info->textureIndex = static_cast<std::size_t>(index);
 		} else {
 			return Error::InvalidGltf;
 		}
 
-		if (const auto error = child["texCoord"].get_uint64().get(index); error == SUCCESS) FASTGLTF_LIKELY {
+		if (const auto error = child["texCoord"].get_uint64().get(index); error == SUCCESS) [[likely]] {
 			info->texCoordIndex = static_cast<std::size_t>(index);
-		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
             return Error::InvalidJson;
 		}
 
 		if (type == TextureInfoType::NormalTexture) {
             double scale;
-			if (const auto error = child["scale"].get_double().get(scale); error == SUCCESS) FASTGLTF_LIKELY {
+			if (const auto error = child["scale"].get_double().get(scale); error == SUCCESS) [[likely]] {
 				reinterpret_cast<NormalTextureInfo*>(info)->scale = static_cast<num>(scale);
-			} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+			} else if (error != NO_SUCH_FIELD) [[unlikely]] {
                 return Error::InvalidGltf;
 			}
 		} else if (type == TextureInfoType::OcclusionTexture) {
 			double strength;
-			if (const auto error = child["strength"].get_double().get(strength); error == SUCCESS) FASTGLTF_LIKELY {
+			if (const auto error = child["strength"].get_double().get(strength); error == SUCCESS) [[likely]] {
 				reinterpret_cast<OcclusionTextureInfo*>(info)->strength = static_cast<num>(strength);
-			} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+			} else if (error != NO_SUCH_FIELD) [[unlikely]] {
                 return Error::InvalidGltf;
             }
 		}
 
 		dom::object extensionsObject;
-		if (child["extensions"].get_object().get(extensionsObject) == SUCCESS) FASTGLTF_LIKELY {
+		if (child["extensions"].get_object().get(extensionsObject) == SUCCESS) [[likely]] {
 			dom::object textureTransform;
-			if (hasBit(extensions, Extensions::KHR_texture_transform) && extensionsObject[extensions::KHR_texture_transform].get_object().get(textureTransform) == SUCCESS) FASTGLTF_LIKELY {
+			if (hasBit(extensions, Extensions::KHR_texture_transform) && extensionsObject[extensions::KHR_texture_transform].get_object().get(textureTransform) == SUCCESS) [[likely]] {
 				auto transform = std::make_unique<TextureTransform>();
 				transform->rotation = 0.0F;
 
-				if (textureTransform["texCoord"].get_uint64().get(index) == SUCCESS) FASTGLTF_LIKELY {
+				if (textureTransform["texCoord"].get_uint64().get(index) == SUCCESS) [[likely]] {
 					transform->texCoordIndex = index;
 				}
 
 				double rotation = 0.0F;
-				if (textureTransform["rotation"].get_double().get(rotation) == SUCCESS) FASTGLTF_LIKELY {
+				if (textureTransform["rotation"].get_double().get(rotation) == SUCCESS) [[likely]] {
 					transform->rotation = static_cast<num>(rotation);
 				}
 
 				dom::array array;
-				if (textureTransform["offset"].get_array().get(array) == SUCCESS) FASTGLTF_LIKELY {
+				if (textureTransform["offset"].get_array().get(array) == SUCCESS) [[likely]] {
 					for (auto i = 0U; i < 2; ++i) {
 						double val;
-						if (array.at(i).get_double().get(val) != SUCCESS) FASTGLTF_UNLIKELY {
+						if (array.at(i).get_double().get(val) != SUCCESS) [[unlikely]] {
 							return Error::InvalidGltf;
 						}
 						transform->uvOffset[i] = static_cast<num>(val);
 					}
 				}
 
-				if (textureTransform["scale"].get_array().get(array) == SUCCESS) FASTGLTF_LIKELY {
+				if (textureTransform["scale"].get_array().get(array) == SUCCESS) [[likely]] {
 					for (auto i = 0U; i < 2; ++i) {
 						double val;
-						if (array.at(i).get_double().get(val) != SUCCESS) FASTGLTF_UNLIKELY {
+						if (array.at(i).get_double().get(val) != SUCCESS) [[unlikely]] {
 							return Error::InvalidGltf;
 						}
 						transform->uvScale[i] = static_cast<num>(val);
@@ -785,7 +785,7 @@ template <typename T> fg::Error fg::Parser::parseAttributes(simdjson::dom::objec
 		const auto key = field.key;
 
 		std::uint64_t accessorIndex;
-		if (field.value.get_uint64().get(accessorIndex) != SUCCESS) FASTGLTF_UNLIKELY {
+		if (field.value.get_uint64().get(accessorIndex) != SUCCESS) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 		attributes.emplace_back(Attribute {
@@ -1461,12 +1461,12 @@ fg::Expected<fg::Asset> fg::Parser::parse(simdjson::dom::object root, Category c
 		if (error == NO_SUCH_FIELD) {
 			return Error::InvalidOrMissingAssetField;
 		}
-		if (error != SUCCESS) FASTGLTF_UNLIKELY {
+		if (error != SUCCESS) [[unlikely]] {
 			return Error::InvalidJson;
 		}
 
 		std::string_view version;
-		if (assetInfo["version"].get_string().get(version) != SUCCESS) FASTGLTF_UNLIKELY {
+		if (assetInfo["version"].get_string().get(version) != SUCCESS) [[unlikely]] {
 			return Error::InvalidOrMissingAssetField;
 		}
 
@@ -1478,22 +1478,22 @@ fg::Expected<fg::Asset> fg::Parser::parse(simdjson::dom::object root, Category c
 		info.gltfVersion = std::string { version };
 
 		std::string_view copyright;
-		if (assetInfo["copyright"].get_string().get(copyright) == SUCCESS) FASTGLTF_LIKELY {
+		if (assetInfo["copyright"].get_string().get(copyright) == SUCCESS) [[likely]] {
 			info.copyright = std::string { copyright };
 		}
 
 		std::string_view generator;
-		if (assetInfo["generator"].get_string().get(generator) == SUCCESS) FASTGLTF_LIKELY {
+		if (assetInfo["generator"].get_string().get(generator) == SUCCESS) [[likely]] {
 			info.generator = std::string { generator };
 		}
 
 		asset.assetInfo = std::move(info);
 	}
 
-	if (dom::array extensionsRequired; root["extensionsRequired"].get_array().get(extensionsRequired) == SUCCESS) FASTGLTF_LIKELY {
+	if (dom::array extensionsRequired; root["extensionsRequired"].get_array().get(extensionsRequired) == SUCCESS) [[likely]] {
 		for (auto extension : extensionsRequired) {
 			std::string_view string;
-			if (extension.get_string().get(string) != SUCCESS) FASTGLTF_UNLIKELY {
+			if (extension.get_string().get(string) != SUCCESS) [[unlikely]] {
 				return Error::InvalidGltf;
 			}
 
@@ -1522,7 +1522,7 @@ fg::Expected<fg::Asset> fg::Parser::parse(simdjson::dom::object root, Category c
 		auto hashedKey = crcStringFunction(object.key);
 		if (hashedKey == force_consteval<crc32c("scene")>) {
 			std::uint64_t defaultScene;
-			if (object.value.get_uint64().get(defaultScene) != SUCCESS) FASTGLTF_UNLIKELY {
+			if (object.value.get_uint64().get(defaultScene) != SUCCESS) [[unlikely]] {
 				return Error::InvalidGltf;
 			}
 			asset.defaultScene = static_cast<std::size_t>(defaultScene);
@@ -1531,7 +1531,7 @@ fg::Expected<fg::Asset> fg::Parser::parse(simdjson::dom::object root, Category c
 
 		if (hashedKey == force_consteval<crc32c("extensions")>) {
 			dom::object extensionsObject;
-			if (object.value.get_object().get(extensionsObject) != SUCCESS) FASTGLTF_UNLIKELY {
+			if (object.value.get_object().get(extensionsObject) != SUCCESS) [[unlikely]] {
 				return Error::InvalidGltf;
 			}
 
@@ -1545,7 +1545,7 @@ fg::Expected<fg::Asset> fg::Parser::parse(simdjson::dom::object root, Category c
 		}
 
 		dom::array array;
-		if (object.value.get_array().get(array) != SUCCESS) FASTGLTF_UNLIKELY {
+		if (object.value.get_array().get(array) != SUCCESS) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
@@ -1573,7 +1573,7 @@ fg::Expected<fg::Asset> fg::Parser::parse(simdjson::dom::object root, Category c
 			case force_consteval<crc32c("extensionsUsed")>: {
 				for (auto usedValue : array) {
 					std::string_view usedString;
-					if (auto eError = usedValue.get_string().get(usedString); eError == SUCCESS) FASTGLTF_LIKELY {
+					if (auto eError = usedValue.get_string().get(usedString); eError == SUCCESS) [[likely]] {
 						FASTGLTF_STD_PMR_NS::string FASTGLTF_CONSTRUCT_PMR_RESOURCE(string, resourceAllocator.get(), usedString);
 						asset.extensionsUsed.emplace_back(std::move(string));
 					} else {
@@ -1627,12 +1627,12 @@ fg::Error fg::Parser::parseAccessors(const simdjson::dom::array& accessors, Asse
         // Required fields: "componentType", "count"
         Accessor accessor = {};
         dom::object accessorObject;
-        if (accessorValue.get_object().get(accessorObject) != SUCCESS) FASTGLTF_UNLIKELY {
+        if (accessorValue.get_object().get(accessorObject) != SUCCESS) [[unlikely]] {
             return Error::InvalidGltf;
         }
 
         std::uint64_t componentType;
-        if (accessorObject["componentType"].get_uint64().get(componentType) != SUCCESS) FASTGLTF_UNLIKELY {
+        if (accessorObject["componentType"].get_uint64().get(componentType) != SUCCESS) [[unlikely]] {
             return Error::InvalidGltf;
         }
 		accessor.componentType = getComponentType(static_cast<std::underlying_type_t<ComponentType>>(componentType));
@@ -1641,35 +1641,35 @@ fg::Error fg::Parser::parseAccessors(const simdjson::dom::array& accessors, Asse
         }
 
         std::string_view accessorType;
-        if (accessorObject["type"].get_string().get(accessorType) != SUCCESS) FASTGLTF_UNLIKELY {
+        if (accessorObject["type"].get_string().get(accessorType) != SUCCESS) [[unlikely]] {
             return Error::InvalidGltf;
         }
 		accessor.type = getAccessorType(accessorType);
 
         std::uint64_t accessorCount;
-        if (accessorObject["count"].get_uint64().get(accessorCount) != SUCCESS) FASTGLTF_UNLIKELY {
+        if (accessorObject["count"].get_uint64().get(accessorCount) != SUCCESS) [[unlikely]] {
             return Error::InvalidGltf;
         }
 		accessor.count = static_cast<std::size_t>(accessorCount);
 
 
         std::uint64_t bufferView;
-        if (accessorObject["bufferView"].get_uint64().get(bufferView) == SUCCESS) FASTGLTF_LIKELY {
+        if (accessorObject["bufferView"].get_uint64().get(bufferView) == SUCCESS) [[likely]] {
             accessor.bufferViewIndex = static_cast<std::size_t>(bufferView);
         }
 
         // byteOffset is optional, but defaults to 0
         std::uint64_t byteOffset;
-        if (auto error = accessorObject["byteOffset"].get_uint64().get(byteOffset); error == SUCCESS) FASTGLTF_LIKELY {
+        if (auto error = accessorObject["byteOffset"].get_uint64().get(byteOffset); error == SUCCESS) [[likely]] {
             accessor.byteOffset = static_cast<std::size_t>(byteOffset);
-        } else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+        } else if (error != NO_SUCH_FIELD) [[unlikely]] {
             return Error::InvalidGltf;
         }
 
 		// Type of min and max should always be the same.
 		auto parseMinMax = [&](const std::string_view key, std::optional<AccessorBoundsArray>& ref) -> Error {
 			dom::array elements;
-			if (accessorObject[key].get_array().get(elements) == SUCCESS) FASTGLTF_LIKELY {
+			if (accessorObject[key].get_array().get(elements) == SUCCESS) [[likely]] {
 				const auto num = getNumComponents(accessor.type);
 
 				if (accessor.componentType == ComponentType::Float || accessor.componentType == ComponentType::Double) {
@@ -1681,14 +1681,14 @@ fg::Error fg::Parser::parseAccessors(const simdjson::dom::array& accessors, Asse
 				auto& array = ref.value();
 				std::size_t idx = 0;
 				for (auto element : elements) {
-					if (idx == num) FASTGLTF_UNLIKELY {
+					if (idx == num) [[unlikely]] {
 						return Error::InvalidGltf;
 					}
 
 					switch (element.type()) {
 						case dom::element_type::DOUBLE: {
 							double value;
-							if (element.get_double().get(value) != SUCCESS) FASTGLTF_UNLIKELY {
+							if (element.get_double().get(value) != SUCCESS) [[unlikely]] {
 								return Error::InvalidGltf;
 							}
 
@@ -1703,7 +1703,7 @@ fg::Error fg::Parser::parseAccessors(const simdjson::dom::array& accessors, Asse
 						}
 						case dom::element_type::INT64: {
 							std::int64_t value;
-							if (element.get_int64().get(value) != SUCCESS) FASTGLTF_UNLIKELY {
+							if (element.get_int64().get(value) != SUCCESS) [[unlikely]] {
 								return Error::InvalidGltf;
 							}
 
@@ -1721,7 +1721,7 @@ fg::Error fg::Parser::parseAccessors(const simdjson::dom::array& accessors, Asse
 							// truncating uint64 to int64 wouldn't make any difference, as those large values
 							// aren't allowed anyway.
 							std::uint64_t value;
-							if (element.get_uint64().get(value) != SUCCESS) FASTGLTF_UNLIKELY {
+							if (element.get_uint64().get(value) != SUCCESS) [[unlikely]] {
 								return Error::InvalidGltf;
 							}
 
@@ -1738,7 +1738,7 @@ fg::Error fg::Parser::parseAccessors(const simdjson::dom::array& accessors, Asse
 					}
 				}
 
-				if (idx < num) FASTGLTF_UNLIKELY {
+				if (idx < num) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 			}
@@ -1752,7 +1752,7 @@ fg::Error fg::Parser::parseAccessors(const simdjson::dom::array& accessors, Asse
 			return error;
 		}
 
-        if (auto error = accessorObject["normalized"].get_bool().get(accessor.normalized); error != SUCCESS && error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+        if (auto error = accessorObject["normalized"].get_bool().get(accessor.normalized); error != SUCCESS && error != NO_SUCH_FIELD) [[unlikely]] {
             return Error::InvalidGltf;
         }
 
@@ -1762,49 +1762,49 @@ fg::Error fg::Parser::parseAccessors(const simdjson::dom::array& accessors, Asse
 		}
 
         dom::object sparseAccessorObject;
-        if (accessorObject["sparse"].get_object().get(sparseAccessorObject) == SUCCESS) FASTGLTF_LIKELY {
+        if (accessorObject["sparse"].get_object().get(sparseAccessorObject) == SUCCESS) [[likely]] {
             SparseAccessor sparse = {};
             std::uint64_t value;
             dom::object child;
-            if (sparseAccessorObject["count"].get_uint64().get(value) != SUCCESS) FASTGLTF_UNLIKELY {
+            if (sparseAccessorObject["count"].get_uint64().get(value) != SUCCESS) [[unlikely]] {
                 return Error::InvalidGltf;
             }
             sparse.count = static_cast<std::size_t>(value);
 
             // Accessor Sparce Indices
-            if (sparseAccessorObject["indices"].get_object().get(child) != SUCCESS) FASTGLTF_UNLIKELY {
+            if (sparseAccessorObject["indices"].get_object().get(child) != SUCCESS) [[unlikely]] {
                 return Error::InvalidGltf;
             }
 
-            if (child["bufferView"].get_uint64().get(value) != SUCCESS) FASTGLTF_UNLIKELY {
+            if (child["bufferView"].get_uint64().get(value) != SUCCESS) [[unlikely]] {
                 return Error::InvalidGltf;
             }
             sparse.indicesBufferView = static_cast<std::size_t>(value);
 
-            if (auto error = child["byteOffset"].get_uint64().get(value); error == SUCCESS) FASTGLTF_LIKELY {
+            if (auto error = child["byteOffset"].get_uint64().get(value); error == SUCCESS) [[likely]] {
                 sparse.indicesByteOffset = static_cast<std::size_t>(value);
-            } else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+            } else if (error != NO_SUCH_FIELD) [[unlikely]] {
                 return Error::InvalidGltf;
             }
 
-            if (child["componentType"].get_uint64().get(value) != SUCCESS) FASTGLTF_UNLIKELY {
+            if (child["componentType"].get_uint64().get(value) != SUCCESS) [[unlikely]] {
                 return Error::InvalidGltf;
             }
             sparse.indexComponentType = getComponentType(static_cast<std::underlying_type_t<ComponentType>>(value));
 
             // Accessor Sparse Values
-            if (sparseAccessorObject["values"].get_object().get(child) != SUCCESS) FASTGLTF_UNLIKELY {
+            if (sparseAccessorObject["values"].get_object().get(child) != SUCCESS) [[unlikely]] {
                 return Error::InvalidGltf;
             }
 
-            if (child["bufferView"].get_uint64().get(value) != SUCCESS) FASTGLTF_UNLIKELY {
+            if (child["bufferView"].get_uint64().get(value) != SUCCESS) [[unlikely]] {
                 return Error::InvalidGltf;
             }
             sparse.valuesBufferView = static_cast<std::size_t>(value);
 
-            if (auto error = child["byteOffset"].get_uint64().get(value); error == SUCCESS) FASTGLTF_LIKELY {
+            if (auto error = child["byteOffset"].get_uint64().get(value); error == SUCCESS) [[likely]] {
                 sparse.valuesByteOffset = static_cast<std::size_t>(value);
-            } else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+            } else if (error != NO_SUCH_FIELD) [[unlikely]] {
                 return Error::InvalidGltf;
             }
 
@@ -1838,7 +1838,7 @@ fg::Error fg::Parser::parseAnimations(simdjson::dom::array& animations, Asset& a
     for (auto animationValue : animations) {
         dom::object animationObject;
         Animation animation = {};
-        if (animationValue.get_object().get(animationObject) != SUCCESS) FASTGLTF_UNLIKELY {
+        if (animationValue.get_object().get(animationObject) != SUCCESS) [[unlikely]] {
             return Error::InvalidGltf;
         }
 
@@ -1853,24 +1853,24 @@ fg::Error fg::Parser::parseAnimations(simdjson::dom::array& animations, Asset& a
         for (auto channelValue : channels) {
             dom::object channelObject;
             AnimationChannel channel = {};
-            if (channelValue.get_object().get(channelObject) != SUCCESS) FASTGLTF_UNLIKELY {
+            if (channelValue.get_object().get(channelObject) != SUCCESS) [[unlikely]] {
                 return Error::InvalidGltf;
             }
 
             std::uint64_t sampler;
-            if (channelObject["sampler"].get_uint64().get(sampler) != SUCCESS) FASTGLTF_UNLIKELY {
+            if (channelObject["sampler"].get_uint64().get(sampler) != SUCCESS) [[unlikely]] {
                 return Error::InvalidGltf;
             }
             channel.samplerIndex = static_cast<std::size_t>(sampler);
 
             dom::object targetObject;
-            if (channelObject["target"].get_object().get(targetObject) != SUCCESS) FASTGLTF_UNLIKELY {
+            if (channelObject["target"].get_object().get(targetObject) != SUCCESS) [[unlikely]] {
                 return Error::InvalidGltf;
             } else {
                 std::uint64_t node;
-				if (auto error = targetObject["node"].get_uint64().get(node); error == SUCCESS) FASTGLTF_LIKELY {
+				if (auto error = targetObject["node"].get_uint64().get(node); error == SUCCESS) [[likely]] {
 					channel.nodeIndex = static_cast<std::size_t>(node);
-				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					// the glTF spec allows the node index of an animation channel to be absent, and requires
 					// implementations to just ignore the animation if no extension exists to override it.
 					// > When node isn't defined, channel SHOULD be ignored.
@@ -1878,7 +1878,7 @@ fg::Error fg::Parser::parseAnimations(simdjson::dom::array& animations, Asset& a
 				}
 
                 std::string_view path;
-                if (targetObject["path"].get_string().get(path) != SUCCESS) FASTGLTF_UNLIKELY {
+                if (targetObject["path"].get_string().get(path) != SUCCESS) [[unlikely]] {
                     return Error::InvalidGltf;
                 }
 
@@ -1907,24 +1907,24 @@ fg::Error fg::Parser::parseAnimations(simdjson::dom::array& animations, Asset& a
         for (auto samplerValue : samplers) {
             dom::object samplerObject;
             AnimationSampler sampler = {};
-            if (samplerValue.get_object().get(samplerObject) != SUCCESS) FASTGLTF_UNLIKELY {
+            if (samplerValue.get_object().get(samplerObject) != SUCCESS) [[unlikely]] {
                 return Error::InvalidGltf;
             }
 
             std::uint64_t input;
-            if (samplerObject["input"].get_uint64().get(input) != SUCCESS) FASTGLTF_UNLIKELY {
+            if (samplerObject["input"].get_uint64().get(input) != SUCCESS) [[unlikely]] {
                 return Error::InvalidGltf;
             }
             sampler.inputAccessor = static_cast<std::size_t>(input);
 
             std::uint64_t output;
-            if (samplerObject["output"].get_uint64().get(output) != SUCCESS) FASTGLTF_UNLIKELY {
+            if (samplerObject["output"].get_uint64().get(output) != SUCCESS) [[unlikely]] {
                 return Error::InvalidGltf;
             }
             sampler.outputAccessor = static_cast<std::size_t>(output);
 
             std::string_view interpolation;
-            if (samplerObject["interpolation"].get_string().get(interpolation) != SUCCESS) FASTGLTF_UNLIKELY {
+            if (samplerObject["interpolation"].get_string().get(interpolation) != SUCCESS) [[unlikely]] {
                 sampler.interpolation = AnimationInterpolation::Linear;
             } else {
                 if (interpolation == "LINEAR") {
@@ -1971,12 +1971,12 @@ fg::Error fg::Parser::parseBuffers(simdjson::dom::array& buffers, Asset& asset) 
         // Required fields: "byteLength"
         Buffer buffer = {};
         dom::object bufferObject;
-        if (bufferValue.get_object().get(bufferObject) != SUCCESS) FASTGLTF_UNLIKELY {
+        if (bufferValue.get_object().get(bufferObject) != SUCCESS) [[unlikely]] {
             return Error::InvalidGltf;
         }
 
         std::uint64_t byteLength;
-        if (bufferObject["byteLength"].get_uint64().get(byteLength) != SUCCESS) FASTGLTF_UNLIKELY {
+        if (bufferObject["byteLength"].get_uint64().get(byteLength) != SUCCESS) [[unlikely]] {
             return Error::InvalidGltf;
         }
 		buffer.byteLength = static_cast<std::size_t>(byteLength);
@@ -1997,7 +1997,7 @@ fg::Error fg::Parser::parseBuffers(simdjson::dom::array& buffers, Asset& asset) 
         // When parsing GLB, there's a buffer object that will point to the BUF chunk in the
         // file. Otherwise, data must be specified in the "uri" field.
         std::string_view uriString;
-        if (bufferObject["uri"].get_string().get(uriString) == SUCCESS) FASTGLTF_LIKELY {
+        if (bufferObject["uri"].get_string().get(uriString) == SUCCESS) [[likely]] {
 			URIView uriView(uriString);
 
             if (!uriView.valid()) {
@@ -2065,59 +2065,59 @@ fg::Error fg::Parser::parseBufferViews(const simdjson::dom::array& bufferViews, 
 	asset.bufferViews.reserve(bufferViews.size());
     for (auto bufferViewValue : bufferViews) {
         dom::object bufferViewObject;
-        if (bufferViewValue.get_object().get(bufferViewObject) != SUCCESS) FASTGLTF_UNLIKELY {
+        if (bufferViewValue.get_object().get(bufferViewObject) != SUCCESS) [[unlikely]] {
             return Error::InvalidGltf;
         }
 
         std::uint64_t number;
         BufferView view;
-        if (auto error = bufferViewObject["buffer"].get_uint64().get(number); error != SUCCESS) FASTGLTF_UNLIKELY {
+        if (auto error = bufferViewObject["buffer"].get_uint64().get(number); error != SUCCESS) [[unlikely]] {
             return error == NO_SUCH_FIELD ? Error::InvalidGltf : Error::InvalidJson;
         }
         view.bufferIndex = static_cast<std::size_t>(number);
 
-        if (auto error = bufferViewObject["byteOffset"].get_uint64().get(number); error == SUCCESS) FASTGLTF_LIKELY {
+        if (auto error = bufferViewObject["byteOffset"].get_uint64().get(number); error == SUCCESS) [[likely]] {
             view.byteOffset = static_cast<std::size_t>(number);
-        } else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+        } else if (error != NO_SUCH_FIELD) [[unlikely]] {
             return Error::InvalidJson;
         }
 
-        if (auto error = bufferViewObject["byteLength"].get_uint64().get(number); error != SUCCESS) FASTGLTF_UNLIKELY {
+        if (auto error = bufferViewObject["byteLength"].get_uint64().get(number); error != SUCCESS) [[unlikely]] {
             return error == NO_SUCH_FIELD ? Error::InvalidGltf : Error::InvalidJson;
         }
         view.byteLength = static_cast<std::size_t>(number);
 
-        if (auto error = bufferViewObject["byteStride"].get_uint64().get(number); error == SUCCESS) FASTGLTF_LIKELY {
+        if (auto error = bufferViewObject["byteStride"].get_uint64().get(number); error == SUCCESS) [[likely]] {
             view.byteStride = static_cast<std::size_t>(number);
-        } else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+        } else if (error != NO_SUCH_FIELD) [[unlikely]] {
             return Error::InvalidJson;
         }
 
-        if (auto error = bufferViewObject["target"].get_uint64().get(number); error == SUCCESS) FASTGLTF_LIKELY {
+        if (auto error = bufferViewObject["target"].get_uint64().get(number); error == SUCCESS) [[likely]] {
             view.target = static_cast<BufferTarget>(number);
-        } else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+        } else if (error != NO_SUCH_FIELD) [[unlikely]] {
             return Error::InvalidJson;
         }
 
         std::string_view string;
         if (auto error = bufferViewObject["name"].get_string().get(string); error == SUCCESS) {
 	        view.name = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(view.name), resourceAllocator.get(), string);
-        } else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+        } else if (error != NO_SUCH_FIELD) [[unlikely]] {
             return Error::InvalidJson;
         }
 
         dom::object extensionObject;
-        if (bufferViewObject["extensions"].get_object().get(extensionObject) == SUCCESS) FASTGLTF_LIKELY {
+        if (bufferViewObject["extensions"].get_object().get(extensionObject) == SUCCESS) [[likely]] {
             dom::object meshoptCompression;
-            if (hasBit(config.extensions, Extensions::EXT_meshopt_compression) && extensionObject[extensions::EXT_meshopt_compression].get_object().get(meshoptCompression) == SUCCESS) FASTGLTF_LIKELY {
+            if (hasBit(config.extensions, Extensions::EXT_meshopt_compression) && extensionObject[extensions::EXT_meshopt_compression].get_object().get(meshoptCompression) == SUCCESS) [[likely]] {
                 auto compression = std::make_unique<CompressedBufferView>();
 
-                if (auto error = meshoptCompression["buffer"].get_uint64().get(number); error != SUCCESS) FASTGLTF_UNLIKELY {
+                if (auto error = meshoptCompression["buffer"].get_uint64().get(number); error != SUCCESS) [[unlikely]] {
                     return error == NO_SUCH_FIELD ? Error::InvalidGltf : Error::InvalidJson;
                 }
                 compression->bufferIndex = static_cast<std::size_t>(number);
 
-                if (auto error = meshoptCompression["byteOffset"].get_uint64().get(number); error == SUCCESS) FASTGLTF_LIKELY {
+                if (auto error = meshoptCompression["byteOffset"].get_uint64().get(number); error == SUCCESS) [[likely]] {
                     compression->byteOffset = static_cast<std::size_t>(number);
                 } else if (error == NO_SUCH_FIELD) {
                     compression->byteOffset = 0;
@@ -2125,22 +2125,22 @@ fg::Error fg::Parser::parseBufferViews(const simdjson::dom::array& bufferViews, 
                     return Error::InvalidJson;
                 }
 
-                if (auto error = meshoptCompression["byteLength"].get_uint64().get(number); error != SUCCESS) FASTGLTF_UNLIKELY {
+                if (auto error = meshoptCompression["byteLength"].get_uint64().get(number); error != SUCCESS) [[unlikely]] {
                     return error == NO_SUCH_FIELD ? Error::InvalidGltf : Error::InvalidJson;
                 }
                 compression->byteLength = static_cast<std::size_t>(number);
 
-                if (auto error = meshoptCompression["byteStride"].get_uint64().get(number); error != SUCCESS) FASTGLTF_UNLIKELY {
+                if (auto error = meshoptCompression["byteStride"].get_uint64().get(number); error != SUCCESS) [[unlikely]] {
                     return error == NO_SUCH_FIELD ? Error::InvalidGltf : Error::InvalidJson;
                 }
                 compression->byteStride = static_cast<std::size_t>(number);
 
-                if (auto error = meshoptCompression["count"].get_uint64().get(number); error != SUCCESS) FASTGLTF_UNLIKELY {
+                if (auto error = meshoptCompression["count"].get_uint64().get(number); error != SUCCESS) [[unlikely]] {
                     return error == NO_SUCH_FIELD ? Error::InvalidGltf : Error::InvalidJson;
                 }
                 compression->count = number;
 
-                if (auto error = meshoptCompression["mode"].get_string().get(string); error != SUCCESS) FASTGLTF_UNLIKELY {
+                if (auto error = meshoptCompression["mode"].get_string().get(string); error != SUCCESS) [[unlikely]] {
                     return error == NO_SUCH_FIELD ? Error::InvalidGltf : Error::InvalidJson;
                 }
                 switch (crcStringFunction(string)) {
@@ -2161,7 +2161,7 @@ fg::Error fg::Parser::parseBufferViews(const simdjson::dom::array& bufferViews, 
                     }
                 }
 
-                if (auto error = meshoptCompression["filter"].get_string().get(string); error == SUCCESS) FASTGLTF_LIKELY {
+                if (auto error = meshoptCompression["filter"].get_string().get(string); error == SUCCESS) [[likely]] {
                     switch (crcStringFunction(string)) {
                         case force_consteval<crc32c("NONE")>: {
                             compression->filter = MeshoptCompressionFilter::None;
@@ -2215,7 +2215,7 @@ fg::Error fg::Parser::parseCameras(simdjson::dom::array& cameras, Asset& asset) 
     for (auto cameraValue : cameras) {
         Camera camera = {};
         dom::object cameraObject;
-        if (cameraValue.get_object().get(cameraObject) != SUCCESS) FASTGLTF_UNLIKELY {
+        if (cameraValue.get_object().get(cameraObject) != SUCCESS) [[unlikely]] {
             return Error::InvalidGltf;
         }
 
@@ -2225,37 +2225,37 @@ fg::Error fg::Parser::parseCameras(simdjson::dom::array& cameras, Asset& asset) 
         }
 
         std::string_view type;
-        if (cameraObject["type"].get_string().get(type) != SUCCESS) FASTGLTF_UNLIKELY {
+        if (cameraObject["type"].get_string().get(type) != SUCCESS) [[unlikely]] {
             return Error::InvalidGltf;
         }
 
         if (type == "perspective") {
             dom::object perspectiveCamera;
-            if (cameraObject["perspective"].get_object().get(perspectiveCamera) != SUCCESS) FASTGLTF_UNLIKELY {
+            if (cameraObject["perspective"].get_object().get(perspectiveCamera) != SUCCESS) [[unlikely]] {
                 return Error::InvalidGltf;
             }
 
             Camera::Perspective perspective = {};
             double value;
-            if (auto error = perspectiveCamera["aspectRatio"].get_double().get(value); error == SUCCESS) FASTGLTF_LIKELY {
+            if (auto error = perspectiveCamera["aspectRatio"].get_double().get(value); error == SUCCESS) [[likely]] {
                 perspective.aspectRatio = static_cast<num>(value);
             } else if (error != NO_SUCH_FIELD) {
 				return Error::InvalidGltf;
 			}
 
-            if (auto error = perspectiveCamera["zfar"].get_double().get(value); error == SUCCESS) FASTGLTF_LIKELY {
+            if (auto error = perspectiveCamera["zfar"].get_double().get(value); error == SUCCESS) [[likely]] {
                 perspective.zfar = static_cast<num>(value);
             } else if (error != NO_SUCH_FIELD) {
 				return Error::InvalidGltf;
 			}
 
-            if (perspectiveCamera["yfov"].get_double().get(value) == SUCCESS) FASTGLTF_LIKELY {
+            if (perspectiveCamera["yfov"].get_double().get(value) == SUCCESS) [[likely]] {
                 perspective.yfov = static_cast<num>(value);
             } else {
                 return Error::InvalidGltf;
             }
 
-            if (perspectiveCamera["znear"].get_double().get(value) == SUCCESS) FASTGLTF_LIKELY {
+            if (perspectiveCamera["znear"].get_double().get(value) == SUCCESS) [[likely]] {
                 perspective.znear = static_cast<num>(value);
             } else {
                 return Error::InvalidGltf;
@@ -2264,31 +2264,31 @@ fg::Error fg::Parser::parseCameras(simdjson::dom::array& cameras, Asset& asset) 
             camera.camera = perspective;
         } else if (type == "orthographic") {
             dom::object orthographicCamera;
-            if (cameraObject["orthographic"].get_object().get(orthographicCamera) != SUCCESS) FASTGLTF_UNLIKELY {
+            if (cameraObject["orthographic"].get_object().get(orthographicCamera) != SUCCESS) [[unlikely]] {
                 return Error::InvalidGltf;
             }
 
             Camera::Orthographic orthographic = {};
             double value;
-            if (orthographicCamera["xmag"].get_double().get(value) == SUCCESS) FASTGLTF_LIKELY {
+            if (orthographicCamera["xmag"].get_double().get(value) == SUCCESS) [[likely]] {
                 orthographic.xmag = static_cast<num>(value);
             } else {
                 return Error::InvalidGltf;
             }
 
-            if (orthographicCamera["ymag"].get_double().get(value) == SUCCESS) FASTGLTF_LIKELY {
+            if (orthographicCamera["ymag"].get_double().get(value) == SUCCESS) [[likely]] {
                 orthographic.ymag = static_cast<num>(value);
             } else {
                 return Error::InvalidGltf;
             }
 
-            if (orthographicCamera["zfar"].get_double().get(value) == SUCCESS) FASTGLTF_LIKELY {
+            if (orthographicCamera["zfar"].get_double().get(value) == SUCCESS) [[likely]] {
                 orthographic.zfar = static_cast<num>(value);
             } else {
                 return Error::InvalidGltf;
             }
 
-            if (orthographicCamera["znear"].get_double().get(value) == SUCCESS) FASTGLTF_LIKELY {
+            if (orthographicCamera["znear"].get_double().get(value) == SUCCESS) [[likely]] {
                 orthographic.znear = static_cast<num>(value);
             } else {
                 return Error::InvalidGltf;
@@ -2319,7 +2319,7 @@ fg::Error fg::Parser::parseExtensions(const simdjson::dom::object& extensionsObj
 
     for (auto extensionValue : extensionsObject) {
         dom::object extensionObject;
-        if (auto error = extensionValue.value.get_object().get(extensionObject); error != SUCCESS) FASTGLTF_UNLIKELY {
+        if (auto error = extensionValue.value.get_object().get(extensionObject); error != SUCCESS) [[unlikely]] {
             if (error == INCORRECT_TYPE) {
                 continue; // We want to ignore
             }
@@ -2332,7 +2332,7 @@ fg::Error fg::Parser::parseExtensions(const simdjson::dom::object& extensionsObj
                     break;
 
                 dom::array lightsArray;
-                if (auto error = extensionObject["lights"].get_array().get(lightsArray); error == SUCCESS) FASTGLTF_LIKELY {
+                if (auto error = extensionObject["lights"].get_array().get(lightsArray); error == SUCCESS) [[likely]] {
                     if (auto lightsError = parseLights(lightsArray, asset); lightsError != Error::None)
 						return lightsError;
                 } else if (error != NO_SUCH_FIELD) {
@@ -2345,7 +2345,7 @@ fg::Error fg::Parser::parseExtensions(const simdjson::dom::object& extensionsObj
 					break;
 
 				dom::array variantsArray;
-				if (auto arrayError = extensionObject["variants"].get_array().get(variantsArray); arrayError == SUCCESS) FASTGLTF_LIKELY {
+				if (auto arrayError = extensionObject["variants"].get_array().get(variantsArray); arrayError == SUCCESS) [[likely]] {
 					asset.materialVariants.reserve(variantsArray.size());
 					for (auto variant : variantsArray) {
 						dom::object variantObject;
@@ -2372,8 +2372,8 @@ fg::Error fg::Parser::parseExtensions(const simdjson::dom::object& extensionsObj
 				}
 
 				dom::array shapesArray;
-				if (auto arrayError = extensionObject["shapes"].get_array().get(shapesArray); arrayError == SUCCESS) FASTGLTF_LIKELY {
-					if (auto shapesError = parseShapes(shapesArray, asset); shapesError != Error::None) FASTGLTF_UNLIKELY {
+				if (auto arrayError = extensionObject["shapes"].get_array().get(shapesArray); arrayError == SUCCESS) [[likely]] {
+					if (auto shapesError = parseShapes(shapesArray, asset); shapesError != Error::None) [[unlikely]] {
 						return shapesError;
 					}
 				} else {
@@ -2390,28 +2390,28 @@ fg::Error fg::Parser::parseExtensions(const simdjson::dom::object& extensionsObj
 
 				dom::array materialsArray;
 				if (auto arrayError = extensionObject["physicsMaterials"].get_array().get(materialsArray); arrayError == SUCCESS) {
-					if (auto materialsError = parsePhysicsMaterials(materialsArray, asset); materialsError != Error::None) FASTGLTF_UNLIKELY {
+					if (auto materialsError = parsePhysicsMaterials(materialsArray, asset); materialsError != Error::None) [[unlikely]] {
 						return materialsError;
 					}
-				} else if (arrayError != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+				} else if (arrayError != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
 				dom::array filtersArray;
 				if (auto arrayError = extensionObject["collisionFilters"].get_array().get(filtersArray); arrayError == SUCCESS) {
-					if (auto filtersError = parseCollisionFilters(filtersArray, asset); filtersError != Error::None) FASTGLTF_UNLIKELY {
+					if (auto filtersError = parseCollisionFilters(filtersArray, asset); filtersError != Error::None) [[unlikely]] {
 						return filtersError;
 					}
-				} else if (arrayError != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+				} else if (arrayError != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
 				dom::array jointsArray;
 				if (auto arrayError = extensionObject["physicsJoints"].get_array().get(jointsArray); arrayError == SUCCESS) {
-					if (auto jointsError = parsePhysicsJoints(jointsArray, asset); jointsError != Error::None) FASTGLTF_UNLIKELY {
+					if (auto jointsError = parsePhysicsJoints(jointsArray, asset); jointsError != Error::None) [[unlikely]] {
 						return jointsError;
 					}
-				} else if (arrayError != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+				} else if (arrayError != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
@@ -2433,13 +2433,13 @@ fg::Error fg::Parser::parseImages(simdjson::dom::array& images, Asset& asset) {
     for (auto imageValue : images) {
         Image image = {};
         dom::object imageObject;
-        if (imageValue.get_object().get(imageObject) != SUCCESS) FASTGLTF_UNLIKELY {
+        if (imageValue.get_object().get(imageObject) != SUCCESS) [[unlikely]] {
             return Error::InvalidGltf;
         }
 
         std::string_view uriString;
-        if (imageObject["uri"].get_string().get(uriString) == SUCCESS) FASTGLTF_LIKELY {
-            if (imageObject["bufferView"].error() == SUCCESS) FASTGLTF_LIKELY {
+        if (imageObject["uri"].get_string().get(uriString) == SUCCESS) [[likely]] {
+            if (imageObject["bufferView"].error() == SUCCESS) [[likely]] {
                 // If uri is declared, bufferView cannot be declared.
                 return Error::InvalidGltf;
             }
@@ -2471,7 +2471,7 @@ fg::Error fg::Parser::parseImages(simdjson::dom::array& images, Asset& asset) {
             }
 
             std::string_view mimeType;
-            if (imageObject["mimeType"].get_string().get(mimeType) == SUCCESS) FASTGLTF_LIKELY {
+            if (imageObject["mimeType"].get_string().get(mimeType) == SUCCESS) [[likely]] {
                 std::visit([&](auto& arg) {
                     using T = std::decay_t<decltype(arg)>;
 
@@ -2484,9 +2484,9 @@ fg::Error fg::Parser::parseImages(simdjson::dom::array& images, Asset& asset) {
         }
 
         std::uint64_t bufferViewIndex;
-        if (imageObject["bufferView"].get_uint64().get(bufferViewIndex) == SUCCESS) FASTGLTF_LIKELY {
+        if (imageObject["bufferView"].get_uint64().get(bufferViewIndex) == SUCCESS) [[likely]] {
             std::string_view mimeType;
-            if (imageObject["mimeType"].get_string().get(mimeType) != SUCCESS) FASTGLTF_UNLIKELY {
+            if (imageObject["mimeType"].get_string().get(mimeType) != SUCCESS) [[unlikely]] {
                 // If bufferView is defined, mimeType needs to also be defined.
                 return Error::InvalidGltf;
             }
@@ -2528,13 +2528,13 @@ fg::Error fg::Parser::parseLights(const simdjson::dom::array& lights, Asset& ass
     asset.lights.reserve(lights.size());
     for (auto lightValue : lights) {
         dom::object lightObject;
-        if (lightValue.get_object().get(lightObject) != SUCCESS) FASTGLTF_UNLIKELY {
+        if (lightValue.get_object().get(lightObject) != SUCCESS) [[unlikely]] {
             return Error::InvalidGltf;
         }
         Light light = {};
 
         std::string_view type;
-        if (lightObject["type"].get_string().get(type) == SUCCESS) FASTGLTF_LIKELY {
+        if (lightObject["type"].get_string().get(type) == SUCCESS) [[likely]] {
             switch (crcStringFunction(type.data())) {
                 case force_consteval<crc32c("directional")>: {
                     light.type = LightType::Directional;
@@ -2558,12 +2558,12 @@ fg::Error fg::Parser::parseLights(const simdjson::dom::array& lights, Asset& ass
 
         if (light.type == LightType::Spot) {
             dom::object spotObject;
-            if (lightObject["spot"].get_object().get(spotObject) != SUCCESS) FASTGLTF_UNLIKELY {
+            if (lightObject["spot"].get_object().get(spotObject) != SUCCESS) [[unlikely]] {
                 return Error::InvalidGltf;
             }
 
             double innerConeAngle;
-            if (auto error = spotObject["innerConeAngle"].get_double().get(innerConeAngle); error == SUCCESS) FASTGLTF_LIKELY {
+            if (auto error = spotObject["innerConeAngle"].get_double().get(innerConeAngle); error == SUCCESS) [[likely]] {
                 light.innerConeAngle = static_cast<num>(innerConeAngle);
             } else if (error == NO_SUCH_FIELD) {
                 light.innerConeAngle = 0.0f;
@@ -2572,7 +2572,7 @@ fg::Error fg::Parser::parseLights(const simdjson::dom::array& lights, Asset& ass
             }
 
             double outerConeAngle;
-            if (auto error = spotObject["outerConeAngle"].get_double().get(outerConeAngle); error == SUCCESS) FASTGLTF_LIKELY {
+            if (auto error = spotObject["outerConeAngle"].get_double().get(outerConeAngle); error == SUCCESS) [[likely]] {
                 light.outerConeAngle = static_cast<num>(outerConeAngle);
             } else if (error == NO_SUCH_FIELD) {
                 light.outerConeAngle = static_cast<num>(math::pi / 4.0);
@@ -2582,13 +2582,13 @@ fg::Error fg::Parser::parseLights(const simdjson::dom::array& lights, Asset& ass
         }
 
         dom::array colorArray;
-        if (auto error = lightObject["color"].get_array().get(colorArray); error == SUCCESS) FASTGLTF_LIKELY {
+        if (auto error = lightObject["color"].get_array().get(colorArray); error == SUCCESS) [[likely]] {
             if (colorArray.size() != 3U) {
                 return Error::InvalidGltf;
             }
             for (std::size_t i = 0U; i < colorArray.size(); ++i) {
                 double color;
-                if (colorArray.at(i).get_double().get(color) == SUCCESS) FASTGLTF_LIKELY {
+                if (colorArray.at(i).get_double().get(color) == SUCCESS) [[likely]] {
                     light.color[i] = static_cast<num>(color);
                 } else {
                     return Error::InvalidGltf;
@@ -2601,14 +2601,14 @@ fg::Error fg::Parser::parseLights(const simdjson::dom::array& lights, Asset& ass
         }
 
         double intensity;
-        if (lightObject["intensity"].get_double().get(intensity) == SUCCESS) FASTGLTF_LIKELY {
+        if (lightObject["intensity"].get_double().get(intensity) == SUCCESS) [[likely]] {
             light.intensity = static_cast<num>(intensity);
         } else {
             light.intensity = 1.0f;
         }
 
         double range;
-        if (lightObject["range"].get_double().get(range) == SUCCESS) FASTGLTF_LIKELY {
+        if (lightObject["range"].get_double().get(range) == SUCCESS) [[likely]] {
             light.range = static_cast<num>(range);
         }
 
@@ -2634,7 +2634,7 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 
 				dom::object anisotropyObject;
 				auto anisotropyError = extensionField.value.get_object().get(anisotropyObject);
-				if (anisotropyError != SUCCESS) FASTGLTF_UNLIKELY {
+				if (anisotropyError != SUCCESS) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
@@ -2642,23 +2642,23 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 
 				double anisotropyStrength;
 				if (auto error = anisotropyObject["anisotropyStrength"].get_double().get(anisotropyStrength);
-						error == SUCCESS) FASTGLTF_LIKELY {
+						error == SUCCESS) [[likely]] {
 					anisotropy->anisotropyStrength = static_cast<num>(anisotropyStrength);
-				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidJson;
 				}
 
 				double anisotropyRotation;
 				if (auto error = anisotropyObject["anisotropyRotation"].get_double().get(anisotropyRotation);
-						error == SUCCESS) FASTGLTF_LIKELY {
+						error == SUCCESS) [[likely]] {
 					anisotropy->anisotropyRotation = static_cast<num>(anisotropyRotation);
-				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidJson;
 				}
 
 				TextureInfo anisotropyTexture;
 				if (auto error = parseTextureInfo(anisotropyObject, "anisotropyTexture", &anisotropyTexture,
-												  config.extensions); error == Error::None) FASTGLTF_LIKELY {
+												  config.extensions); error == Error::None) [[likely]] {
 					anisotropy->anisotropyTexture = std::move(anisotropyTexture);
 				} else if (error != Error::MissingField) {
 					return error;
@@ -2673,7 +2673,7 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 
 				dom::object clearcoatObject;
 				auto clearcoatError = extensionField.value.get_object().get(clearcoatObject);
-				if (clearcoatError != SUCCESS) FASTGLTF_UNLIKELY {
+				if (clearcoatError != SUCCESS) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
@@ -2683,13 +2683,13 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 				if (auto error = clearcoatObject["clearcoatFactor"].get_double().get(clearcoatFactor); error ==
 																									   SUCCESS) {
 					clearcoat->clearcoatFactor = static_cast<num>(clearcoatFactor);
-				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidJson;
 				}
 
 				TextureInfo clearcoatTexture;
 				if (auto error = parseTextureInfo(clearcoatObject, "clearcoatTexture", &clearcoatTexture,
-												  config.extensions); error == Error::None) FASTGLTF_LIKELY {
+												  config.extensions); error == Error::None) [[likely]] {
 					clearcoat->clearcoatTexture = std::move(clearcoatTexture);
 				} else if (error != Error::MissingField) {
 					return error;
@@ -2697,9 +2697,9 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 
 				double clearcoatRoughnessFactor;
 				if (auto error = clearcoatObject["clearcoatRoughnessFactor"].get_double().get(
-							clearcoatRoughnessFactor); error == SUCCESS) FASTGLTF_LIKELY {
+							clearcoatRoughnessFactor); error == SUCCESS) [[likely]] {
 					clearcoat->clearcoatRoughnessFactor = static_cast<num>(clearcoatRoughnessFactor);
-				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidJson;
 				}
 
@@ -2730,15 +2730,15 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 
 				dom::object dispersionObject;
 				auto dispersionError = extensionField.value.get_object().get(dispersionObject);
-				if (dispersionError != SUCCESS) FASTGLTF_UNLIKELY {
+				if (dispersionError != SUCCESS) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
 				double dispersionFactor;
 				auto error = dispersionObject["dispersion"].get_double().get(dispersionFactor);
-				if (error == SUCCESS) FASTGLTF_LIKELY {
+				if (error == SUCCESS) [[likely]] {
 					material.dispersion = static_cast<num>(dispersionFactor);
-				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 				break;
@@ -2749,15 +2749,15 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 
 				dom::object emissiveObject;
 				auto emissiveError = extensionField.value.get_object().get(emissiveObject);
-				if (emissiveError != SUCCESS) FASTGLTF_UNLIKELY {
+				if (emissiveError != SUCCESS) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
 				double emissiveStrength;
 				auto error = emissiveObject["emissiveStrength"].get_double().get(emissiveStrength);
-				if (error == SUCCESS) FASTGLTF_LIKELY {
+				if (error == SUCCESS) [[likely]] {
 					material.emissiveStrength = static_cast<num>(emissiveStrength);
-				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 				break;
@@ -2768,15 +2768,15 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 
 				dom::object iorObject;
 				auto iorError = extensionField.value.get_object().get(iorObject);
-				if (iorError != SUCCESS) FASTGLTF_UNLIKELY {
+				if (iorError != SUCCESS) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
 				double ior;
 				auto error = iorObject["ior"].get_double().get(ior);
-				if (error == SUCCESS) FASTGLTF_LIKELY {
+				if (error == SUCCESS) [[likely]] {
 					material.ior = static_cast<num>(ior);
-				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidJson;
 				}
 				break;
@@ -2787,7 +2787,7 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 
 				dom::object iridescenceObject;
 				auto iridescenceError = extensionField.value.get_object().get(iridescenceObject);
-				if (iridescenceError != SUCCESS) FASTGLTF_UNLIKELY {
+				if (iridescenceError != SUCCESS) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
@@ -2795,15 +2795,15 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 
 				double iridescenceFactor;
 				if (auto error = iridescenceObject["iridescenceFactor"].get_double().get(iridescenceFactor);
-						error == SUCCESS) FASTGLTF_LIKELY {
+						error == SUCCESS) [[likely]] {
 					iridescence->iridescenceFactor = static_cast<num>(iridescenceFactor);
-				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
 				TextureInfo iridescenceTexture;
 				if (auto error = parseTextureInfo(iridescenceObject, "iridescenceTexture", &iridescenceTexture,
-												  config.extensions); error == Error::None) FASTGLTF_LIKELY {
+												  config.extensions); error == Error::None) [[likely]] {
 					iridescence->iridescenceTexture = std::move(iridescenceTexture);
 				} else if (error != Error::MissingField) {
 					return error;
@@ -2813,23 +2813,23 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 				if (auto error = iridescenceObject["iridescenceIor"].get_double().get(iridescenceIor); error ==
 																									   SUCCESS) {
 					iridescence->iridescenceIor = static_cast<num>(iridescenceIor);
-				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
 				double iridescenceThicknessMinimum;
 				if (auto error = iridescenceObject["iridescenceThicknessMinimum"].get_double().get(
-							iridescenceThicknessMinimum); error == SUCCESS) FASTGLTF_LIKELY {
+							iridescenceThicknessMinimum); error == SUCCESS) [[likely]] {
 					iridescence->iridescenceThicknessMinimum = static_cast<num>(iridescenceThicknessMinimum);
-				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
 				double iridescenceThicknessMaximum;
 				if (auto error = iridescenceObject["iridescenceThicknessMaximum"].get_double().get(
-							iridescenceThicknessMaximum); error == SUCCESS) FASTGLTF_LIKELY {
+							iridescenceThicknessMaximum); error == SUCCESS) [[likely]] {
 					iridescence->iridescenceThicknessMaximum = static_cast<num>(iridescenceThicknessMaximum);
-				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
@@ -2851,35 +2851,35 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 
 				dom::object diffuseTransmissionObject;
 				auto diffuseTransmissionError = extensionField.value.get_object().get(diffuseTransmissionObject);
-				if (diffuseTransmissionError != SUCCESS) FASTGLTF_UNLIKELY {
+				if (diffuseTransmissionError != SUCCESS) [[unlikely]] {
 					return Error::InvalidGltf;
 				}	
 
 				auto diffuseTransmission = std::make_unique<MaterialDiffuseTransmission>();
 
 				double diffuseTransmissionFactor;
-				if (auto error = diffuseTransmissionObject["diffuseTransmissionFactor"].get_double().get(diffuseTransmissionFactor); error == SUCCESS) FASTGLTF_LIKELY {
+				if (auto error = diffuseTransmissionObject["diffuseTransmissionFactor"].get_double().get(diffuseTransmissionFactor); error == SUCCESS) [[likely]] {
 					diffuseTransmission->diffuseTransmissionFactor = static_cast<num>(diffuseTransmissionFactor);
-				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
 				TextureInfo diffuseTransmissionTexture;
-				if (auto error = parseTextureInfo(diffuseTransmissionObject, "diffuseTransmissionTexture", &diffuseTransmissionTexture, config.extensions); error == Error::None) FASTGLTF_LIKELY {
+				if (auto error = parseTextureInfo(diffuseTransmissionObject, "diffuseTransmissionTexture", &diffuseTransmissionTexture, config.extensions); error == Error::None) [[likely]] {
 					diffuseTransmission->diffuseTransmissionTexture = std::move(diffuseTransmissionTexture);
 				} else if (error != Error::MissingField) {
 					return error;
 				}
 
 				dom::array diffuseTransmissionColorFactor;
-				if (auto error = diffuseTransmissionObject["diffuseTransmissionColorFactor"].get_array().get(diffuseTransmissionColorFactor); error == SUCCESS) FASTGLTF_LIKELY {
+				if (auto error = diffuseTransmissionObject["diffuseTransmissionColorFactor"].get_array().get(diffuseTransmissionColorFactor); error == SUCCESS) [[likely]] {
 					std::size_t i = 0;
 					for (auto factor: diffuseTransmissionColorFactor) {
 						if (i >= diffuseTransmission->diffuseTransmissionColorFactor.size()) {
 							return Error::InvalidGltf;
 						}
 						double value;
-						if (factor.get_double().get(value) != SUCCESS) FASTGLTF_UNLIKELY {
+						if (factor.get_double().get(value) != SUCCESS) [[unlikely]] {
 							return Error::InvalidGltf;
 						}
 						diffuseTransmission->diffuseTransmissionColorFactor[i++] = static_cast<num>(value);
@@ -2887,7 +2887,7 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 				}
 
 				TextureInfo diffuseTransmissionColorTexture;
-				if (auto error = parseTextureInfo(diffuseTransmissionObject, "diffuseTransmissionColorTexture", &diffuseTransmissionColorTexture, config.extensions); error == Error::None) FASTGLTF_LIKELY {
+				if (auto error = parseTextureInfo(diffuseTransmissionObject, "diffuseTransmissionColorTexture", &diffuseTransmissionColorTexture, config.extensions); error == Error::None) [[likely]] {
 					diffuseTransmission->diffuseTransmissionColorTexture = std::move(diffuseTransmissionColorTexture);
 				} else if (error != Error::MissingField) {
 					return error;
@@ -2903,7 +2903,7 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 
 				dom::object sheenObject;
 				auto sheenError = extensionField.value.get_object().get(sheenObject);
-				if (sheenError != SUCCESS) FASTGLTF_UNLIKELY {
+				if (sheenError != SUCCESS) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
@@ -2918,18 +2918,18 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 							return Error::InvalidGltf;
 						}
 						double value;
-						if (factor.get_double().get(value) != SUCCESS) FASTGLTF_UNLIKELY {
+						if (factor.get_double().get(value) != SUCCESS) [[unlikely]] {
 							return Error::InvalidGltf;
 						}
 						sheen->sheenColorFactor[i++] = static_cast<num>(value);
 					}
-				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
 				TextureInfo sheenColorTexture;
 				if (auto error = parseTextureInfo(sheenObject, "sheenColorTexture", &sheenColorTexture,
-												  config.extensions); error == Error::None) FASTGLTF_LIKELY {
+												  config.extensions); error == Error::None) [[likely]] {
 					sheen->sheenColorTexture = std::move(sheenColorTexture);
 				} else if (error != Error::MissingField) {
 					return error;
@@ -2937,15 +2937,15 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 
 				double sheenRoughnessFactor;
 				if (auto error = sheenObject["sheenRoughnessFactor"].get_double().get(sheenRoughnessFactor);
-						error == SUCCESS) FASTGLTF_LIKELY {
+						error == SUCCESS) [[likely]] {
 					sheen->sheenRoughnessFactor = static_cast<num>(sheenRoughnessFactor);
-				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
 				TextureInfo sheenRoughnessTexture;
 				if (auto error = parseTextureInfo(sheenObject, "sheenRoughnessTexture", &sheenRoughnessTexture,
-												  config.extensions); error == Error::None) FASTGLTF_LIKELY {
+												  config.extensions); error == Error::None) [[likely]] {
 					sheen->sheenRoughnessTexture = std::move(sheenRoughnessTexture);
 				} else if (error != Error::MissingField) {
 					return error;
@@ -2960,7 +2960,7 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 
 				dom::object specularObject;
 				auto specularError = extensionField.value.get_object().get(specularObject);
-				if (specularError != SUCCESS) FASTGLTF_UNLIKELY {
+				if (specularError != SUCCESS) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
@@ -2970,13 +2970,13 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 				if (auto error = specularObject["specularFactor"].get_double().get(specularFactor); error ==
 																									SUCCESS) {
 					specular->specularFactor = static_cast<num>(specularFactor);
-				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
 				TextureInfo specularTexture;
 				if (auto error = parseTextureInfo(specularObject, "specularTexture", &specularTexture,
-												  config.extensions); error == Error::None) FASTGLTF_LIKELY {
+												  config.extensions); error == Error::None) [[likely]] {
 					specular->specularTexture = std::move(specularTexture);
 				} else if (error != Error::MissingField) {
 					return error;
@@ -2984,25 +2984,25 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 
 				dom::array specularColorFactor;
 				if (auto error = specularObject["specularColorFactor"].get_array().get(specularColorFactor);
-						error == SUCCESS) FASTGLTF_LIKELY {
+						error == SUCCESS) [[likely]] {
 					std::size_t i = 0;
 					for (auto factor: specularColorFactor) {
 						if (i >= specular->specularColorFactor.size()) {
 							return Error::InvalidGltf;
 						}
 						double value;
-						if (factor.get_double().get(value) != SUCCESS) FASTGLTF_UNLIKELY {
+						if (factor.get_double().get(value) != SUCCESS) [[unlikely]] {
 							return Error::InvalidGltf;
 						}
 						specular->specularColorFactor[i++] = static_cast<num>(value);
 					}
-				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
 				TextureInfo specularColorTexture;
 				if (auto error = parseTextureInfo(specularObject, "specularColorTexture", &specularColorTexture,
-												  config.extensions); error == Error::None) FASTGLTF_LIKELY {
+												  config.extensions); error == Error::None) [[likely]] {
 					specular->specularColorTexture = std::move(specularColorTexture);
 				} else if (error != Error::MissingField) {
 					return error;
@@ -3017,7 +3017,7 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 
 				dom::object transmissionObject;
 				auto transmissionError = extensionField.value.get_object().get(transmissionObject);
-				if (transmissionError != SUCCESS) FASTGLTF_UNLIKELY {
+				if (transmissionError != SUCCESS) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
@@ -3025,15 +3025,15 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 
 				double transmissionFactor;
 				if (auto error = transmissionObject["transmissionFactor"].get_double().get(transmissionFactor);
-						error == SUCCESS) FASTGLTF_LIKELY {
+						error == SUCCESS) [[likely]] {
 					transmission->transmissionFactor = static_cast<num>(transmissionFactor);
-				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
 				TextureInfo transmissionTexture;
 				if (auto error = parseTextureInfo(transmissionObject, "transmissionTexture", &transmissionTexture,
-												  config.extensions); error == Error::None) FASTGLTF_LIKELY {
+												  config.extensions); error == Error::None) [[likely]] {
 					transmission->transmissionTexture = std::move(transmissionTexture);
 				} else if (error != Error::MissingField) {
 					return error;
@@ -3048,7 +3048,7 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 
 				dom::object unlitObject;
 				auto unlitError = extensionField.value.get_object().get(unlitObject);
-				if (unlitError == SUCCESS) FASTGLTF_LIKELY {
+				if (unlitError == SUCCESS) [[likely]] {
 					material.unlit = true;
 				} else {
 					return Error::InvalidGltf;
@@ -3061,47 +3061,47 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 
 				dom::object volumeObject;
 				auto volumeError = extensionField.value.get_object().get(volumeObject);
-				if (volumeError != SUCCESS) FASTGLTF_UNLIKELY {
+				if (volumeError != SUCCESS) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
 				auto volume = std::make_unique<MaterialVolume>();
 
 				double thicknessFactor;
-				if (auto error = volumeObject["thicknessFactor"].get_double().get(thicknessFactor); error == SUCCESS) FASTGLTF_LIKELY {
+				if (auto error = volumeObject["thicknessFactor"].get_double().get(thicknessFactor); error == SUCCESS) [[likely]] {
 					volume->thicknessFactor = static_cast<num>(thicknessFactor);
-				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
 				TextureInfo thicknessTexture;
-				if (auto error = parseTextureInfo(volumeObject, "thicknessTexture", &thicknessTexture, config.extensions); error == Error::None) FASTGLTF_LIKELY {
+				if (auto error = parseTextureInfo(volumeObject, "thicknessTexture", &thicknessTexture, config.extensions); error == Error::None) [[likely]] {
 					volume->thicknessTexture = std::move(thicknessTexture);
 				} else if (error != Error::MissingField) {
 					return error;
 				}
 
 				double attenuationDistance;
-				if (auto error = volumeObject["attenuationDistance"].get_double().get(attenuationDistance); error == SUCCESS) FASTGLTF_LIKELY {
+				if (auto error = volumeObject["attenuationDistance"].get_double().get(attenuationDistance); error == SUCCESS) [[likely]] {
 					volume->attenuationDistance = static_cast<num>(attenuationDistance);
-				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
 				dom::array attenuationColor;
-				if (auto error = volumeObject["attenuationColor"].get_array().get(attenuationColor); error == SUCCESS) FASTGLTF_LIKELY {
+				if (auto error = volumeObject["attenuationColor"].get_array().get(attenuationColor); error == SUCCESS) [[likely]] {
 					std::size_t i = 0;
 					for (auto factor : attenuationColor) {
 						if (i >= volume->attenuationColor.size()) {
 							return Error::InvalidGltf;
 						}
 						double value;
-						if (factor.get_double().get(value) != SUCCESS) FASTGLTF_UNLIKELY {
+						if (factor.get_double().get(value) != SUCCESS) [[unlikely]] {
 							return Error::InvalidGltf;
 						}
 						(volume->attenuationColor)[i++] = static_cast<num>(value);
 					}
-				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
@@ -3113,11 +3113,11 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 					break;
 
 				dom::object normalRoughnessMetallic;
-				if (extensionField.value.get_object().get(normalRoughnessMetallic) != SUCCESS) FASTGLTF_UNLIKELY {
+				if (extensionField.value.get_object().get(normalRoughnessMetallic) != SUCCESS) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 				TextureInfo textureInfo = {};
-				if (auto error = parseTextureInfo(normalRoughnessMetallic, "normalRoughnessMetallicTexture", &textureInfo, config.extensions); error == Error::None) FASTGLTF_LIKELY {
+				if (auto error = parseTextureInfo(normalRoughnessMetallic, "normalRoughnessMetallicTexture", &textureInfo, config.extensions); error == Error::None) [[likely]] {
 					material.packedNormalMetallicRoughnessTexture = std::move(textureInfo);
 				} else if (error != Error::MissingField) {
 					return error;
@@ -3129,24 +3129,24 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 					break;
 
 				dom::object occlusionRoughnessMetallic;
-				if (extensionField.value.get_object().get(occlusionRoughnessMetallic) != SUCCESS) FASTGLTF_UNLIKELY {
+				if (extensionField.value.get_object().get(occlusionRoughnessMetallic) != SUCCESS) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 				auto packedTextures = std::make_unique<MaterialPackedTextures>();
 				TextureInfo textureInfo = {};
-				if (auto error = parseTextureInfo(occlusionRoughnessMetallic, "occlusionRoughnessMetallicTexture", &textureInfo, config.extensions); error == Error::None) FASTGLTF_LIKELY {
+				if (auto error = parseTextureInfo(occlusionRoughnessMetallic, "occlusionRoughnessMetallicTexture", &textureInfo, config.extensions); error == Error::None) [[likely]] {
 					packedTextures->occlusionRoughnessMetallicTexture = std::move(textureInfo);
 				} else if (error != Error::MissingField) {
 					return error;
 				}
 
-				if (auto error = parseTextureInfo(occlusionRoughnessMetallic, "roughnessMetallicOcclusionTexture", &textureInfo, config.extensions); error == Error::None) FASTGLTF_LIKELY {
+				if (auto error = parseTextureInfo(occlusionRoughnessMetallic, "roughnessMetallicOcclusionTexture", &textureInfo, config.extensions); error == Error::None) [[likely]] {
 					packedTextures->roughnessMetallicOcclusionTexture = std::move(textureInfo);
 				} else if (error != Error::MissingField) {
 					return error;
 				}
 
-				if (auto error = parseTextureInfo(occlusionRoughnessMetallic, "normalTexture", &textureInfo, config.extensions); error == Error::None) FASTGLTF_LIKELY {
+				if (auto error = parseTextureInfo(occlusionRoughnessMetallic, "normalTexture", &textureInfo, config.extensions); error == Error::None) [[likely]] {
 					packedTextures->normalTexture = std::move(textureInfo);
 				} else if (error != Error::MissingField) {
 					return error;
@@ -3162,61 +3162,61 @@ fg::Error fg::Parser::parseMaterialExtensions(simdjson::dom::object &object, Mat
 
 				dom::object specularGlossinessObject;
 				auto specularGlossinessError = extensionField.value.get_object().get(specularGlossinessObject);
-				if (specularGlossinessError != SUCCESS) FASTGLTF_UNLIKELY {
+				if (specularGlossinessError != SUCCESS) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 				auto specularGlossiness = std::make_unique<MaterialSpecularGlossiness>();
 
 				dom::array diffuseFactor;
-				if (auto error = specularGlossinessObject["diffuseFactor"].get_array().get(diffuseFactor); error == SUCCESS) FASTGLTF_LIKELY {
+				if (auto error = specularGlossinessObject["diffuseFactor"].get_array().get(diffuseFactor); error == SUCCESS) [[likely]] {
 					std::size_t i = 0;
 					for (auto factor : diffuseFactor) {
 						if (i >= specularGlossiness->diffuseFactor.size()) {
 							return Error::InvalidGltf;
 						}
 						double value;
-						if (factor.get_double().get(value) != SUCCESS) FASTGLTF_UNLIKELY {
+						if (factor.get_double().get(value) != SUCCESS) [[unlikely]] {
 							return Error::InvalidGltf;
 						}
 						specularGlossiness->diffuseFactor[i++] = static_cast<num>(value);
 					}
-				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
 				TextureInfo diffuseTexture;
-				if (auto error = parseTextureInfo(specularGlossinessObject, "diffuseTexture", &diffuseTexture, config.extensions); error == Error::None) FASTGLTF_LIKELY {
+				if (auto error = parseTextureInfo(specularGlossinessObject, "diffuseTexture", &diffuseTexture, config.extensions); error == Error::None) [[likely]] {
 					specularGlossiness->diffuseTexture = std::move(diffuseTexture);
 				} else if (error != Error::MissingField) {
 					return error;
 				}
 
 				dom::array specularFactor;
-				if (auto error = specularGlossinessObject["specularFactor"].get_array().get(specularFactor); error == SUCCESS) FASTGLTF_LIKELY {
+				if (auto error = specularGlossinessObject["specularFactor"].get_array().get(specularFactor); error == SUCCESS) [[likely]] {
 					std::size_t i = 0;
 					for (auto factor : specularFactor) {
 						if (i >= specularGlossiness->specularFactor.size()) {
 							return Error::InvalidGltf;
 						}
 						double value;
-						if (factor.get_double().get(value) != SUCCESS) FASTGLTF_UNLIKELY {
+						if (factor.get_double().get(value) != SUCCESS) [[unlikely]] {
 							return Error::InvalidGltf;
 						}
 						specularGlossiness->specularFactor[i++] = static_cast<num>(value);
 					}
-				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
 				double glossinessFactor;
-				if (auto error = specularGlossinessObject["glossinessFactor"].get_double().get(glossinessFactor); error == SUCCESS) FASTGLTF_LIKELY {
+				if (auto error = specularGlossinessObject["glossinessFactor"].get_double().get(glossinessFactor); error == SUCCESS) [[likely]] {
 					specularGlossiness->glossinessFactor = static_cast<num>(glossinessFactor);
-				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
 				TextureInfo specularGlossinessTexture;
-				if (auto error = parseTextureInfo(specularGlossinessObject, "specularGlossinessTexture", &specularGlossinessTexture, config.extensions); error == Error::None) FASTGLTF_LIKELY {
+				if (auto error = parseTextureInfo(specularGlossinessObject, "specularGlossinessTexture", &specularGlossinessTexture, config.extensions); error == Error::None) [[likely]] {
 					specularGlossiness->specularGlossinessTexture = std::move(specularGlossinessTexture);
 				} else if (error != Error::MissingField) {
 					return error;
@@ -3241,30 +3241,30 @@ fg::Error fg::Parser::parseMaterials(simdjson::dom::array& materials, Asset& ass
     asset.materials.reserve(materials.size());
     for (auto materialValue : materials) {
         dom::object materialObject;
-        if (materialValue.get_object().get(materialObject) != SUCCESS) FASTGLTF_UNLIKELY {
+        if (materialValue.get_object().get(materialObject) != SUCCESS) [[unlikely]] {
             return Error::InvalidGltf;
         }
         Material material = {};
 
         dom::array emissiveFactor;
-        if (auto error = materialObject["emissiveFactor"].get_array().get(emissiveFactor); error == SUCCESS) FASTGLTF_LIKELY {
+        if (auto error = materialObject["emissiveFactor"].get_array().get(emissiveFactor); error == SUCCESS) [[likely]] {
             if (emissiveFactor.size() != 3) {
                 return Error::InvalidGltf;
             }
             for (auto i = 0U; i < 3; ++i) {
                 double val;
-                if (emissiveFactor.at(i).get_double().get(val) != SUCCESS) FASTGLTF_UNLIKELY {
+                if (emissiveFactor.at(i).get_double().get(val) != SUCCESS) [[unlikely]] {
                     return Error::InvalidGltf;
                 }
                 material.emissiveFactor[i] = static_cast<num>(val);
             }
-        } else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+        } else if (error != NO_SUCH_FIELD) [[unlikely]] {
             return Error::InvalidGltf;
         }
 
 	    {
 		    NormalTextureInfo normalTextureInfo = {};
-		    if (auto error = parseTextureInfo(materialObject, "normalTexture", &normalTextureInfo, config.extensions, TextureInfoType::NormalTexture); error == Error::None) FASTGLTF_LIKELY {
+		    if (auto error = parseTextureInfo(materialObject, "normalTexture", &normalTextureInfo, config.extensions, TextureInfoType::NormalTexture); error == Error::None) [[likely]] {
 			    material.normalTexture = std::move(normalTextureInfo);
 		    } else if (error != Error::MissingField) {
 			    return error;
@@ -3273,7 +3273,7 @@ fg::Error fg::Parser::parseMaterials(simdjson::dom::array& materials, Asset& ass
 
 	    {
 			OcclusionTextureInfo occlusionTextureInfo = {};
-	        if (auto error = parseTextureInfo(materialObject, "occlusionTexture", &occlusionTextureInfo, config.extensions, TextureInfoType::OcclusionTexture); error == Error::None) FASTGLTF_LIKELY {
+	        if (auto error = parseTextureInfo(materialObject, "occlusionTexture", &occlusionTextureInfo, config.extensions, TextureInfoType::OcclusionTexture); error == Error::None) [[likely]] {
 	            material.occlusionTexture = std::move(occlusionTextureInfo);
 	        } else if (error != Error::MissingField) {
 	            return error;
@@ -3282,7 +3282,7 @@ fg::Error fg::Parser::parseMaterials(simdjson::dom::array& materials, Asset& ass
 
 	    {
 		    TextureInfo textureInfo = {};
-	        if (auto error = parseTextureInfo(materialObject, "emissiveTexture", &textureInfo, config.extensions); error == Error::None) FASTGLTF_LIKELY {
+	        if (auto error = parseTextureInfo(materialObject, "emissiveTexture", &textureInfo, config.extensions); error == Error::None) [[likely]] {
 	            material.emissiveTexture = std::move(textureInfo);
 	        } else if (error != Error::MissingField) {
 	            return error;
@@ -3290,14 +3290,14 @@ fg::Error fg::Parser::parseMaterials(simdjson::dom::array& materials, Asset& ass
 	    }
 
         dom::object pbrMetallicRoughness;
-        if (materialObject["pbrMetallicRoughness"].get_object().get(pbrMetallicRoughness) == SUCCESS) FASTGLTF_LIKELY {
+        if (materialObject["pbrMetallicRoughness"].get_object().get(pbrMetallicRoughness) == SUCCESS) [[likely]] {
             PBRData pbr = {};
 
             dom::array baseColorFactor;
-            if (pbrMetallicRoughness["baseColorFactor"].get_array().get(baseColorFactor) == SUCCESS) FASTGLTF_LIKELY {
+            if (pbrMetallicRoughness["baseColorFactor"].get_array().get(baseColorFactor) == SUCCESS) [[likely]] {
                 for (auto i = 0U; i < 4; ++i) {
                     double val;
-                    if (baseColorFactor.at(i).get_double().get(val) != SUCCESS) FASTGLTF_UNLIKELY {
+                    if (baseColorFactor.at(i).get_double().get(val) != SUCCESS) [[unlikely]] {
                         return Error::InvalidGltf;
                     }
                     pbr.baseColorFactor[i] = static_cast<num>(val);
@@ -3305,25 +3305,25 @@ fg::Error fg::Parser::parseMaterials(simdjson::dom::array& materials, Asset& ass
             }
 
             double factor;
-            if (auto error = pbrMetallicRoughness["metallicFactor"].get_double().get(factor); error == SUCCESS) FASTGLTF_LIKELY {
+            if (auto error = pbrMetallicRoughness["metallicFactor"].get_double().get(factor); error == SUCCESS) [[likely]] {
                 pbr.metallicFactor = static_cast<num>(factor);
             } else if (error != NO_SUCH_FIELD) {
 				return Error::InvalidGltf;
 			}
-            if (auto error = pbrMetallicRoughness["roughnessFactor"].get_double().get(factor); error == SUCCESS) FASTGLTF_LIKELY {
+            if (auto error = pbrMetallicRoughness["roughnessFactor"].get_double().get(factor); error == SUCCESS) [[likely]] {
                 pbr.roughnessFactor = static_cast<num>(factor);
             } else if (error != NO_SUCH_FIELD) {
 				return Error::InvalidGltf;
 			}
 
 	        TextureInfo textureInfo;
-            if (auto error = parseTextureInfo(pbrMetallicRoughness, "baseColorTexture", &textureInfo, config.extensions); error == Error::None) FASTGLTF_LIKELY {
+            if (auto error = parseTextureInfo(pbrMetallicRoughness, "baseColorTexture", &textureInfo, config.extensions); error == Error::None) [[likely]] {
                 pbr.baseColorTexture = std::move(textureInfo);
             } else if (error != Error::MissingField) {
                 return error;
             }
 
-            if (auto error = parseTextureInfo(pbrMetallicRoughness, "metallicRoughnessTexture", &textureInfo, config.extensions); error == Error::None) FASTGLTF_LIKELY {
+            if (auto error = parseTextureInfo(pbrMetallicRoughness, "metallicRoughnessTexture", &textureInfo, config.extensions); error == Error::None) [[likely]] {
                 pbr.metallicRoughnessTexture = std::move(textureInfo);
             } else if (error != Error::MissingField) {
                 return error;
@@ -3333,7 +3333,7 @@ fg::Error fg::Parser::parseMaterials(simdjson::dom::array& materials, Asset& ass
         }
 
         std::string_view alphaMode;
-        if (auto error = materialObject["alphaMode"].get_string().get(alphaMode); error == SUCCESS) FASTGLTF_LIKELY {
+        if (auto error = materialObject["alphaMode"].get_string().get(alphaMode); error == SUCCESS) [[likely]] {
             if (alphaMode == "OPAQUE") {
                 material.alphaMode = AlphaMode::Opaque;
             } else if (alphaMode == "MASK") {
@@ -3343,21 +3343,21 @@ fg::Error fg::Parser::parseMaterials(simdjson::dom::array& materials, Asset& ass
             } else {
                 return Error::InvalidGltf;
             }
-        } else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+        } else if (error != NO_SUCH_FIELD) [[unlikely]] {
             return Error::InvalidGltf;
         }
 
         double alphaCutoff;
-        if (auto error = materialObject["alphaCutoff"].get_double().get(alphaCutoff); error == SUCCESS) FASTGLTF_LIKELY {
+        if (auto error = materialObject["alphaCutoff"].get_double().get(alphaCutoff); error == SUCCESS) [[likely]] {
             material.alphaCutoff = static_cast<num>(alphaCutoff);
-        } else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+        } else if (error != NO_SUCH_FIELD) [[unlikely]] {
             return Error::InvalidGltf;
         }
 
         bool doubleSided;
-        if (auto error = materialObject["doubleSided"].get_bool().get(doubleSided); error == SUCCESS) FASTGLTF_LIKELY {
+        if (auto error = materialObject["doubleSided"].get_bool().get(doubleSided); error == SUCCESS) [[likely]] {
             material.doubleSided = doubleSided;
-        } else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+        } else if (error != NO_SUCH_FIELD) [[unlikely]] {
             return Error::InvalidGltf;
         }
 
@@ -3369,7 +3369,7 @@ fg::Error fg::Parser::parseMaterials(simdjson::dom::array& materials, Asset& ass
         dom::object extensionsObject;
         if (auto extensionError = materialObject["extensions"].get_object().get(extensionsObject); extensionError == SUCCESS) {
 			parseMaterialExtensions(extensionsObject, material);
-        } else if (extensionError != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+        } else if (extensionError != NO_SUCH_FIELD) [[unlikely]] {
             return Error::InvalidJson;
         }
 
@@ -3403,28 +3403,28 @@ fastgltf::Error fg::Parser::parsePrimitiveExtensions(const simdjson::dom::object
 				}
 
 				dom::array mappingsArray;
-				if (variantObject["mappings"].get_array().get(mappingsArray) != SUCCESS) FASTGLTF_UNLIKELY {
+				if (variantObject["mappings"].get_array().get(mappingsArray) != SUCCESS) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
 				for (auto mapping : mappingsArray) {
 					dom::object mappingObject;
-					if (mapping.get_object().get(mappingObject) != SUCCESS) FASTGLTF_UNLIKELY {
+					if (mapping.get_object().get(mappingObject) != SUCCESS) [[unlikely]] {
 						return Error::InvalidGltf;
 					}
 
 					std::uint64_t materialIndex;
-					if (mappingObject["material"].get_uint64().get(materialIndex) != SUCCESS) FASTGLTF_UNLIKELY {
+					if (mappingObject["material"].get_uint64().get(materialIndex) != SUCCESS) [[unlikely]] {
 						return Error::InvalidGltf;
 					}
 
 					dom::array variantsArray;
-					if (mappingObject["variants"].get_array().get(variantsArray) != SUCCESS) FASTGLTF_UNLIKELY {
+					if (mappingObject["variants"].get_array().get(variantsArray) != SUCCESS) [[unlikely]] {
 						return Error::InvalidGltf;
 					}
 					for (auto variant : variantsArray) {
 						std::uint64_t variantIndex;
-						if (variant.get_uint64().get(variantIndex) != SUCCESS) FASTGLTF_UNLIKELY {
+						if (variant.get_uint64().get(variantIndex) != SUCCESS) [[unlikely]] {
 							return Error::InvalidGltf;
 						}
 
@@ -3447,13 +3447,13 @@ fastgltf::Error fg::Parser::parsePrimitiveExtensions(const simdjson::dom::object
 				auto dracoCompression = std::make_unique<DracoCompressedPrimitive>();
 
 				std::uint64_t value;
-				if (auto error = dracoObject["bufferView"].get_uint64().get(value); error != SUCCESS) FASTGLTF_UNLIKELY {
+				if (auto error = dracoObject["bufferView"].get_uint64().get(value); error != SUCCESS) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 				dracoCompression->bufferView = static_cast<std::size_t>(value);
 
 				dom::object attributesObject;
-				if (dracoObject["attributes"].get_object().get(attributesObject) != SUCCESS) FASTGLTF_UNLIKELY {
+				if (dracoObject["attributes"].get_object().get(attributesObject) != SUCCESS) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 				if (auto attributesError = parseAttributes(attributesObject, dracoCompression->attributes); attributesError != Error::None) {
@@ -3476,7 +3476,7 @@ fg::Error fg::Parser::parseMeshes(simdjson::dom::array& meshes, Asset& asset) {
     for (auto meshValue : meshes) {
         // Required fields: "primitives"
         dom::object meshObject;
-        if (meshValue.get_object().get(meshObject) != SUCCESS) FASTGLTF_UNLIKELY {
+        if (meshValue.get_object().get(meshObject) != SUCCESS) [[unlikely]] {
             return Error::InvalidGltf;
         }
         Mesh mesh = {};
@@ -3493,12 +3493,12 @@ fg::Error fg::Parser::parseMeshes(simdjson::dom::array& meshes, Asset& asset) {
 			// Required fields: "attributes"
 			Primitive primitive = {};
 			dom::object primitiveObject;
-			if (primitiveValue.get_object().get(primitiveObject) != SUCCESS) FASTGLTF_UNLIKELY {
+			if (primitiveValue.get_object().get(primitiveObject) != SUCCESS) [[unlikely]] {
 				return Error::InvalidGltf;
 			}
 
 			dom::object attributesObject;
-			if (primitiveObject["attributes"].get_object().get(attributesObject) != SUCCESS) FASTGLTF_UNLIKELY {
+			if (primitiveObject["attributes"].get_object().get(attributesObject) != SUCCESS) [[unlikely]] {
 				return Error::InvalidGltf;
 			}
 			if (auto attributesError = parseAttributes(attributesObject, primitive.attributes); attributesError != Error::None) {
@@ -3506,11 +3506,11 @@ fg::Error fg::Parser::parseMeshes(simdjson::dom::array& meshes, Asset& asset) {
 			}
 
 			dom::array targets;
-			if (primitiveObject["targets"].get_array().get(targets) == SUCCESS) FASTGLTF_LIKELY {
+			if (primitiveObject["targets"].get_array().get(targets) == SUCCESS) [[likely]] {
 				primitive.targets = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(primitive.targets), resourceAllocator.get(), 0);
 				primitive.targets.reserve(targets.size());
 				for (auto targetValue : targets) {
-					if (targetValue.get_object().get(attributesObject) != SUCCESS) FASTGLTF_UNLIKELY {
+					if (targetValue.get_object().get(attributesObject) != SUCCESS) [[unlikely]] {
 						return Error::InvalidGltf;
 					}
 					auto& map = primitive.targets.emplace_back();
@@ -3521,19 +3521,19 @@ fg::Error fg::Parser::parseMeshes(simdjson::dom::array& meshes, Asset& asset) {
 			}
 
 			std::uint64_t value;
-			if (auto error = primitiveObject["mode"].get_uint64().get(value); error == SUCCESS) FASTGLTF_LIKELY {
+			if (auto error = primitiveObject["mode"].get_uint64().get(value); error == SUCCESS) [[likely]] {
 				primitive.type = static_cast<PrimitiveType>(value);
-			} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+			} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 				return Error::InvalidGltf;
 			}
 
-			if (auto error = primitiveObject["indices"].get_uint64().get(value); error == SUCCESS) FASTGLTF_LIKELY {
+			if (auto error = primitiveObject["indices"].get_uint64().get(value); error == SUCCESS) [[likely]] {
 				primitive.indicesAccessor = static_cast<std::size_t>(value);
 			} else if (error != NO_SUCH_FIELD) {
 				return Error::InvalidGltf;
 			}
 
-			if (auto error = primitiveObject["material"].get_uint64().get(value); error == SUCCESS) FASTGLTF_LIKELY {
+			if (auto error = primitiveObject["material"].get_uint64().get(value); error == SUCCESS) [[likely]] {
 				primitive.materialIndex = static_cast<std::size_t>(value);
 			} else if (error != NO_SUCH_FIELD) {
 				return Error::InvalidGltf;
@@ -3552,12 +3552,12 @@ fg::Error fg::Parser::parseMeshes(simdjson::dom::array& meshes, Asset& asset) {
 			mesh.primitives.emplace_back(std::move(primitive));
 		}
 
-        if (meshError = getJsonArray(meshObject, "weights", &array); meshError == Error::None) FASTGLTF_LIKELY {
+        if (meshError = getJsonArray(meshObject, "weights", &array); meshError == Error::None) [[likely]] {
 	        mesh.weights = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(mesh.weights), resourceAllocator.get(), 0);
             mesh.weights.reserve(array.size());
             for (auto weightValue : array) {
                 double val;
-                if (weightValue.get_double().get(val) != SUCCESS) FASTGLTF_UNLIKELY {
+                if (weightValue.get_double().get(val) != SUCCESS) [[unlikely]] {
                     return Error::InvalidGltf;
                 }
                 mesh.weights.emplace_back(static_cast<num>(val));
@@ -3593,34 +3593,34 @@ fg::Error fg::Parser::parseNodes(simdjson::dom::array& nodes, Asset& asset) {
     for (auto nodeValue : nodes) {
         Node node = {};
         dom::object nodeObject;
-        if (nodeValue.get_object().get(nodeObject) != SUCCESS) FASTGLTF_UNLIKELY {
+        if (nodeValue.get_object().get(nodeObject) != SUCCESS) [[unlikely]] {
             return Error::InvalidGltf;
         }
 
         std::uint64_t index;
         if (auto error = nodeObject["mesh"].get_uint64().get(index); error == SUCCESS) {
             node.meshIndex = static_cast<std::size_t>(index);
-        } else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+        } else if (error != NO_SUCH_FIELD) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
         if (auto error = nodeObject["skin"].get_uint64().get(index); error == SUCCESS) {
             node.skinIndex = static_cast<std::size_t>(index);
-        } else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+        } else if (error != NO_SUCH_FIELD) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
         if (auto error = nodeObject["camera"].get_uint64().get(index); error == SUCCESS) {
             node.cameraIndex = static_cast<std::size_t>(index);
-        } else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+        } else if (error != NO_SUCH_FIELD) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
         dom::array array;
         auto childError = getJsonArray(nodeObject, "children", &array);
-        if (childError == Error::None) FASTGLTF_LIKELY {
+        if (childError == Error::None) [[likely]] {
 	        node.children = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(node.children), resourceAllocator.get(), 0);
 			node.children.reserve(array.size());
             for (auto childValue : array) {
-                if (childValue.get_uint64().get(index) != SUCCESS) FASTGLTF_UNLIKELY {
+                if (childValue.get_uint64().get(index) != SUCCESS) [[unlikely]] {
                     return Error::InvalidGltf;
                 }
 
@@ -3637,7 +3637,7 @@ fg::Error fg::Parser::parseNodes(simdjson::dom::array& nodes, Asset& asset) {
                 node.weights.reserve(array.size());
                 for (auto weightValue : array) {
                     double val;
-                    if (weightValue.get_double().get(val) != SUCCESS) FASTGLTF_UNLIKELY {
+                    if (weightValue.get_double().get(val) != SUCCESS) [[unlikely]] {
                         return Error::InvalidGltf;
                     }
                     node.weights.emplace_back(static_cast<num>(val));
@@ -3648,15 +3648,15 @@ fg::Error fg::Parser::parseNodes(simdjson::dom::array& nodes, Asset& asset) {
         }
 
         auto error = nodeObject["matrix"].get_array().get(array);
-        if (error == SUCCESS) FASTGLTF_LIKELY {
-            if (array.size() != 16) FASTGLTF_UNLIKELY {
+        if (error == SUCCESS) [[likely]] {
+            if (array.size() != 16) [[unlikely]] {
                 return Error::InvalidGltf;
             }
             math::fmat4x4 transformMatrix;
             std::size_t i = 0, j = 0;
 			for (auto num : array) {
                 double val;
-                if (num.get_double().get(val) != SUCCESS) FASTGLTF_UNLIKELY {
+                if (num.get_double().get(val) != SUCCESS) [[unlikely]] {
                     return Error::InvalidGltf;
                 }
 				transformMatrix.col(i)[j++] = static_cast<fastgltf::num>(val);
@@ -3677,54 +3677,54 @@ fg::Error fg::Parser::parseNodes(simdjson::dom::array& nodes, Asset& asset) {
             TRS trs = {};
 
             // There's no matrix, let's see if there's scale, rotation, or rotation fields.
-            if (auto scaleError = nodeObject["scale"].get_array().get(array); scaleError == SUCCESS) FASTGLTF_LIKELY {
-                if (array.size() != 3) FASTGLTF_UNLIKELY {
+            if (auto scaleError = nodeObject["scale"].get_array().get(array); scaleError == SUCCESS) [[likely]] {
+                if (array.size() != 3) [[unlikely]] {
                     return Error::InvalidGltf;
                 }
                 auto i = 0U;
                 for (auto num : array) {
                     double val;
-                    if (num.get_double().get(val) != SUCCESS) FASTGLTF_UNLIKELY {
+                    if (num.get_double().get(val) != SUCCESS) [[unlikely]] {
                         return Error::InvalidGltf;
                     }
                     trs.scale[i] = static_cast<fastgltf::num>(val);
                     ++i;
                 }
-            } else if (scaleError != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+            } else if (scaleError != NO_SUCH_FIELD) [[unlikely]] {
                 return Error::InvalidJson;
             }
 
-            if (auto translationError = nodeObject["translation"].get_array().get(array); translationError == SUCCESS) FASTGLTF_LIKELY {
-                if (array.size() != 3) FASTGLTF_UNLIKELY {
+            if (auto translationError = nodeObject["translation"].get_array().get(array); translationError == SUCCESS) [[likely]] {
+                if (array.size() != 3) [[unlikely]] {
                     return Error::InvalidGltf;
                 }
                 auto i = 0U;
                 for (auto num : array) {
                     double val;
-                    if (num.get_double().get(val) != SUCCESS) FASTGLTF_UNLIKELY {
+                    if (num.get_double().get(val) != SUCCESS) [[unlikely]] {
                         return Error::InvalidGltf;
                     }
                     trs.translation[i] = static_cast<fastgltf::num>(val);
                     ++i;
                 }
-            } else if (translationError != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+            } else if (translationError != NO_SUCH_FIELD) [[unlikely]] {
                 return Error::InvalidGltf;
             }
 
-            if (auto rotationError = nodeObject["rotation"].get_array().get(array); rotationError == SUCCESS) FASTGLTF_LIKELY {
-                if (array.size() != 4) FASTGLTF_UNLIKELY {
+            if (auto rotationError = nodeObject["rotation"].get_array().get(array); rotationError == SUCCESS) [[likely]] {
+                if (array.size() != 4) [[unlikely]] {
                     return Error::InvalidGltf;
                 }
                 auto i = 0U;
                 for (auto num : array) {
                     double val;
-                    if (num.get_double().get(val) != SUCCESS) FASTGLTF_UNLIKELY {
+                    if (num.get_double().get(val) != SUCCESS) [[unlikely]] {
                         return Error::InvalidGltf;
                     }
                     trs.rotation[i] = static_cast<fastgltf::num>(val);
                     ++i;
                 }
-            } else if (rotationError != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+            } else if (rotationError != NO_SUCH_FIELD) [[unlikely]] {
                 return Error::InvalidGltf;
             }
 
@@ -3732,12 +3732,12 @@ fg::Error fg::Parser::parseNodes(simdjson::dom::array& nodes, Asset& asset) {
         }
 
         dom::object extensionsObject;
-        if (nodeObject["extensions"].get_object().get(extensionsObject) == SUCCESS) FASTGLTF_LIKELY {
+        if (nodeObject["extensions"].get_object().get(extensionsObject) == SUCCESS) [[likely]] {
 			if (hasBit(config.extensions, Extensions::KHR_lights_punctual)) {
 				dom::object lightsObject;
-				if (extensionsObject[extensions::KHR_lights_punctual].get_object().get(lightsObject) == SUCCESS) FASTGLTF_LIKELY {
+				if (extensionsObject[extensions::KHR_lights_punctual].get_object().get(lightsObject) == SUCCESS) [[likely]] {
 					std::uint64_t light;
-					if (auto lightError = lightsObject["light"].get_uint64().get(light); lightError == SUCCESS) FASTGLTF_LIKELY {
+					if (auto lightError = lightsObject["light"].get_uint64().get(light); lightError == SUCCESS) [[likely]] {
 						node.lightIndex = static_cast<std::size_t>(light);
 					} else {
 						return lightError == NO_SUCH_FIELD || lightError == INCORRECT_TYPE ? Error::InvalidGltf : Error::InvalidJson;
@@ -3749,10 +3749,10 @@ fg::Error fg::Parser::parseNodes(simdjson::dom::array& nodes, Asset& asset) {
 
 			if (hasBit(config.extensions, Extensions::EXT_mesh_gpu_instancing)) {
 				dom::object gpuInstancingObject;
-				if (auto instancingError = extensionsObject[extensions::EXT_mesh_gpu_instancing].get_object().get(gpuInstancingObject); instancingError == SUCCESS) FASTGLTF_LIKELY {
+				if (auto instancingError = extensionsObject[extensions::EXT_mesh_gpu_instancing].get_object().get(gpuInstancingObject); instancingError == SUCCESS) [[likely]] {
 					dom::object attributesObject;
 
-					if (gpuInstancingObject["attributes"].get_object().get(attributesObject) != SUCCESS) FASTGLTF_UNLIKELY {
+					if (gpuInstancingObject["attributes"].get_object().get(attributesObject) != SUCCESS) [[unlikely]] {
 						return Error::InvalidGltf;
 					}
 
@@ -3767,7 +3767,7 @@ fg::Error fg::Parser::parseNodes(simdjson::dom::array& nodes, Asset& asset) {
 #if FASTGLTF_ENABLE_KHR_PHYSICS_RIGID_BODIES
 			if (hasBit(config.extensions, Extensions::KHR_physics_rigid_bodies)) {
 				dom::object physicsRigidBodiesObject;
-				if (auto rigidBodiesError = extensionsObject[extensions::KHR_physics_rigid_bodies].get_object().get(physicsRigidBodiesObject); rigidBodiesError == SUCCESS) FASTGLTF_LIKELY {
+				if (auto rigidBodiesError = extensionsObject[extensions::KHR_physics_rigid_bodies].get_object().get(physicsRigidBodiesObject); rigidBodiesError == SUCCESS) [[likely]] {
 					const auto rigidBodyError = parsePhysicsRigidBody(physicsRigidBodiesObject, node);
 					if (rigidBodyError != Error::None) {
 						return rigidBodyError;
@@ -3807,29 +3807,29 @@ fg::Error fg::Parser::parseSamplers(const simdjson::dom::array& samplers, Asset&
     for (auto samplerValue : samplers) {
         Sampler sampler = {};
         dom::object samplerObject;
-        if (samplerValue.get_object().get(samplerObject) != SUCCESS) FASTGLTF_UNLIKELY {
+        if (samplerValue.get_object().get(samplerObject) != SUCCESS) [[unlikely]] {
             return Error::InvalidGltf;
         }
 
-        if (auto error = samplerObject["magFilter"].get_uint64().get(number); error == SUCCESS) FASTGLTF_LIKELY {
+        if (auto error = samplerObject["magFilter"].get_uint64().get(number); error == SUCCESS) [[likely]] {
             sampler.magFilter = static_cast<Filter>(number);
-        } else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+        } else if (error != NO_SUCH_FIELD) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
-        if (auto error = samplerObject["minFilter"].get_uint64().get(number); error == SUCCESS) FASTGLTF_LIKELY {
+        if (auto error = samplerObject["minFilter"].get_uint64().get(number); error == SUCCESS) [[likely]] {
             sampler.minFilter = static_cast<Filter>(number);
-        } else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+        } else if (error != NO_SUCH_FIELD) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
-        if (auto error = samplerObject["wrapS"].get_uint64().get(number); error == SUCCESS) FASTGLTF_LIKELY {
+        if (auto error = samplerObject["wrapS"].get_uint64().get(number); error == SUCCESS) [[likely]] {
             sampler.wrapS = static_cast<Wrap>(number);
-        } else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+        } else if (error != NO_SUCH_FIELD) [[unlikely]] {
             return Error::InvalidGltf;
         }
-        if (auto error = samplerObject["wrapT"].get_uint64().get(number); error == SUCCESS) FASTGLTF_LIKELY {
+        if (auto error = samplerObject["wrapT"].get_uint64().get(number); error == SUCCESS) [[likely]] {
             sampler.wrapT = static_cast<Wrap>(number);
-        } else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+        } else if (error != NO_SUCH_FIELD) [[unlikely]] {
             return Error::InvalidGltf;
         }
 
@@ -3861,7 +3861,7 @@ fg::Error fg::Parser::parseScenes(const simdjson::dom::array& scenes, Asset& ass
         // The scene object can be completely empty
         Scene scene = {};
         dom::object sceneObject;
-        if (sceneValue.get_object().get(sceneObject) != SUCCESS) FASTGLTF_UNLIKELY {
+        if (sceneValue.get_object().get(sceneObject) != SUCCESS) [[unlikely]] {
             return Error::InvalidGltf;
         }
 
@@ -3882,12 +3882,12 @@ fg::Error fg::Parser::parseScenes(const simdjson::dom::array& scenes, Asset& ass
 		// Parse the array of nodes.
         dom::array nodes;
         auto nodeError = getJsonArray(sceneObject, "nodes", &nodes);
-        if (nodeError == Error::None) FASTGLTF_LIKELY {
+        if (nodeError == Error::None) [[likely]] {
 	        scene.nodeIndices = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(scene.nodeIndices), resourceAllocator.get(), 0);
 			scene.nodeIndices.reserve(nodes.size());
             for (auto nodeValue : nodes) {
                 std::uint64_t index;
-                if (nodeValue.get_uint64().get(index) != SUCCESS) FASTGLTF_UNLIKELY {
+                if (nodeValue.get_uint64().get(index) != SUCCESS) [[unlikely]] {
                     return Error::InvalidGltf;
                 }
 
@@ -3910,30 +3910,30 @@ fg::Error fg::Parser::parseSkins(const simdjson::dom::array& skins, Asset& asset
     for (auto skinValue : skins) {
         Skin skin = {};
         dom::object skinObject;
-        if (skinValue.get_object().get(skinObject) != SUCCESS) FASTGLTF_UNLIKELY {
+        if (skinValue.get_object().get(skinObject) != SUCCESS) [[unlikely]] {
             return Error::InvalidGltf;
         }
 
         std::uint64_t index;
-        if (auto error = skinObject["inverseBindMatrices"].get_uint64().get(index); error == SUCCESS) FASTGLTF_LIKELY {
+        if (auto error = skinObject["inverseBindMatrices"].get_uint64().get(index); error == SUCCESS) [[likely]] {
             skin.inverseBindMatrices = static_cast<std::size_t>(index);
         } else if (error != NO_SUCH_FIELD) {
 			return Error::InvalidGltf;
 		}
-        if (auto error = skinObject["skeleton"].get_uint64().get(index); error == SUCCESS) FASTGLTF_LIKELY {
+        if (auto error = skinObject["skeleton"].get_uint64().get(index); error == SUCCESS) [[likely]] {
             skin.skeleton = static_cast<std::size_t>(index);
         } else if (error != NO_SUCH_FIELD) {
 			return Error::InvalidGltf;
 		}
 
         dom::array jointsArray;
-        if (skinObject["joints"].get_array().get(jointsArray) != SUCCESS) FASTGLTF_UNLIKELY {
+        if (skinObject["joints"].get_array().get(jointsArray) != SUCCESS) [[unlikely]] {
             return Error::InvalidGltf;
         }
 		skin.joints = FASTGLTF_CONSTRUCT_PMR_RESOURCE(decltype(skin.joints), resourceAllocator.get(), 0);
         skin.joints.reserve(jointsArray.size());
         for (auto jointValue : jointsArray) {
-            if (jointValue.get_uint64().get(index) != SUCCESS) FASTGLTF_UNLIKELY {
+            if (jointValue.get_uint64().get(index) != SUCCESS) [[unlikely]] {
                 return Error::InvalidGltf;
             }
             skin.joints.emplace_back(index);
@@ -3965,19 +3965,19 @@ fg::Error fg::Parser::parseTextures(const simdjson::dom::array& textures, Asset&
     for (auto textureValue : textures) {
         Texture texture;
         dom::object textureObject;
-        if (textureValue.get_object().get(textureObject) != SUCCESS) FASTGLTF_UNLIKELY {
+        if (textureValue.get_object().get(textureObject) != SUCCESS) [[unlikely]] {
             return Error::InvalidGltf;
         }
 
         std::uint64_t sourceIndex;
-        if (auto error = textureObject["source"].get_uint64().get(sourceIndex); error == SUCCESS) FASTGLTF_LIKELY {
+        if (auto error = textureObject["source"].get_uint64().get(sourceIndex); error == SUCCESS) [[likely]] {
             texture.imageIndex = static_cast<std::size_t>(sourceIndex);
         } else if (error != NO_SUCH_FIELD) {
 			return Error::InvalidGltf;
 		}
 
         dom::object extensionsObject;
-        if (auto error = textureObject["extensions"].get_object().get(extensionsObject); error == SUCCESS) FASTGLTF_LIKELY {
+        if (auto error = textureObject["extensions"].get_object().get(extensionsObject); error == SUCCESS) [[likely]] {
 			if (!parseTextureExtensions(texture, extensionsObject, config.extensions)) {
 				return Error::InvalidGltf;
 			}
@@ -3988,7 +3988,7 @@ fg::Error fg::Parser::parseTextures(const simdjson::dom::array& textures, Asset&
         // The index of the sampler used by this texture. When undefined, a sampler with
         // repeat wrapping and auto filtering SHOULD be used.
         std::uint64_t samplerIndex;
-        if (auto error = textureObject["sampler"].get_uint64().get(samplerIndex); error == SUCCESS) FASTGLTF_LIKELY {
+        if (auto error = textureObject["sampler"].get_uint64().get(samplerIndex); error == SUCCESS) [[likely]] {
             texture.samplerIndex = static_cast<std::size_t>(samplerIndex);
         } else if (error != NO_SUCH_FIELD) {
 			return Error::InvalidGltf;
@@ -4023,34 +4023,34 @@ fg::Error fg::Parser::parseShapes(const simdjson::dom::array& shapes, Asset& ass
 		auto& shape = asset.shapes.emplace_back();
 
 		dom::object shapeObject;
-		if (shapeValue.get_object().get(shapeObject) != SUCCESS) FASTGLTF_UNLIKELY {
+		if (shapeValue.get_object().get(shapeObject) != SUCCESS) [[unlikely]] {
 		    return Error::InvalidGltf;
 		}
 
 		std::string_view shapeTypeName;
-		if (shapeObject["type"].get_string().get(shapeTypeName) != SUCCESS) FASTGLTF_UNLIKELY {
+		if (shapeObject["type"].get_string().get(shapeTypeName) != SUCCESS) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
 		dom::object sphereObject;
 		if (auto error = shapeObject["sphere"].get_object().get(sphereObject); error == SUCCESS) {
-			if (shapeTypeName != "sphere") FASTGLTF_UNLIKELY {
+			if (shapeTypeName != "sphere") [[unlikely]] {
 				return Error::InvalidGltf;
 			}
 
 			double radius;
 			if (error = sphereObject["radius"].get_double().get(radius); error == SUCCESS) {
 				shape = SphereShape{ static_cast<num>(radius) };
-			} else if(error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+			} else if(error != NO_SUCH_FIELD) [[unlikely]] {
 				return Error::InvalidGltf;
 			}
-		} else if(error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+		} else if(error != NO_SUCH_FIELD) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
 		dom::object boxObject;
 		if (auto error = shapeObject["box"].get_object().get(boxObject); error == SUCCESS) {
-			if (shapeTypeName != "box") FASTGLTF_UNLIKELY {
+			if (shapeTypeName != "box") [[unlikely]] {
 				return Error::InvalidGltf;
 		    }
 
@@ -4064,7 +4064,7 @@ fg::Error fg::Parser::parseShapes(const simdjson::dom::array& shapes, Asset& ass
 				auto curIndex = 0;
 				for (auto sizeNum : sizeArray) {
 					double value;
-					if (sizeNum.get_double().get(value) == SUCCESS) FASTGLTF_LIKELY {
+					if (sizeNum.get_double().get(value) == SUCCESS) [[likely]] {
 						box.size[curIndex] = static_cast<num>(value);
 					} else {
 						return Error::InvalidGltf;
@@ -4072,16 +4072,16 @@ fg::Error fg::Parser::parseShapes(const simdjson::dom::array& shapes, Asset& ass
 
 					curIndex++;
 				}
-			} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+			} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 			    return Error::InvalidGltf;
 			}
-		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
 		dom::object capsuleObject;
 		if (auto error = shapeObject["capsule"].get_object().get(capsuleObject); error == SUCCESS) {
-			if (shapeTypeName != "capsule") FASTGLTF_UNLIKELY {
+			if (shapeTypeName != "capsule") [[unlikely]] {
 				return Error::InvalidGltf;
 			}
 
@@ -4090,31 +4090,31 @@ fg::Error fg::Parser::parseShapes(const simdjson::dom::array& shapes, Asset& ass
 			double height;
 			if (error = capsuleObject["height"].get_double().get(height); error == SUCCESS) {
 				capsule.height = static_cast<num>(height);
-			} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+			} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 				return Error::InvalidGltf;
 			}
 
 			double radiusBottom;
 			if (error = capsuleObject["radiusBottom"].get_double().get(radiusBottom); error == SUCCESS) {
 				capsule.radiusBottom = static_cast<num>(radiusBottom);
-			} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+			} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 				return Error::InvalidGltf;
 			}
 
 			double radiusTop;
 			if (error = capsuleObject["radiusTop"].get_double().get(radiusTop); error == SUCCESS) {
 				capsule.radiusTop = static_cast<num>(radiusTop);
-			} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+			} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 				return Error::InvalidGltf;
 			}
 
-		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
 		dom::object cylinderObject;
 		if (auto error = shapeObject["cylinder"].get_object().get(cylinderObject); error == SUCCESS) {
-			if (shapeTypeName != "cylinder") FASTGLTF_UNLIKELY {
+			if (shapeTypeName != "cylinder") [[unlikely]] {
 				return Error::InvalidGltf;
 			}
 
@@ -4123,25 +4123,25 @@ fg::Error fg::Parser::parseShapes(const simdjson::dom::array& shapes, Asset& ass
 			double height;
 			if (error = cylinderObject["height"].get_double().get(height); error == SUCCESS) {
 				cylinder.height = static_cast<num>(height);
-			} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+			} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 				return Error::InvalidGltf;
 			}
 
 			double radiusBottom;
 			if (error = cylinderObject["radiusBottom"].get_double().get(radiusBottom); error == SUCCESS) {
 				cylinder.radiusBottom = static_cast<num>(radiusBottom);
-			} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+			} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 				return Error::InvalidGltf;
 			}
 
 			double radiusTop;
 			if (error = cylinderObject["radiusTop"].get_double().get(radiusTop); error == SUCCESS) {
 				cylinder.radiusTop = static_cast<num>(radiusTop);
-			} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+			} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 				return Error::InvalidGltf;
 			}
 
-		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
@@ -4149,7 +4149,7 @@ fg::Error fg::Parser::parseShapes(const simdjson::dom::array& shapes, Asset& ass
 			dom::object extrasObject;
 			if (auto extrasError = shapeObject["extras"].get_object().get(extrasObject); extrasError == SUCCESS) {
 				config.extrasCallback(&extrasObject, asset.shapes.size() - 1, Category::Shapes, config.userPointer);
-			} else if (extrasError != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+			} else if (extrasError != NO_SUCH_FIELD) [[unlikely]] {
 				return Error::InvalidGltf;
 			}
 		}
@@ -4167,42 +4167,42 @@ fg::Error fg::Parser::parsePhysicsMaterials(const simdjson::dom::array& physicsM
 	for (auto materialValue : physicsMaterials) {
 		PhysicsMaterial& material = asset.physicsMaterials.emplace_back();
 		dom::object materialObject;
-		if (materialValue.get_object().get(materialObject) != SUCCESS) FASTGLTF_UNLIKELY {
+		if (materialValue.get_object().get(materialObject) != SUCCESS) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
 		double staticFriction;
 		if (auto error = materialObject["staticFriction"].get_double().get(staticFriction); error == SUCCESS) {
 		   material.staticFriction = static_cast<num>(staticFriction);
-		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
 		double dynamicFriction;
 		if (auto error = materialObject["dynamicFriction"].get_double().get(dynamicFriction); error == SUCCESS) {
 		   material.dynamicFriction = static_cast<num>(dynamicFriction);
-		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
 		double restitution;
 		if (auto error = materialObject["restitution"].get_double().get(restitution); error == SUCCESS) {
 		   material.restitution = static_cast<num>(restitution);
-		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
 		std::string_view frictionCombine;
 		if (auto error = materialObject["frictionCombine"].get_string().get(frictionCombine); error == SUCCESS) {
 			material.frictionCombine = getCombineMode(frictionCombine);
-		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
 		std::string_view restitutionCombine;
 		if (auto error = materialObject["restitutionCombine"].get_string().get(restitutionCombine); error == SUCCESS) {
 		   material.restitutionCombine = getCombineMode(restitutionCombine);
-		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
@@ -4210,7 +4210,7 @@ fg::Error fg::Parser::parsePhysicsMaterials(const simdjson::dom::array& physicsM
 			dom::object extrasObject;
 			if (auto extrasError = materialObject["extras"].get_object().get(extrasObject); extrasError == SUCCESS) {
 				config.extrasCallback(&extrasObject, asset.physicsMaterials.size() - 1, Category::PhysicsMaterials, config.userPointer);
-			} else if (extrasError != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+			} else if (extrasError != NO_SUCH_FIELD) [[unlikely]] {
 				return Error::InvalidGltf;
 			}
 		}
@@ -4227,7 +4227,7 @@ fg::Error fg::Parser::parseCollisionFilters(const simdjson::dom::array& collisio
 		auto& collisionFilter = asset.collisionFilters.emplace_back();
 
 		dom::object collisionFilterObject;
-		if (collisionFilterValue.get_object().get(collisionFilterObject) != SUCCESS) FASTGLTF_UNLIKELY {
+		if (collisionFilterValue.get_object().get(collisionFilterObject) != SUCCESS) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
@@ -4236,7 +4236,7 @@ fg::Error fg::Parser::parseCollisionFilters(const simdjson::dom::array& collisio
 			collisionFilter.collisionSystems.reserve(collisionSystems.size());
 			for (auto systemNameValue : collisionSystems) {
 				std::string_view systemName;
-				if (systemNameValue.get_string().get(systemName) == SUCCESS) FASTGLTF_LIKELY {
+				if (systemNameValue.get_string().get(systemName) == SUCCESS) [[likely]] {
 					collisionFilter.collisionSystems.emplace_back(systemName);
 				} else {
 					return Error::InvalidGltf;
@@ -4247,7 +4247,7 @@ fg::Error fg::Parser::parseCollisionFilters(const simdjson::dom::array& collisio
 		}
 
 	    // A glTF isn't allowed to have both
-		if (collisionFilterObject["collideWithSystems"].error() == SUCCESS && collisionFilterObject["notCollideWithSystems"].error() == SUCCESS) FASTGLTF_UNLIKELY {
+		if (collisionFilterObject["collideWithSystems"].error() == SUCCESS && collisionFilterObject["notCollideWithSystems"].error() == SUCCESS) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
@@ -4256,13 +4256,13 @@ fg::Error fg::Parser::parseCollisionFilters(const simdjson::dom::array& collisio
 			collisionFilter.collideWithSystems.reserve(collideWithSystems.size());
 			for (auto systemNameValue : collideWithSystems) {
 				std::string_view systemName;
-				if (systemNameValue.get_string().get(systemName) == SUCCESS) FASTGLTF_LIKELY {
+				if (systemNameValue.get_string().get(systemName) == SUCCESS) [[likely]] {
 					collisionFilter.collideWithSystems.emplace_back(systemName);
 				} else {
 					return Error::InvalidGltf;
 				}
 			}
-		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
@@ -4271,13 +4271,13 @@ fg::Error fg::Parser::parseCollisionFilters(const simdjson::dom::array& collisio
 			collisionFilter.notCollideWithSystems.reserve(notCollideWithSystems.size());
 			for (auto systemNameValue : notCollideWithSystems) {
 				std::string_view systemName;
-				if (systemNameValue.get_string().get(systemName) == SUCCESS) FASTGLTF_LIKELY {
+				if (systemNameValue.get_string().get(systemName) == SUCCESS) [[likely]] {
 					collisionFilter.notCollideWithSystems.emplace_back(systemName);
 				} else {
 					return Error::InvalidGltf;
 				}
 			}
-		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
@@ -4285,7 +4285,7 @@ fg::Error fg::Parser::parseCollisionFilters(const simdjson::dom::array& collisio
 			dom::object extrasObject;
 			if (auto extrasError = collisionFilterObject["extras"].get_object().get(extrasObject); extrasError == SUCCESS) {
 				config.extrasCallback(&extrasObject, asset.collisionFilters.size() - 1, Category::CollisionFilters, config.userPointer);
-			} else if (extrasError != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+			} else if (extrasError != NO_SUCH_FIELD) [[unlikely]] {
 				return Error::InvalidGltf;
 			}
 		}
@@ -4302,7 +4302,7 @@ fg::Error fg::Parser::parsePhysicsJoints(const simdjson::dom::array& physicsJoin
 	    auto& physicsJoint = asset.physicsJoints.emplace_back();
 
 		dom::object physicsJointObject;
-		if (physicsJointValue.get_object().get(physicsJointObject) != SUCCESS) FASTGLTF_UNLIKELY {
+		if (physicsJointValue.get_object().get(physicsJointObject) != SUCCESS) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
@@ -4312,16 +4312,16 @@ fg::Error fg::Parser::parsePhysicsJoints(const simdjson::dom::array& physicsJoin
             for (auto limitValue : limitsArray) {
 				auto& limit = physicsJoint.limits.emplace_back();
 				dom::object limitObject;
-				if (limitValue.get_object().get(limitObject) != SUCCESS) FASTGLTF_UNLIKELY {
+				if (limitValue.get_object().get(limitObject) != SUCCESS) [[unlikely]] {
 			        return Error::InvalidGltf;
 				}
 
-				if(limitObject["linearAxes"].error() == SUCCESS && limitObject["angularAxes"].error() == SUCCESS) FASTGLTF_UNLIKELY {
+				if(limitObject["linearAxes"].error() == SUCCESS && limitObject["angularAxes"].error() == SUCCESS) [[unlikely]] {
 				    // A limit may only have one of these
 					return Error::InvalidGltf;
 				}
 
-				if (limitObject["linearAxes"].error() != SUCCESS && limitObject["angularAxes"].error() != SUCCESS) FASTGLTF_UNLIKELY {
+				if (limitObject["linearAxes"].error() != SUCCESS && limitObject["angularAxes"].error() != SUCCESS) [[unlikely]] {
 					// A limit MUST have one of these
 					return Error::InvalidGltf;
 				}
@@ -4329,28 +4329,28 @@ fg::Error fg::Parser::parsePhysicsJoints(const simdjson::dom::array& physicsJoin
 				double limitMin;
 				if (auto error = limitObject["min"].get_double().get(limitMin); error == SUCCESS) {
 					limit.min = static_cast<num>(limitMin);
-				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 				    return Error::InvalidGltf;
 				}
 
 				double limitMax;
 				if (auto error = limitObject["max"].get_double().get(limitMax); error == SUCCESS) {
 					limit.max = static_cast<num>(limitMax);
-				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
 				double stiffness;
 				if (auto error = limitObject["stiffness"].get_double().get(stiffness); error == SUCCESS) {
 					limit.stiffness = static_cast<num>(stiffness);
-				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
 				double damping;
 				if (auto error = limitObject["damping"].get_double().get(damping); error == SUCCESS) {
 					limit.damping = static_cast<num>(damping);
-				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 				    return Error::InvalidGltf;
 				}
 
@@ -4359,13 +4359,13 @@ fg::Error fg::Parser::parsePhysicsJoints(const simdjson::dom::array& physicsJoin
 					limit.linearAxes.reserve(linearAxesArray.size());
 					for(auto axisValue : linearAxesArray) {
 						std::uint64_t axis;
-						if(axisValue.get_uint64().get(axis) == SUCCESS && axis <= 2) FASTGLTF_LIKELY {
+						if(axisValue.get_uint64().get(axis) == SUCCESS && axis <= 2) [[likely]] {
 							limit.linearAxes.emplace_back(static_cast<uint8_t>(axis));
 						} else {
 							return Error::InvalidGltf;
 						}
 					}
-				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
@@ -4374,13 +4374,13 @@ fg::Error fg::Parser::parsePhysicsJoints(const simdjson::dom::array& physicsJoin
 					limit.angularAxes.reserve(angularAxesArray.size());
 					for (auto axisValue : angularAxesArray) {
 						std::uint64_t axis;
-						if (axisValue.get_uint64().get(axis) == SUCCESS && axis <= 2) FASTGLTF_LIKELY {
+						if (axisValue.get_uint64().get(axis) == SUCCESS && axis <= 2) [[likely]] {
 							limit.angularAxes.emplace_back(static_cast<uint8_t>(axis));
 						} else {
 							return Error::InvalidGltf;
 						}
 					}
-				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
             }
@@ -4392,16 +4392,16 @@ fg::Error fg::Parser::parsePhysicsJoints(const simdjson::dom::array& physicsJoin
 			for (auto driveValue : driveArray) {
 			    auto& drive = physicsJoint.drives.emplace_back();
 				dom::object driveObject;
-				if (driveValue.get_object().get(driveObject) != SUCCESS) FASTGLTF_UNLIKELY {
+				if (driveValue.get_object().get(driveObject) != SUCCESS) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
 				// Type, mode, and axis are required
 
 				std::string_view type;
-				if (driveValue["type"].get_string().get(type) == SUCCESS) FASTGLTF_LIKELY {
+				if (driveValue["type"].get_string().get(type) == SUCCESS) [[likely]] {
 					drive.type = getDriveType(type);
-					if (drive.type == DriveType::Invalid) FASTGLTF_UNLIKELY {
+					if (drive.type == DriveType::Invalid) [[unlikely]] {
 						return Error::InvalidGltf;
 					}
 				} else {
@@ -4409,9 +4409,9 @@ fg::Error fg::Parser::parsePhysicsJoints(const simdjson::dom::array& physicsJoin
 				}
 
 				std::string_view mode;
-				if (driveValue["mode"].get_string().get(mode) == SUCCESS) FASTGLTF_LIKELY {
+				if (driveValue["mode"].get_string().get(mode) == SUCCESS) [[likely]] {
 					drive.mode = getDriveMode(mode);
-					if (drive.mode == DriveMode::Invalid) FASTGLTF_UNLIKELY {
+					if (drive.mode == DriveMode::Invalid) [[unlikely]] {
 						return Error::InvalidGltf;
 				    }
 				} else {
@@ -4419,10 +4419,10 @@ fg::Error fg::Parser::parsePhysicsJoints(const simdjson::dom::array& physicsJoin
 				}
 
 				uint64_t axis;
-				if (driveValue["axis"].get_uint64().get(axis) == SUCCESS) FASTGLTF_LIKELY {
+				if (driveValue["axis"].get_uint64().get(axis) == SUCCESS) [[likely]] {
 				    if (axis < 3) {
 						drive.axis = static_cast<uint8_t>(axis);
-				    } else FASTGLTF_UNLIKELY {
+				    } else [[unlikely]] {
 						return Error::InvalidGltf;
 				    }
 				} else {
@@ -4434,53 +4434,53 @@ fg::Error fg::Parser::parsePhysicsJoints(const simdjson::dom::array& physicsJoin
 				double maxForce;
 				if (error = driveValue["maxForce"].get_double().get(maxForce); error == SUCCESS) {
 					drive.maxForce = static_cast<num>(maxForce);
-				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
 				// If the drive has positionTarget, it must also have stiffness
 				const auto hasPositionTarget = driveValue["positionTarget"].error() == SUCCESS;
 				const auto hasStiffness = driveValue["stiffness"].error() == SUCCESS;
-				if (hasPositionTarget != hasStiffness) FASTGLTF_UNLIKELY {
+				if (hasPositionTarget != hasStiffness) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
 				double positionTarget;
 				if (error = driveValue["positionTarget"].get_double().get(positionTarget); error == SUCCESS) {
 				    drive.positionTarget = static_cast<num>(positionTarget);
-				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
 				double stiffness;
 				if (error = driveValue["stiffness"].get_double().get(stiffness); error == SUCCESS) {
 					drive.stiffness = static_cast<num>(stiffness);
-				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
 				// If the drive has velocityTarget, it must also have damping
 				const auto hasVelocityTarget = driveValue["velocityTarget"].error() == SUCCESS;
 				const auto hasDamping = driveValue["damping"].error() == SUCCESS;
-				if (hasVelocityTarget != hasDamping) FASTGLTF_UNLIKELY {
+				if (hasVelocityTarget != hasDamping) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
 				double velocityTarget;
 				if (error = driveValue["velocityTarget"].get_double().get(velocityTarget); error == SUCCESS) {
 					drive.velocityTarget = static_cast<num>(velocityTarget);
-				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 
 				double damping;
 				if (error = driveValue["damping"].get_double().get(damping); error == SUCCESS) {
 					drive.damping = static_cast<num>(damping);
-				} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+				} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 			}
-		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
     		return Error::InvalidGltf;
 		}
 
@@ -4488,7 +4488,7 @@ fg::Error fg::Parser::parsePhysicsJoints(const simdjson::dom::array& physicsJoin
 			dom::object extrasObject;
 			if (auto extrasError = physicsJointValue["extras"].get_object().get(extrasObject); extrasError == SUCCESS) {
 				config.extrasCallback(&extrasObject, asset.physicsJoints.size() - 1, Category::PhysicsJoints, config.userPointer);
-			} else if (extrasError != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+			} else if (extrasError != NO_SUCH_FIELD) [[unlikely]] {
 				return Error::InvalidGltf;
 			}
 		}
@@ -4510,39 +4510,39 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 		bool isKinematic;
 		if (error = motionObject["isKinematic"].get_bool().get(isKinematic); error == SUCCESS) {
 			motion.isKinematic = isKinematic;
-		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
 		double mass;
 		if (error = motionObject["mass"].get_double().get(mass); error == SUCCESS) {
 			motion.mass = static_cast<num>(mass);
-		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
 		dom::array centerOfMassArray;
 		if (error = motionObject["centerOfMass"].get_array().get(centerOfMassArray); error == SUCCESS) {
-			if (centerOfMassArray.size() != 3) FASTGLTF_UNLIKELY {
+			if (centerOfMassArray.size() != 3) [[unlikely]] {
 				return Error::InvalidGltf;
 			}
 
 			auto i = 0U;
 			for (auto numValue : centerOfMassArray) {
 				double val;
-				if (numValue.get_double().get(val) != SUCCESS) FASTGLTF_UNLIKELY {
+				if (numValue.get_double().get(val) != SUCCESS) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 				motion.centerOfMass[i] = static_cast<num>(val);
 				++i;
 			}
-		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
 		dom::array inertiaDiagonalArray;
 		if (error = motionObject["inertiaDiagonal"].get_array().get(inertiaDiagonalArray); error == SUCCESS) {
-			if (inertiaDiagonalArray.size() != 3) FASTGLTF_UNLIKELY {
+			if (inertiaDiagonalArray.size() != 3) [[unlikely]] {
 				return Error::InvalidGltf;
 			}
 
@@ -4551,7 +4551,7 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 			auto i = 0U;
 			for (auto numValue : inertiaDiagonalArray) {
 				double val;
-				if (numValue.get_double().get(val) != SUCCESS) FASTGLTF_UNLIKELY {
+				if (numValue.get_double().get(val) != SUCCESS) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 				inertialDiagonal[i] = static_cast<num>(val);
@@ -4560,13 +4560,13 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 
 			motion.inertialDiagonal = inertialDiagonal;
 
-		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
 		dom::array inertialOrientationArray;
 		if (error = motionObject["inertialOrientation"].get_array().get(inertialOrientationArray); error == SUCCESS) {
-			if (inertialOrientationArray.size() != 4) FASTGLTF_UNLIKELY {
+			if (inertialOrientationArray.size() != 4) [[unlikely]] {
 				return Error::InvalidGltf;
 			}
 
@@ -4575,7 +4575,7 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 			auto i = 0U;
 			for (auto numValue : inertialOrientationArray) {
 				double val;
-				if (numValue.get_double().get(val) != SUCCESS) FASTGLTF_UNLIKELY {
+				if (numValue.get_double().get(val) != SUCCESS) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 				inertialOrientation[i] = static_cast<num>(val);
@@ -4584,57 +4584,57 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 
 			motion.inertialOrientation = inertialOrientation;
 
-		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
 		dom::array linearVelocityArray;
 		if (error = motionObject["linearVelocity"].get_array().get(linearVelocityArray); error == SUCCESS) {
-			if (linearVelocityArray.size() != 3) FASTGLTF_UNLIKELY {
+			if (linearVelocityArray.size() != 3) [[unlikely]] {
 				return Error::InvalidGltf;
 			}
 
 			auto i = 0U;
 			for (auto numValue : linearVelocityArray) {
 				double val;
-				if (numValue.get_double().get(val) != SUCCESS) FASTGLTF_UNLIKELY {
+				if (numValue.get_double().get(val) != SUCCESS) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 				motion.linearVelocity[i] = static_cast<num>(val);
 				++i;
 			}
 
-		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
 		dom::array angularVelocityArray;
 		if (error = motionObject["angularVelocity"].get_array().get(angularVelocityArray); error == SUCCESS) {
-			if (angularVelocityArray.size() != 3) FASTGLTF_UNLIKELY {
+			if (angularVelocityArray.size() != 3) [[unlikely]] {
 				return Error::InvalidGltf;
 			}
 
 			auto i = 0U;
 			for (auto numValue : angularVelocityArray) {
 				double val;
-				if (numValue.get_double().get(val) != SUCCESS) FASTGLTF_UNLIKELY {
+				if (numValue.get_double().get(val) != SUCCESS) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 				motion.angularVelocity[i] = static_cast<num>(val);
 				++i;
 			}
-		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
 		double gravityFactor;
 		if (error = motionObject["gravityFactor"].get_double().get(gravityFactor); error == SUCCESS) {
 			motion.gravityFactor = static_cast<num>(gravityFactor);
-		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
-	} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+	} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 		return Error::InvalidGltf;
 	}
 
@@ -4643,9 +4643,9 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 		auto& collider = rigidBody.collider.emplace();
 
 		dom::object geometryObject;
-		if (colliderObject["geometry"].get_object().get(geometryObject) == SUCCESS) FASTGLTF_LIKELY {
+		if (colliderObject["geometry"].get_object().get(geometryObject) == SUCCESS) [[likely]] {
 			std::uint64_t shape;
-			if (error = geometryObject["shape"].get_uint64().get(shape); error == SUCCESS) FASTGLTF_LIKELY {
+			if (error = geometryObject["shape"].get_uint64().get(shape); error == SUCCESS) [[likely]] {
 				collider.geometry.shape = static_cast<std::size_t>(shape);
 			} else if (error != NO_SUCH_FIELD) {
 				return Error::InvalidGltf;
@@ -4653,13 +4653,13 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 			std::uint64_t geometryNode;
 			if (error = geometryObject["node"].get_uint64().get(geometryNode); error == SUCCESS) {
 				collider.geometry.node = static_cast<std::size_t>(geometryNode);
-			} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+			} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 				return Error::InvalidGltf;
 			}
 			bool convexHull;
 			if (error = geometryObject["convexHull"].get_bool().get(convexHull); error == SUCCESS) {
 				collider.geometry.convexHull = convexHull;
-			} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+			} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 				return Error::InvalidGltf;
 			}
 		} else {
@@ -4669,18 +4669,18 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 		std::uint64_t physicsMaterial;
 		if (error = colliderObject["physicsMaterial"].get_uint64().get(physicsMaterial); error == SUCCESS) {
 			collider.physicsMaterial = static_cast<std::size_t>(physicsMaterial);
-		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
 		std::uint64_t collisionFilter;
 		if (error = colliderObject["collisionFilter"].get_uint64().get(collisionFilter); error == SUCCESS) {
 			collider.collisionFilter = static_cast<std::size_t>(collisionFilter);
-		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
-	} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+	} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 		return Error::InvalidGltf;
 	}
 
@@ -4691,7 +4691,7 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 			auto& geometryTrigger = rigidBody.trigger.emplace().emplace<GeometryTrigger>();
 
 			std::uint64_t shape;
-			if (error = geometryObject["shape"].get_uint64().get(shape); error == SUCCESS) FASTGLTF_LIKELY {
+			if (error = geometryObject["shape"].get_uint64().get(shape); error == SUCCESS) [[likely]] {
 				geometryTrigger.geometry.shape = static_cast<std::size_t>(shape);
 			} else if (error != NO_SUCH_FIELD) {
 				return Error::InvalidGltf;
@@ -4699,13 +4699,13 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 			std::uint64_t geometryNode;
 			if (error = geometryObject["node"].get_uint64().get(geometryNode); error == SUCCESS) {
 				geometryTrigger.geometry.node = static_cast<std::size_t>(geometryNode);
-			} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+			} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 				return Error::InvalidGltf;
 			}
 			bool convexHull;
 			if (error = geometryObject["convexHull"].get_bool().get(convexHull); error == SUCCESS) {
 				geometryTrigger.geometry.convexHull = convexHull;
-			} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+			} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 				return Error::InvalidGltf;
 			}
 
@@ -4713,11 +4713,11 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 			std::uint64_t collisionFilter;
 			if (error = triggerObject["collisionFilter"].get_uint64().get(collisionFilter); error == SUCCESS) {
 				geometryTrigger.collisionFilter = static_cast<std::size_t>(collisionFilter);
-			} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+			} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 				return Error::InvalidGltf;
 			}
 
-		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 
@@ -4729,18 +4729,18 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 			auto i = 0U;
 			for (auto num : nodes) {
 				std::uint64_t val;
-				if (num.get_uint64().get(val) != SUCCESS) FASTGLTF_UNLIKELY {
+				if (num.get_uint64().get(val) != SUCCESS) [[unlikely]] {
 					return Error::InvalidGltf;
 				}
 				nodeTrigger.nodes[i] = static_cast<std::size_t>(val);
 				++i;
 			}
 
-		} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+		} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 	    
-	} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+	} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 		return Error::InvalidGltf;
 	}
 
@@ -4748,24 +4748,24 @@ fg::Error fg::Parser::parsePhysicsRigidBody(simdjson::dom::object& khr_physics_r
 	if (auto error = khr_physics_rigid_bodies["joint"].get_object().get(jointObject); error == SUCCESS) {
 		auto& joint = rigidBody.joint.emplace();
 		std::uint64_t connectedNodeId;
-		if (jointObject["connectedNode"].get_uint64().get(connectedNodeId) == SUCCESS) FASTGLTF_LIKELY {
+		if (jointObject["connectedNode"].get_uint64().get(connectedNodeId) == SUCCESS) [[likely]] {
 			joint.connectedNode = connectedNodeId;
 		} else {
 			return Error::InvalidGltf;
 		}
 
 		std::uint64_t jointId;
-		if (jointObject["joint"].get_uint64().get(jointId) == SUCCESS) FASTGLTF_LIKELY {
+		if (jointObject["joint"].get_uint64().get(jointId) == SUCCESS) [[likely]] {
 			joint.joint = static_cast<std::size_t>(jointId);
 		} else {
 			return Error::InvalidGltf;
 		}
 
-		if (error = jointObject["enableCollision"].get_bool().get(joint.enableCollision); error != SUCCESS && error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+		if (error = jointObject["enableCollision"].get_bool().get(joint.enableCollision); error != SUCCESS && error != NO_SUCH_FIELD) [[unlikely]] {
 			return Error::InvalidGltf;
 		}
 	    
-	} else if (error != NO_SUCH_FIELD) FASTGLTF_UNLIKELY {
+	} else if (error != NO_SUCH_FIELD) [[unlikely]] {
 		return Error::InvalidGltf;
 	}
 
@@ -4847,7 +4847,7 @@ fg::Expected<fg::Asset> fg::Parser::loadGltfJson(GltfDataGetter& data, fs::path 
 									  data.totalSize(),
 									  data.totalSize() + SIMDJSON_PADDING);
 	dom::object root;
-    if (auto error = jsonParser->parse(view).get(root); error != SUCCESS) FASTGLTF_UNLIKELY {
+    if (auto error = jsonParser->parse(view).get(root); error != SUCCESS) [[unlikely]] {
 	    return Error::InvalidJson;
     }
 
@@ -4894,7 +4894,7 @@ fg::Expected<fg::Asset> fg::Parser::loadGltfBinary(GltfDataGetter& data, fs::pat
                                                jsonChunk.chunkLength + SIMDJSON_PADDING);
 
 	simdjson::dom::object root;
-    if (jsonParser->parse(jsonChunkView).get(root) != SUCCESS) FASTGLTF_UNLIKELY {
+    if (jsonParser->parse(jsonChunkView).get(root) != SUCCESS) [[unlikely]] {
 	    return Error::InvalidJson;
     }
 

--- a/src/fastgltf.ixx
+++ b/src/fastgltf.ixx
@@ -28,7 +28,7 @@ module;
 export module fastgltf;
 
 #ifndef FASTGLTF_USE_STD_MODULE
-#define FASTGLTF_USE_STD_MODULE 0
+#	define FASTGLTF_USE_STD_MODULE 0
 #endif
 
 #define FASTGLTF_EXPORT export
@@ -43,25 +43,27 @@ import std.compat;
 // The STL developers do the same exact thing.
 extern "C++" {
 #if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Winclude-angled-in-module-purview"
+#	pragma clang diagnostic push
+#	pragma clang diagnostic ignored "-Winclude-angled-in-module-purview"
 #elif defined(_MSC_VER)
-#pragma warning(push)
-#pragma warning(disable : 5244) // Including header in the purview of module 'fastgltf' appears erroneous.
+#	pragma warning(push)
+#	pragma warning(disable : 5244)  // Including header in the purview of module 'fastgltf' appears
+									 // erroneous.
 #endif
 
-//  When using the define we use import std instead of normal includes, which does not include any macros.
+//  When using the define we use import std instead of normal includes, which does not include any
+//  macros.
 #if FASTGLTF_USE_STD_MODULE
-#include <cassert>
+#	include <cassert>
 #endif
 
-#include <fastgltf/core.hpp>
 #include <fastgltf/base64.hpp>
+#include <fastgltf/core.hpp>
 #include <fastgltf/tools.hpp>
 
 #if defined(__clang__)
-#pragma clang diagnostic pop
+#	pragma clang diagnostic pop
 #elif defined(_MSC_VER)
-#pragma warning(pop)
+#	pragma warning(pop)
 #endif
 }

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -24,18 +24,23 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#if !defined(__cplusplus) || (!defined(_MSVC_LANG) && __cplusplus < 202002L) || \
+	(defined(_MSVC_LANG) && _MSVC_LANG < 202002L)
+#	error "fastgltf requires C++20"
+#endif
+
 #include <simdjson.h>
 
 #include <fastgltf/core.hpp>
 
 #if defined(__APPLE__) || defined(__linux__)
-#include <fcntl.h>
-#include <unistd.h>
-#include <sys/file.h>
-#include <sys/mman.h>
-#include <sys/stat.h>
+#	include <fcntl.h>
+#	include <sys/file.h>
+#	include <sys/mman.h>
+#	include <sys/stat.h>
+#	include <unistd.h>
 #elif defined(_WIN32)
-#include <windows.h>
+#	include <windows.h>
 #endif
 
 namespace fs = std::filesystem;
@@ -62,14 +67,15 @@ fg::GltfDataBuffer::GltfDataBuffer(const fs::path& path) noexcept {
 
 	if (buffer != nullptr) {
 		// Copy the data and fill the padding region with zeros.
-		file.read(reinterpret_cast<std::ifstream::char_type*>(buffer.get()), static_cast<std::streamsize>(dataSize));
+		file.read(reinterpret_cast<std::ifstream::char_type*>(buffer.get()),
+				  static_cast<std::streamsize>(dataSize));
 		std::memset(buffer.get() + dataSize, 0, allocatedSize - dataSize);
 	} else {
 		error = Error::FileBufferAllocationFailed;
 	}
 }
 
-fg::GltfDataBuffer::GltfDataBuffer(const std::byte *bytes, const std::size_t count) noexcept {
+fg::GltfDataBuffer::GltfDataBuffer(const std::byte* bytes, const std::size_t count) noexcept {
 	assert(bytes != nullptr && "Passing nullptr is not allowed.");
 	dataSize = count;
 	allocateAndCopy(bytes);
@@ -81,7 +87,7 @@ fg::GltfDataBuffer::GltfDataBuffer(const std::span<std::byte> span) noexcept {
 	allocateAndCopy(span.data());
 }
 
-void fg::GltfDataBuffer::allocateAndCopy(const std::byte *bytes) noexcept {
+void fg::GltfDataBuffer::allocateAndCopy(const std::byte* bytes) noexcept {
 	allocatedSize = dataSize + simdjson::SIMDJSON_PADDING;
 	buffer = std::make_unique_for_overwrite<std::byte[]>(allocatedSize);
 
@@ -93,72 +99,55 @@ void fg::GltfDataBuffer::allocateAndCopy(const std::byte *bytes) noexcept {
 	}
 }
 
-void fg::GltfDataBuffer::read(void *ptr, std::size_t count) {
+void fg::GltfDataBuffer::read(void* ptr, std::size_t count) {
 	std::memcpy(ptr, buffer.get() + idx, count);
 	idx += count;
 }
 
-std::span<std::byte> fg::GltfDataBuffer::read(std::size_t count, [[maybe_unused]] std::size_t padding) {
+std::span<std::byte> fg::GltfDataBuffer::read(std::size_t count,
+											  [[maybe_unused]] std::size_t padding) {
 	std::span sub(buffer.get() + idx, count);
 	idx += count;
 	return sub;
 }
 
-void fg::GltfDataBuffer::reset() {
-	idx = 0;
-}
+void fg::GltfDataBuffer::reset() { idx = 0; }
 
-std::size_t fg::GltfDataBuffer::bytesRead() {
-	return idx;
-}
+std::size_t fg::GltfDataBuffer::bytesRead() { return idx; }
 
-std::size_t fg::GltfDataBuffer::totalSize() {
-	return dataSize;
-}
+std::size_t fg::GltfDataBuffer::totalSize() { return dataSize; }
 
 fg::GltfFileStream::GltfFileStream(const fs::path& path) : fileStream(path, std::ios::binary) {
 	fileSize = fs::file_size(path);
 }
 
-bool fg::GltfFileStream::isOpen() const {
-	return fileStream.is_open();
-}
+bool fg::GltfFileStream::isOpen() const { return fileStream.is_open(); }
 
-void fg::GltfFileStream::read(void *ptr, std::size_t count) {
-	fileStream.read(
-			static_cast<char*>(ptr),
-			static_cast<std::streamsize>(count));
+void fg::GltfFileStream::read(void* ptr, std::size_t count) {
+	fileStream.read(static_cast<char*>(ptr), static_cast<std::streamsize>(count));
 }
 
 std::span<std::byte> fg::GltfFileStream::read(std::size_t count, std::size_t padding) {
 	static_assert(sizeof(decltype(buf)::value_type) == sizeof(std::byte));
 
 	buf.resize(count + padding);
-	fileStream.read(
-			reinterpret_cast<char*>(buf.data()),
-			static_cast<std::streamsize>(count));
+	fileStream.read(reinterpret_cast<char*>(buf.data()), static_cast<std::streamsize>(count));
 
 	return {reinterpret_cast<std::byte*>(buf.data()), buf.size()};
 }
 
-void fg::GltfFileStream::reset() {
-	fileStream.seekg(0, std::ifstream::beg);
-}
+void fg::GltfFileStream::reset() { fileStream.seekg(0, std::ifstream::beg); }
 
-std::size_t fg::GltfFileStream::bytesRead() {
-	return fileStream.tellg();
-}
+std::size_t fg::GltfFileStream::bytesRead() { return fileStream.tellg(); }
 
-std::size_t fg::GltfFileStream::totalSize() {
-	return fileSize;
-}
+std::size_t fg::GltfFileStream::totalSize() { return fileSize; }
 
 #if defined(FASTGLTF_HAS_MEMORY_MAPPED_FILE)
-#if defined(_WIN32)
+#	if defined(_WIN32)
 fg::MappedGltfFile::MappedGltfFile(const fs::path& path) noexcept {
 	// Create file with FILE_FLAG_SEQUENTIAL_SCAN flag, to match the Parser behaviour.
-	auto* file = CreateFileW(path.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr,
-							 OPEN_EXISTING, FILE_FLAG_SEQUENTIAL_SCAN, nullptr);
+	auto* file = CreateFileW(path.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING,
+							 FILE_FLAG_SEQUENTIAL_SCAN, nullptr);
 	if (file == nullptr) {
 		error = Error::InvalidPath;
 		return;
@@ -170,11 +159,11 @@ fg::MappedGltfFile::MappedGltfFile(const fs::path& path) noexcept {
 		error = Error::InvalidPath;
 		return;
 	}
-	fileSize = static_cast<std::uint64_t>(result.QuadPart);;
+	fileSize = static_cast<std::uint64_t>(result.QuadPart);
+	;
 
 	// Create the file mapping
-	auto* mapping = CreateFileMapping(fileHandle, nullptr, PAGE_READONLY,
-									  0, 0, nullptr);
+	auto* mapping = CreateFileMapping(fileHandle, nullptr, PAGE_READONLY, 0, 0, nullptr);
 	if (mapping == nullptr) {
 		error = Error::FileBufferAllocationFailed;
 		return;
@@ -182,14 +171,13 @@ fg::MappedGltfFile::MappedGltfFile(const fs::path& path) noexcept {
 	fileMapping = mapping;
 
 	// Map the view
-	auto* map = MapViewOfFile(fileMapping, FILE_MAP_READ,
-							 0, 0, fileSize);
+	auto* map = MapViewOfFile(fileMapping, FILE_MAP_READ, 0, 0, fileSize);
 	if (map == nullptr) {
 		error = Error::FileBufferAllocationFailed;
 		return;
 	}
 	mappedFile = map;
-#else
+#	else
 fg::MappedGltfFile::MappedGltfFile(const fs::path& path) noexcept : mappedFile(MAP_FAILED) {
 	// Open the file
 	int fd = open(path.c_str(), O_RDONLY, 0);
@@ -200,19 +188,14 @@ fg::MappedGltfFile::MappedGltfFile(const fs::path& path) noexcept : mappedFile(M
 	}
 
 	// Get the file size
-	struct stat statInfo {};
+	struct stat statInfo{};
 	if (fstat(fd, &statInfo) != 0) {
 		error = Error::InvalidPath;
 		return;
 	}
 
 	// Map the file
-	mappedFile = mmap(nullptr,
-					  statInfo.st_size,
-					  PROT_READ,
-					  MAP_PRIVATE,
-					  fd,
-					  0);
+	mappedFile = mmap(nullptr, statInfo.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
 	if (mappedFile != MAP_FAILED) {
 		fileSize = static_cast<std::uint64_t>(statInfo.st_size);
 
@@ -224,25 +207,25 @@ fg::MappedGltfFile::MappedGltfFile(const fs::path& path) noexcept : mappedFile(M
 
 	// The file descriptor is not used for the memory mapped and is not required anymore.
 	close(fd);
-#endif
+#	endif
 }
 
-fg::MappedGltfFile::MappedGltfFile(fastgltf::MappedGltfFile &&other) noexcept {
-#if defined(_WIN32)
+fg::MappedGltfFile::MappedGltfFile(fastgltf::MappedGltfFile&& other) noexcept {
+#	if defined(_WIN32)
 	mappedFile = std::exchange(other.mappedFile, nullptr);
 	fileMapping = std::exchange(other.fileMapping, nullptr);
 	fileHandle = std::exchange(other.fileHandle, nullptr);
-#else
+#	else
 	// Make sure that munmap is never called when other gets destructed.
 	mappedFile = std::exchange(other.mappedFile, MAP_FAILED);
-#endif
+#	endif
 	fileSize = other.fileSize;
 	idx = other.idx;
 	error = other.error;
 }
 
-fg::MappedGltfFile& fg::MappedGltfFile::operator=(fastgltf::MappedGltfFile &&other) noexcept {
-#if defined(_WIN32)
+fg::MappedGltfFile& fg::MappedGltfFile::operator=(fastgltf::MappedGltfFile&& other) noexcept {
+#	if defined(_WIN32)
 	if (mappedFile != nullptr) {
 		UnmapViewOfFile(mappedFile);
 	}
@@ -257,12 +240,12 @@ fg::MappedGltfFile& fg::MappedGltfFile::operator=(fastgltf::MappedGltfFile &&oth
 		CloseHandle(fileHandle);
 	}
 	fileHandle = std::exchange(other.fileHandle, nullptr);
-#else
+#	else
 	if (mappedFile != MAP_FAILED) {
 		munmap(mappedFile, fileSize);
 	}
 	mappedFile = std::exchange(other.mappedFile, MAP_FAILED);
-#endif
+#	endif
 	fileSize = other.fileSize;
 	idx = other.idx;
 	error = other.error;
@@ -270,7 +253,7 @@ fg::MappedGltfFile& fg::MappedGltfFile::operator=(fastgltf::MappedGltfFile &&oth
 }
 
 fg::MappedGltfFile::~MappedGltfFile() noexcept {
-#if defined(_WIN32)
+#	if defined(_WIN32)
 	if (mappedFile != nullptr) {
 		UnmapViewOfFile(mappedFile);
 	}
@@ -280,54 +263,50 @@ fg::MappedGltfFile::~MappedGltfFile() noexcept {
 	if (fileHandle != nullptr) {
 		CloseHandle(fileHandle);
 	}
-#else
+#	else
 	if (mappedFile != MAP_FAILED) {
 		munmap(mappedFile, fileSize);
 	}
-#endif
+#	endif
 }
 
-void fg::MappedGltfFile::read(void *ptr, std::size_t count) {
+void fg::MappedGltfFile::read(void* ptr, std::size_t count) {
 	std::memcpy(ptr, static_cast<std::byte*>(mappedFile) + idx, count);
 	idx += count;
 }
 
-std::span<std::byte> fg::MappedGltfFile::read(const std::size_t count, [[maybe_unused]] std::size_t padding) {
+std::span<std::byte> fg::MappedGltfFile::read(const std::size_t count,
+											  [[maybe_unused]] std::size_t padding) {
 	const std::span sub(static_cast<std::byte*>(mappedFile) + idx, count);
 	idx += count;
 	return sub;
 }
 
-void fg::MappedGltfFile::reset() {
-	idx = 0;
-}
+void fg::MappedGltfFile::reset() { idx = 0; }
 
-std::size_t fg::MappedGltfFile::bytesRead() {
-	return idx;
-}
+std::size_t fg::MappedGltfFile::bytesRead() { return idx; }
 
-std::size_t fg::MappedGltfFile::totalSize() {
-	return fileSize;
-}
-#endif // FASTGLTF_HAS_MEMORY_MAPPED_FILE
+std::size_t fg::MappedGltfFile::totalSize() { return fileSize; }
+#endif  // FASTGLTF_HAS_MEMORY_MAPPED_FILE
 
 #pragma region AndroidGltfDataBuffer
 #if defined(__ANDROID__)
-#include <android/asset_manager.h>
+#	include <android/asset_manager.h>
 
 namespace fastgltf {
-	/**
-	 * Global asset manager that can be accessed freely.
-	 * The value of this global should only be set by fastgltf::setAndroidAssetManager.
-	 */
-	static AAssetManager* androidAssetManager = nullptr;
-}
+/**
+ * Global asset manager that can be accessed freely.
+ * The value of this global should only be set by fastgltf::setAndroidAssetManager.
+ */
+static AAssetManager* androidAssetManager = nullptr;
+}  // namespace fastgltf
 
 void fg::setAndroidAssetManager(AAssetManager* assetManager) noexcept {
 	androidAssetManager = assetManager;
 }
 
-fg::AndroidGltfDataBuffer::AndroidGltfDataBuffer(const fs::path& path, std::uint64_t byteOffset) noexcept {
+fg::AndroidGltfDataBuffer::AndroidGltfDataBuffer(const fs::path& path,
+												 std::uint64_t byteOffset) noexcept {
 	if (androidAssetManager == nullptr) {
 		error = Error::InvalidPath;
 		return;
@@ -354,8 +333,7 @@ fg::AndroidGltfDataBuffer::AndroidGltfDataBuffer(const fs::path& path, std::uint
 	if (buffer == nullptr) {
 		error = Error::FileBufferAllocationFailed;
 	} else {
-		if (byteOffset > 0)
-			AAsset_seek64(file.get(), byteOffset, SEEK_SET);
+		if (byteOffset > 0) AAsset_seek64(file.get(), byteOffset, SEEK_SET);
 
 		// Copy the data and fill the padding region with zeros.
 		AAsset_read(file.get(), buffer.get(), dataSize);
@@ -383,55 +361,57 @@ fg::Expected<fg::DataSource> fg::Parser::loadFileFromApk(const fs::path& path) c
 	if (config.mapCallback != nullptr) {
 		auto info = config.mapCallback(static_cast<std::uint64_t>(length), config.userPointer);
 		if (info.mappedMemory != nullptr) {
-			const sources::CustomBuffer customBufferSource = { info.customId, MimeType::None };
+			const sources::CustomBuffer customBufferSource = {info.customId, MimeType::None};
 			AAsset_read(file.get(), info.mappedMemory, length);
 			if (config.unmapCallback != nullptr) {
 				config.unmapCallback(&info, config.userPointer);
 			}
 
-			return { customBufferSource };
+			return {customBufferSource};
 		}
 	}
 
 	StaticVector<std::byte> data(static_cast<std::size_t>(length));
 	AAsset_read(file.get(), data.data(), length);
-	sources::Array arraySource {
+	sources::Array arraySource{
 		std::move(data),
 	};
-	return { std::move(arraySource) };
+	return {std::move(arraySource)};
 }
 #endif
 
 fg::Expected<fg::DataSource> fg::Parser::loadFileFromUri(URIView& uri) const noexcept {
-	URI decodedUri(uri.path()); // Re-allocate so we can decode potential characters.
+	URI decodedUri(uri.path());  // Re-allocate so we can decode potential characters.
 	// JSON strings are always in UTF-8, so we can safely always use u8path here.
 	// Since u8path is deprecated with C++20 and newer, u8path is deprecated.
 	// As there is no other proper solution that doesn't do something illegal,
 	// we'll just disable related warnings here.
 #if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#	pragma GCC diagnostic push
+#	pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #elif defined(_MSC_VER)
-#pragma warning(push)
-#pragma warning(disable : 4996)
+#	pragma warning(push)
+#	pragma warning(disable : 4996)
 #endif
 	auto path = directory / fs::u8path(decodedUri.path());
 #if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic pop
+#	pragma GCC diagnostic pop
 #elif defined(_MSC_VER)
-#pragma warning(pop)
+#	pragma warning(pop)
 #endif
 
 #if defined(__ANDROID__)
 	if (androidAssetManager != nullptr) {
-		// Try to load external buffers from the APK. If they're not there, fall through to the file case
+		// Try to load external buffers from the APK. If they're not there, fall through to the file
+		// case
 		if (auto androidResult = loadFileFromApk(path); androidResult.error() == Error::None) {
 			return std::move(androidResult.get());
 		}
 	}
 #endif
 
-	// If we were instructed to load external buffers and the files don't exist, we'll return an error.
+	// If we were instructed to load external buffers and the files don't exist, we'll return an
+	// error.
 	std::error_code error;
 	if (!fs::exists(path, error) || error) {
 		return Error::MissingExternalBuffer;
@@ -447,21 +427,21 @@ fg::Expected<fg::DataSource> fg::Parser::loadFileFromUri(URIView& uri) const noe
 	if (config.mapCallback != nullptr) {
 		auto info = config.mapCallback(static_cast<std::uint64_t>(length), config.userPointer);
 		if (info.mappedMemory != nullptr) {
-			const sources::CustomBuffer customBufferSource = { info.customId };
+			const sources::CustomBuffer customBufferSource = {info.customId};
 			file.read(static_cast<char*>(info.mappedMemory), length);
 			if (config.unmapCallback != nullptr) {
 				config.unmapCallback(&info, config.userPointer);
 			}
 
-			return { customBufferSource };
+			return {customBufferSource};
 		}
 	}
 
 	StaticVector<std::byte> data(static_cast<std::size_t>(length));
 	file.read(reinterpret_cast<char*>(data.data()), length);
-	sources::Array arraySource {
+	sources::Array arraySource{
 		std::move(data),
 	};
-	return { std::move(arraySource) };
+	return {std::move(arraySource)};
 }
 #pragma endregion

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -99,7 +99,7 @@ void fg::GltfDataBuffer::read(void *ptr, std::size_t count) {
 }
 
 std::span<std::byte> fg::GltfDataBuffer::read(std::size_t count, [[maybe_unused]] std::size_t padding) {
-	std::span<std::byte> sub(buffer.get() + idx, count);
+	std::span sub(buffer.get() + idx, count);
 	idx += count;
 	return sub;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,7 +4,7 @@ message(STATUS "fastgltf: Bulding tests")
 
 # We want these tests to be a optional executable.
 add_executable(fastgltf_tests EXCLUDE_FROM_ALL "main.cpp"
-    "base64_tests.cpp" "basic_test.cpp" "benchmarks.cpp" "glb_tests.cpp" "gltf_path.hpp" "util_tests.cpp"
+    "base64_tests.cpp" "basic_test.cpp" "benchmarks.cpp" "glb_tests.cpp" "gltf_path.hpp" "util_tests.cpp" "optional_tests.cpp"
     "vector_tests.cpp" "uri_tests.cpp" "extension_tests.cpp" "accessor_tests.cpp" "write_tests.cpp" "math_tests.cpp")
 target_compile_features(fastgltf_tests PRIVATE ${FASTGLTF_COMPILE_TARGET})
 target_link_libraries(fastgltf_tests PRIVATE fastgltf::fastgltf)

--- a/tests/accessor_tests.cpp
+++ b/tests/accessor_tests.cpp
@@ -1,170 +1,177 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
-
 #include <fastgltf/core.hpp>
 #include <fastgltf/tools.hpp>
+
 #include "gltf_path.hpp"
 
 static auto getBufferData(const fastgltf::Buffer& buffer) {
-	return std::visit(fastgltf::visitor {
-		[](auto&) -> const std::byte* {
-			assert(false);
-			return nullptr;
-		},
-		[&](const fastgltf::sources::Array& vec) {
-			return reinterpret_cast<const std::byte*>(vec.bytes.data());
-		},
-		[&](const fastgltf::sources::ByteView& bv) {
-			return bv.bytes.data();
-		},
-	}, buffer.data);
+	return std::visit(fastgltf::visitor{
+						  [](auto&) -> const std::byte* {
+		assert(false);
+		return nullptr;
+	},
+						  [&](const fastgltf::sources::Array& vec) {
+		return reinterpret_cast<const std::byte*>(vec.bytes.data());
+	},
+						  [&](const fastgltf::sources::ByteView& bv) { return bv.bytes.data(); },
+					  },
+					  buffer.data);
 }
 
 TEST_CASE("Test data type conversion", "[gltf-tools]") {
 	// normalized int-to-float and normalized float-to-int
-	for (auto i = std::numeric_limits<std::int8_t>::min(); i < std::numeric_limits<std::int8_t>::max(); ++i) {
+	for (auto i = std::numeric_limits<std::int8_t>::min();
+		 i < std::numeric_limits<std::int8_t>::max(); ++i) {
 		auto converted = fastgltf::internal::convertComponent<float>(i, true);
 		REQUIRE(converted == Catch::Approx(fastgltf::max<float>(i / 127.0f, -1)));
-		REQUIRE(fastgltf::internal::convertComponent<std::int8_t>(converted, true) == std::round(converted * 127.0f));
+		REQUIRE(fastgltf::internal::convertComponent<std::int8_t>(converted, true) ==
+				std::round(converted * 127.0f));
 	}
-	for (auto i = std::numeric_limits<std::uint8_t>::min(); i < std::numeric_limits<std::uint8_t>::max(); ++i) {
+	for (auto i = std::numeric_limits<std::uint8_t>::min();
+		 i < std::numeric_limits<std::uint8_t>::max(); ++i) {
 		auto converted = fastgltf::internal::convertComponent<float>(i, true);
 		REQUIRE(converted == Catch::Approx(i / 255.0f));
-		REQUIRE(fastgltf::internal::convertComponent<std::uint8_t>(converted, true) == std::round(converted * 255.0f));
+		REQUIRE(fastgltf::internal::convertComponent<std::uint8_t>(converted, true) ==
+				std::round(converted * 255.0f));
 	}
-	for (auto i = std::numeric_limits<std::int16_t>::min(); i < std::numeric_limits<std::int16_t>::max(); ++i) {
+	for (auto i = std::numeric_limits<std::int16_t>::min();
+		 i < std::numeric_limits<std::int16_t>::max(); ++i) {
 		auto converted = fastgltf::internal::convertComponent<float>(i, true);
 		REQUIRE(converted == Catch::Approx(fastgltf::max<float>(i / 32767.0f, -1)));
-		REQUIRE(fastgltf::internal::convertComponent<std::int16_t>(converted, true) == std::round(converted * 32767.0f));
+		REQUIRE(fastgltf::internal::convertComponent<std::int16_t>(converted, true) ==
+				std::round(converted * 32767.0f));
 	}
-	for (auto i = std::numeric_limits<std::uint16_t>::min(); i < std::numeric_limits<std::uint16_t>::max(); ++i) {
+	for (auto i = std::numeric_limits<std::uint16_t>::min();
+		 i < std::numeric_limits<std::uint16_t>::max(); ++i) {
 		auto converted = fastgltf::internal::convertComponent<float>(i, true);
 		REQUIRE(converted == Catch::Approx(i / 65535.0f));
-		REQUIRE(fastgltf::internal::convertComponent<std::uint16_t>(converted, true) == std::round(converted * 65535.0f));
+		REQUIRE(fastgltf::internal::convertComponent<std::uint16_t>(converted, true) ==
+				std::round(converted * 65535.0f));
 	}
 }
 
 TEST_CASE("Test little-endian correctness", "[gltf-tools]") {
-    // The test here is merely to verify that the internal deserialization functions correctly treat
-    // the input bytes as little-endian, regardless of system endianness.
-    // This test is effectively useless on little endian systems, but it should still make sense to keep it.
-    std::array<std::byte, 4> integer {{ std::byte(0x0A), std::byte(0x0B), std::byte(0x0C), std::byte(0x0D) }};
-    auto deserialized = fastgltf::internal::deserializeComponent<std::uint32_t>(integer.data(), 0);
-    REQUIRE(deserialized == 0x0D0C0B0A);
+	// The test here is merely to verify that the internal deserialization functions correctly treat
+	// the input bytes as little-endian, regardless of system endianness.
+	// This test is effectively useless on little endian systems, but it should still make sense to
+	// keep it.
+	std::array<std::byte, 4> integer{
+		{std::byte(0x0A), std::byte(0x0B), std::byte(0x0C), std::byte(0x0D)}};
+	auto deserialized = fastgltf::internal::deserializeComponent<std::uint32_t>(integer.data(), 0);
+	REQUIRE(deserialized == 0x0D0C0B0A);
 }
 
 TEST_CASE("Test matrix data padding", "[gltf-tools]") {
-    // First a case that doesn't require any padding
-    std::array<std::uint16_t, 4> unpaddedMat2 {{
-       1, 2,
-       3, 4
-    }};
-    REQUIRE(fastgltf::getElementByteSize(fastgltf::AccessorType::Mat2, fastgltf::ComponentType::UnsignedShort) == unpaddedMat2.size() * sizeof(std::uint16_t));
-    auto umat2 = fastgltf::internal::getAccessorElementAt<fastgltf::math::fmat2x2>(
-            fastgltf::ComponentType::UnsignedShort,
-            reinterpret_cast<const std::byte*>(unpaddedMat2.data()));
-    REQUIRE(umat2[0] == fastgltf::math::fvec2(1, 2));
-    REQUIRE(umat2[1] == fastgltf::math::fvec2(3, 4));
+	// First a case that doesn't require any padding
+	std::array<std::uint16_t, 4> unpaddedMat2{{1, 2, 3, 4}};
+	REQUIRE(fastgltf::getElementByteSize(fastgltf::AccessorType::Mat2,
+										 fastgltf::ComponentType::UnsignedShort) ==
+			unpaddedMat2.size() * sizeof(std::uint16_t));
+	auto umat2 = fastgltf::internal::getAccessorElementAt<fastgltf::math::fmat2x2>(
+		fastgltf::ComponentType::UnsignedShort,
+		reinterpret_cast<const std::byte*>(unpaddedMat2.data()));
+	REQUIRE(umat2[0] == fastgltf::math::fvec2(1, 2));
+	REQUIRE(umat2[1] == fastgltf::math::fvec2(3, 4));
 
 	for (std::size_t i = 0; i < fastgltf::getNumComponents(fastgltf::AccessorType::Mat2); ++i) {
 		auto val = fastgltf::internal::getAccessorComponentAt<std::uint16_t>(
-			fastgltf::ComponentType::UnsignedShort, fastgltf::AccessorType::Mat2, reinterpret_cast<const std::byte*>(unpaddedMat2.data()), i, false);
+			fastgltf::ComponentType::UnsignedShort, fastgltf::AccessorType::Mat2,
+			reinterpret_cast<const std::byte*>(unpaddedMat2.data()), i, false);
 		REQUIRE(std::uint16_t(i + 1) == val);
 	}
 
-    // This will simulate a padded 2x2 matrix with the correct 4-byte padding per column
-    std::array<std::uint8_t, 8> paddedMat2 {{
-        1, 2, 0, 0,
-        3, 4, 0, 0
-    }};
-    REQUIRE(fastgltf::getElementByteSize(fastgltf::AccessorType::Mat2, fastgltf::ComponentType::UnsignedByte) == paddedMat2.size());
-    auto mat2 = fastgltf::internal::getAccessorElementAt<fastgltf::math::fmat2x2>(
-            fastgltf::ComponentType::UnsignedByte,
-            reinterpret_cast<const std::byte*>(paddedMat2.data()));
-    REQUIRE(mat2[0] == fastgltf::math::fvec2(1, 2));
-    REQUIRE(mat2[1] == fastgltf::math::fvec2(3, 4));
+	// This will simulate a padded 2x2 matrix with the correct 4-byte padding per column
+	std::array<std::uint8_t, 8> paddedMat2{{1, 2, 0, 0, 3, 4, 0, 0}};
+	REQUIRE(fastgltf::getElementByteSize(fastgltf::AccessorType::Mat2,
+										 fastgltf::ComponentType::UnsignedByte) ==
+			paddedMat2.size());
+	auto mat2 = fastgltf::internal::getAccessorElementAt<fastgltf::math::fmat2x2>(
+		fastgltf::ComponentType::UnsignedByte,
+		reinterpret_cast<const std::byte*>(paddedMat2.data()));
+	REQUIRE(mat2[0] == fastgltf::math::fvec2(1, 2));
+	REQUIRE(mat2[1] == fastgltf::math::fvec2(3, 4));
 
 	for (std::size_t i = 0; i < fastgltf::getNumComponents(fastgltf::AccessorType::Mat2); ++i) {
 		auto val = fastgltf::internal::getAccessorComponentAt<std::uint8_t>(
-			fastgltf::ComponentType::UnsignedByte, fastgltf::AccessorType::Mat2, reinterpret_cast<const std::byte*>(paddedMat2.data()), i, false);
+			fastgltf::ComponentType::UnsignedByte, fastgltf::AccessorType::Mat2,
+			reinterpret_cast<const std::byte*>(paddedMat2.data()), i, false);
 		REQUIRE(std::uint8_t(i + 1) == val);
 	}
 
-    std::array<std::uint8_t, 12> paddedMat3 {{
-        1, 2, 3, 0,
-        4, 5, 6, 0,
-        7, 8, 9, 0
-    }};
-    REQUIRE(fastgltf::getElementByteSize(fastgltf::AccessorType::Mat3, fastgltf::ComponentType::UnsignedByte) == paddedMat3.size());
-    auto mat3 = fastgltf::internal::getAccessorElementAt<fastgltf::math::fmat3x3>(
-            fastgltf::ComponentType::UnsignedByte,
-            reinterpret_cast<const std::byte*>(paddedMat3.data()));
-    REQUIRE(mat3[0] == fastgltf::math::fvec3(1, 2, 3));
-    REQUIRE(mat3[1] == fastgltf::math::fvec3(4, 5, 6));
-    REQUIRE(mat3[2] == fastgltf::math::fvec3(7, 8, 9));
+	std::array<std::uint8_t, 12> paddedMat3{{1, 2, 3, 0, 4, 5, 6, 0, 7, 8, 9, 0}};
+	REQUIRE(fastgltf::getElementByteSize(fastgltf::AccessorType::Mat3,
+										 fastgltf::ComponentType::UnsignedByte) ==
+			paddedMat3.size());
+	auto mat3 = fastgltf::internal::getAccessorElementAt<fastgltf::math::fmat3x3>(
+		fastgltf::ComponentType::UnsignedByte,
+		reinterpret_cast<const std::byte*>(paddedMat3.data()));
+	REQUIRE(mat3[0] == fastgltf::math::fvec3(1, 2, 3));
+	REQUIRE(mat3[1] == fastgltf::math::fvec3(4, 5, 6));
+	REQUIRE(mat3[2] == fastgltf::math::fvec3(7, 8, 9));
 
 	for (std::size_t i = 0; i < fastgltf::getNumComponents(fastgltf::AccessorType::Mat3); ++i) {
 		auto val = fastgltf::internal::getAccessorComponentAt<std::uint8_t>(
-			fastgltf::ComponentType::UnsignedByte, fastgltf::AccessorType::Mat3, reinterpret_cast<const std::byte*>(paddedMat3.data()), i, false);
+			fastgltf::ComponentType::UnsignedByte, fastgltf::AccessorType::Mat3,
+			reinterpret_cast<const std::byte*>(paddedMat3.data()), i, false);
 		REQUIRE(std::uint8_t(i + 1) == val);
 	}
 
-    // This now uses 16-bit shorts for the component types.
-    std::array<std::uint16_t, 12> padded2BMat3 {{
-        1, 2, 3, 0,
-        4, 5, 6, 0,
-        7, 8, 9, 0
-    }};
-    REQUIRE(fastgltf::getElementByteSize(fastgltf::AccessorType::Mat3, fastgltf::ComponentType::UnsignedShort) == paddedMat3.size() * sizeof(std::uint16_t));
-    auto mat3_2 = fastgltf::internal::getAccessorElementAt<fastgltf::math::fmat3x3>(
-            fastgltf::ComponentType::UnsignedShort,
-            reinterpret_cast<const std::byte*>(padded2BMat3.data()));
-    REQUIRE(mat3_2[0] == fastgltf::math::fvec3(1, 2, 3));
-    REQUIRE(mat3_2[1] == fastgltf::math::fvec3(4, 5, 6));
-    REQUIRE(mat3_2[2] == fastgltf::math::fvec3(7, 8, 9));
+	// This now uses 16-bit shorts for the component types.
+	std::array<std::uint16_t, 12> padded2BMat3{{1, 2, 3, 0, 4, 5, 6, 0, 7, 8, 9, 0}};
+	REQUIRE(fastgltf::getElementByteSize(fastgltf::AccessorType::Mat3,
+										 fastgltf::ComponentType::UnsignedShort) ==
+			paddedMat3.size() * sizeof(std::uint16_t));
+	auto mat3_2 = fastgltf::internal::getAccessorElementAt<fastgltf::math::fmat3x3>(
+		fastgltf::ComponentType::UnsignedShort,
+		reinterpret_cast<const std::byte*>(padded2BMat3.data()));
+	REQUIRE(mat3_2[0] == fastgltf::math::fvec3(1, 2, 3));
+	REQUIRE(mat3_2[1] == fastgltf::math::fvec3(4, 5, 6));
+	REQUIRE(mat3_2[2] == fastgltf::math::fvec3(7, 8, 9));
 
 	for (std::size_t i = 0; i < fastgltf::getNumComponents(fastgltf::AccessorType::Mat3); ++i) {
 		auto val = fastgltf::internal::getAccessorComponentAt<std::uint16_t>(
-			fastgltf::ComponentType::UnsignedShort, fastgltf::AccessorType::Mat3, reinterpret_cast<const std::byte*>(padded2BMat3.data()), i, false);
+			fastgltf::ComponentType::UnsignedShort, fastgltf::AccessorType::Mat3,
+			reinterpret_cast<const std::byte*>(padded2BMat3.data()), i, false);
 		REQUIRE(std::uint16_t(i + 1) == val);
 	}
 }
 
 TEST_CASE("Test matrix transpose", "[gltf-tools]") {
 	// First a case that doesn't require any padding
-	std::array<float, 4> mat2 {{
-		1, 2,
-		3, 4
-	}};
-	REQUIRE(fastgltf::getElementByteSize(fastgltf::AccessorType::Mat2, fastgltf::ComponentType::Float) == mat2.size() * sizeof(float));
+	std::array<float, 4> mat2{{1, 2, 3, 4}};
+	REQUIRE(fastgltf::getElementByteSize(fastgltf::AccessorType::Mat2,
+										 fastgltf::ComponentType::Float) ==
+			mat2.size() * sizeof(float));
 
-	static constexpr std::array<float, 4> transposed {{
-		1, 3, 2, 4
-	}};
+	static constexpr std::array<float, 4> transposed{{1, 3, 2, 4}};
 	for (std::size_t i = 0; i < 4; ++i) {
 		REQUIRE(float(i + 1) == fastgltf::internal::getAccessorComponentAt<float>(
-				fastgltf::ComponentType::Float, fastgltf::AccessorType::Mat2, reinterpret_cast<std::byte*>(mat2.data()), i, false, false));
+									fastgltf::ComponentType::Float, fastgltf::AccessorType::Mat2,
+									reinterpret_cast<std::byte*>(mat2.data()), i, false, false));
 		REQUIRE(transposed[i] == fastgltf::internal::getAccessorComponentAt<float>(
-				fastgltf::ComponentType::Float, fastgltf::AccessorType::Mat2, reinterpret_cast<std::byte*>(mat2.data()), i, false, true));
+									 fastgltf::ComponentType::Float, fastgltf::AccessorType::Mat2,
+									 reinterpret_cast<std::byte*>(mat2.data()), i, false, true));
 	}
 }
 
 TEST_CASE("Test accessor", "[gltf-tools]") {
-    auto lightsLamp = sampleAssets / "Models" / "LightsPunctualLamp" / "glTF";
+	auto lightsLamp = sampleAssets / "Models" / "LightsPunctualLamp" / "glTF";
 
 	fastgltf::GltfFileStream jsonData(lightsLamp / "LightsPunctualLamp.gltf");
 	REQUIRE(jsonData.isOpen());
 
-    fastgltf::Parser parser(fastgltf::Extensions::KHR_lights_punctual);
-    auto asset = parser.loadGltfJson(jsonData, lightsLamp, fastgltf::Options::LoadExternalBuffers,
-								 fastgltf::Category::Buffers | fastgltf::Category::BufferViews | fastgltf::Category::Accessors);
-    REQUIRE(asset.error() == fastgltf::Error::None);
+	fastgltf::Parser parser(fastgltf::Extensions::KHR_lights_punctual);
+	auto asset = parser.loadGltfJson(jsonData, lightsLamp, fastgltf::Options::LoadExternalBuffers,
+									 fastgltf::Category::Buffers | fastgltf::Category::BufferViews |
+										 fastgltf::Category::Accessors);
+	REQUIRE(asset.error() == fastgltf::Error::None);
 
-    REQUIRE(asset->accessors.size() == 15);
-    auto& accessors = asset->accessors;
+	REQUIRE(asset->accessors.size() == 15);
+	auto& accessors = asset->accessors;
 
-    SECTION("getAccessorElement<std::uint16_t>") {
-        auto& firstAccessor = accessors[0];
+	SECTION("getAccessorElement<std::uint16_t>") {
+		auto& firstAccessor = accessors[0];
 		REQUIRE(firstAccessor.type == fastgltf::AccessorType::Scalar);
 		REQUIRE(firstAccessor.componentType == fastgltf::ComponentType::UnsignedShort);
 
@@ -174,14 +181,15 @@ TEST_CASE("Test accessor", "[gltf-tools]") {
 		auto* bufferData = getBufferData(asset->buffers[view.bufferIndex]);
 		REQUIRE(bufferData != nullptr);
 
-		auto* checkData = reinterpret_cast<const std::uint16_t*>(bufferData + view.byteOffset
-				+ firstAccessor.byteOffset);
+		auto* checkData = reinterpret_cast<const std::uint16_t*>(bufferData + view.byteOffset +
+																 firstAccessor.byteOffset);
 
-		REQUIRE(*checkData == fastgltf::getAccessorElement<std::uint16_t>(asset.get(), firstAccessor, 0));
-    }
+		REQUIRE(*checkData ==
+				fastgltf::getAccessorElement<std::uint16_t>(asset.get(), firstAccessor, 0));
+	}
 
 	{
-        auto& secondAccessor = accessors[1];
+		auto& secondAccessor = accessors[1];
 		REQUIRE(secondAccessor.type == fastgltf::AccessorType::Vec3);
 		REQUIRE(secondAccessor.componentType == fastgltf::ComponentType::Float);
 
@@ -191,47 +199,54 @@ TEST_CASE("Test accessor", "[gltf-tools]") {
 		auto* bufferData = getBufferData(asset->buffers[view.bufferIndex]);
 		REQUIRE(bufferData != nullptr);
 
-		auto* checkData = reinterpret_cast<const fastgltf::math::fvec3*>(bufferData + view.byteOffset
-				+ secondAccessor.byteOffset);
+		auto* checkData = reinterpret_cast<const fastgltf::math::fvec3*>(
+			bufferData + view.byteOffset + secondAccessor.byteOffset);
 
 		SECTION("getAccessorElement<fastgltf::math::fvec3>") {
-			REQUIRE(*checkData == fastgltf::getAccessorElement<fastgltf::math::fvec3>(asset.get(), secondAccessor, 0));
+			REQUIRE(*checkData == fastgltf::getAccessorElement<fastgltf::math::fvec3>(
+									  asset.get(), secondAccessor, 0));
 		}
 
 		SECTION("iterateAccessor") {
 			auto dstCopy = std::make_unique<fastgltf::math::fvec3[]>(secondAccessor.count);
 			std::size_t i = 0;
 
-			fastgltf::iterateAccessor<fastgltf::math::fvec3>(asset.get(), secondAccessor, [&](auto&& v3) {
-				dstCopy[i++] = std::forward<fastgltf::math::fvec3>(v3);
-			});
+			fastgltf::iterateAccessor<fastgltf::math::fvec3>(
+				asset.get(), secondAccessor,
+				[&](auto&& v3) { dstCopy[i++] = std::forward<fastgltf::math::fvec3>(v3); });
 
-			REQUIRE(std::memcmp(dstCopy.get(), checkData, secondAccessor.count * sizeof(fastgltf::math::fvec3)) == 0);
+			REQUIRE(std::memcmp(dstCopy.get(), checkData,
+								secondAccessor.count * sizeof(fastgltf::math::fvec3)) == 0);
 		}
 
 		SECTION("copyFromAccessor") {
 			auto dstCopy = std::make_unique<fastgltf::math::fvec3[]>(secondAccessor.count);
-			fastgltf::copyFromAccessor<fastgltf::math::fvec3>(asset.get(), secondAccessor, dstCopy.get());
-			REQUIRE(std::memcmp(dstCopy.get(), checkData, secondAccessor.count * sizeof(fastgltf::math::fvec3)) == 0);
+			fastgltf::copyFromAccessor<fastgltf::math::fvec3>(asset.get(), secondAccessor,
+															  dstCopy.get());
+			REQUIRE(std::memcmp(dstCopy.get(), checkData,
+								secondAccessor.count * sizeof(fastgltf::math::fvec3)) == 0);
 		}
 
 		SECTION("Iterator test") {
 			auto dstCopy = std::make_unique<fastgltf::math::fvec3[]>(secondAccessor.count);
-			auto accessor = fastgltf::iterateAccessor<fastgltf::math::fvec3>(asset.get(), secondAccessor);
+			auto accessor =
+				fastgltf::iterateAccessor<fastgltf::math::fvec3>(asset.get(), secondAccessor);
 			for (auto it = accessor.begin(); it != accessor.end(); ++it) {
 				dstCopy[std::distance(accessor.begin(), it)] = *it;
 			}
-			REQUIRE(std::memcmp(dstCopy.get(), checkData, secondAccessor.count * sizeof(fastgltf::math::fvec3)) == 0);
+			REQUIRE(std::memcmp(dstCopy.get(), checkData,
+								secondAccessor.count * sizeof(fastgltf::math::fvec3)) == 0);
 		}
 
 		SECTION("copyComponentsFromAccessor<float>") {
 			auto componentCount = fastgltf::getNumComponents(secondAccessor.type);
 			auto dstCopy = std::make_unique<float[]>(secondAccessor.count * componentCount);
 			fastgltf::copyComponentsFromAccessor<float>(asset.get(), secondAccessor, dstCopy.get());
-			fastgltf::iterateAccessorWithIndex<fastgltf::math::fvec3>(asset.get(), secondAccessor, [&](auto&& p1, std::size_t idx) {
+			fastgltf::iterateAccessorWithIndex<fastgltf::math::fvec3>(
+				asset.get(), secondAccessor, [&](auto&& p1, std::size_t idx) {
 				auto p2 = fastgltf::math::fvec3(dstCopy.get()[idx * componentCount + 0],
-				                                dstCopy.get()[idx * componentCount + 1],
-				                                dstCopy.get()[idx * componentCount + 2]);
+												dstCopy.get()[idx * componentCount + 1],
+												dstCopy.get()[idx * componentCount + 2]);
 				REQUIRE(p1 == p2);
 			});
 		}
@@ -239,41 +254,46 @@ TEST_CASE("Test accessor", "[gltf-tools]") {
 }
 
 TEST_CASE("Test sparse accessor", "[gltf-tools]") {
-    auto simpleSparseAccessor = sampleAssets / "Models" / "SimpleSparseAccessor" / "glTF";
+	auto simpleSparseAccessor = sampleAssets / "Models" / "SimpleSparseAccessor" / "glTF";
 
 	fastgltf::GltfFileStream jsonData(simpleSparseAccessor / "SimpleSparseAccessor.gltf");
 	REQUIRE(jsonData.isOpen());
 
-    fastgltf::Parser parser;
-    auto asset = parser.loadGltfJson(jsonData, simpleSparseAccessor, fastgltf::Options::LoadExternalBuffers,
-								 fastgltf::Category::Buffers | fastgltf::Category::BufferViews | fastgltf::Category::Accessors);
-    REQUIRE(asset.error() == fastgltf::Error::None);
+	fastgltf::Parser parser;
+	auto asset =
+		parser.loadGltfJson(jsonData, simpleSparseAccessor, fastgltf::Options::LoadExternalBuffers,
+							fastgltf::Category::Buffers | fastgltf::Category::BufferViews |
+								fastgltf::Category::Accessors);
+	REQUIRE(asset.error() == fastgltf::Error::None);
 
-    REQUIRE(asset->accessors.size() == 2);
-    REQUIRE(!asset->accessors[0].sparse.has_value());
-    REQUIRE(asset->accessors[1].sparse.has_value());
-    auto& sparse = asset->accessors[1].sparse.value();
-    REQUIRE(sparse.count == 3);
-    REQUIRE(sparse.indicesBufferView == 2);
-    REQUIRE(sparse.indicesByteOffset == 0);
-    REQUIRE(sparse.valuesBufferView == 3);
-    REQUIRE(sparse.valuesByteOffset == 0);
-    REQUIRE(sparse.indexComponentType == fastgltf::ComponentType::UnsignedShort);
+	REQUIRE(asset->accessors.size() == 2);
+	REQUIRE(!asset->accessors[0].sparse.has_value());
+	REQUIRE(asset->accessors[1].sparse.has_value());
+	auto& sparse = asset->accessors[1].sparse.value();
+	REQUIRE(sparse.count == 3);
+	REQUIRE(sparse.indicesBufferView == 2);
+	REQUIRE(sparse.indicesByteOffset == 0);
+	REQUIRE(sparse.valuesBufferView == 3);
+	REQUIRE(sparse.valuesByteOffset == 0);
+	REQUIRE(sparse.indexComponentType == fastgltf::ComponentType::UnsignedShort);
 
 	auto& secondAccessor = asset->accessors[1];
 	auto& viewIndices = asset->bufferViews[secondAccessor.sparse->indicesBufferView];
 	auto& viewValues = asset->bufferViews[secondAccessor.sparse->valuesBufferView];
 
 	auto& viewData = asset->bufferViews[*secondAccessor.bufferViewIndex];
-	auto* bufferData = getBufferData(asset->buffers[viewData.bufferIndex]) + viewData.byteOffset
-			+ secondAccessor.byteOffset;
+	auto* bufferData = getBufferData(asset->buffers[viewData.bufferIndex]) + viewData.byteOffset +
+					   secondAccessor.byteOffset;
 	auto dataStride = viewData.byteStride ? *viewData.byteStride
-			: fastgltf::getElementByteSize(secondAccessor.type, secondAccessor.componentType);
+										  : fastgltf::getElementByteSize(
+												secondAccessor.type, secondAccessor.componentType);
 
-	auto* dataIndices = reinterpret_cast<const std::uint16_t*>(getBufferData(asset->buffers[viewIndices.bufferIndex])
-			+ viewIndices.byteOffset + secondAccessor.sparse->indicesByteOffset);
-	auto* dataValues = reinterpret_cast<const fastgltf::math::fvec3*>(getBufferData(asset->buffers[viewValues.bufferIndex])
-			+ viewValues.byteOffset + secondAccessor.sparse->valuesByteOffset);
+	auto* dataIndices = reinterpret_cast<const std::uint16_t*>(
+		getBufferData(asset->buffers[viewIndices.bufferIndex]) + viewIndices.byteOffset +
+		secondAccessor.sparse->indicesByteOffset);
+	auto* dataValues = reinterpret_cast<const fastgltf::math::fvec3*>(
+		getBufferData(asset->buffers[viewValues.bufferIndex]) + viewValues.byteOffset +
+		secondAccessor.sparse->valuesByteOffset);
 
 	auto checkValues = std::make_unique<fastgltf::math::fvec3[]>(secondAccessor.count);
 
@@ -282,13 +302,15 @@ TEST_CASE("Test sparse accessor", "[gltf-tools]") {
 			checkValues[i] = dataValues[sparseIndex];
 			++sparseIndex;
 		} else {
-			checkValues[i] = *reinterpret_cast<const fastgltf::math::fvec3*>(bufferData + dataStride * i);
+			checkValues[i] =
+				*reinterpret_cast<const fastgltf::math::fvec3*>(bufferData + dataStride * i);
 		}
 	}
 
 	SECTION("getAccessorElement") {
 		for (std::size_t i = 0; i < secondAccessor.count; ++i) {
-			REQUIRE(checkValues[i] == fastgltf::getAccessorElement<fastgltf::math::fvec3>(asset.get(), secondAccessor, i));
+			REQUIRE(checkValues[i] == fastgltf::getAccessorElement<fastgltf::math::fvec3>(
+										  asset.get(), secondAccessor, i));
 		}
 	}
 
@@ -296,35 +318,42 @@ TEST_CASE("Test sparse accessor", "[gltf-tools]") {
 		auto dstCopy = std::make_unique<fastgltf::math::fvec3[]>(secondAccessor.count);
 		std::size_t i = 0;
 
-		fastgltf::iterateAccessor<fastgltf::math::fvec3>(asset.get(), secondAccessor, [&](auto&& v3) {
-			dstCopy[i++] = std::forward<fastgltf::math::fvec3>(v3);
-		});
+		fastgltf::iterateAccessor<fastgltf::math::fvec3>(
+			asset.get(), secondAccessor,
+			[&](auto&& v3) { dstCopy[i++] = std::forward<fastgltf::math::fvec3>(v3); });
 
-		REQUIRE(std::memcmp(dstCopy.get(), checkValues.get(), secondAccessor.count * sizeof(fastgltf::math::fvec3)) == 0);
+		REQUIRE(std::memcmp(dstCopy.get(), checkValues.get(),
+							secondAccessor.count * sizeof(fastgltf::math::fvec3)) == 0);
 	}
 
 	SECTION("iterateAccessor with idx") {
 		auto dstCopy = std::make_unique<fastgltf::math::fvec3[]>(secondAccessor.count);
 
-		fastgltf::iterateAccessorWithIndex<fastgltf::math::fvec3>(asset.get(), secondAccessor, [&](auto&& v3, std::size_t i) {
+		fastgltf::iterateAccessorWithIndex<fastgltf::math::fvec3>(asset.get(), secondAccessor,
+																  [&](auto&& v3, std::size_t i) {
 			dstCopy[i] = std::forward<fastgltf::math::fvec3>(v3);
 		});
 
-		REQUIRE(std::memcmp(dstCopy.get(), checkValues.get(), secondAccessor.count * sizeof(fastgltf::math::fvec3)) == 0);
+		REQUIRE(std::memcmp(dstCopy.get(), checkValues.get(),
+							secondAccessor.count * sizeof(fastgltf::math::fvec3)) == 0);
 	}
 
 	SECTION("copyFromAccessor") {
 		auto dstCopy = std::make_unique<fastgltf::math::fvec3[]>(secondAccessor.count);
-		fastgltf::copyFromAccessor<fastgltf::math::fvec3>(asset.get(), secondAccessor, dstCopy.get());
-		REQUIRE(std::memcmp(dstCopy.get(), checkValues.get(), secondAccessor.count * sizeof(fastgltf::math::fvec3)) == 0);
+		fastgltf::copyFromAccessor<fastgltf::math::fvec3>(asset.get(), secondAccessor,
+														  dstCopy.get());
+		REQUIRE(std::memcmp(dstCopy.get(), checkValues.get(),
+							secondAccessor.count * sizeof(fastgltf::math::fvec3)) == 0);
 	}
 
 	SECTION("Iterator test") {
 		auto dstCopy = std::make_unique<fastgltf::math::fvec3[]>(secondAccessor.count);
-		auto accessor = fastgltf::iterateAccessor<fastgltf::math::fvec3>(asset.get(), secondAccessor);
+		auto accessor =
+			fastgltf::iterateAccessor<fastgltf::math::fvec3>(asset.get(), secondAccessor);
 		for (auto it = accessor.begin(); it != accessor.end(); ++it) {
 			dstCopy[std::distance(accessor.begin(), it)] = *it;
 		}
-		REQUIRE(std::memcmp(dstCopy.get(), checkValues.get(), secondAccessor.count * sizeof(fastgltf::math::fvec3)) == 0);
+		REQUIRE(std::memcmp(dstCopy.get(), checkValues.get(),
+							secondAccessor.count * sizeof(fastgltf::math::fvec3)) == 0);
 	}
 }

--- a/tests/base64_tests.cpp
+++ b/tests/base64_tests.cpp
@@ -1,43 +1,42 @@
+#include <catch2/benchmark/catch_benchmark.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <fastgltf/base64.hpp>
+#include <fastgltf/core.hpp>
+#include <fastgltf/types.hpp>
 #include <fstream>
 #include <sstream>
 
-#include <catch2/catch_test_macros.hpp>
-#include <catch2/benchmark/catch_benchmark.hpp>
-
-#include <fastgltf/base64.hpp>
-#include <fastgltf/types.hpp>
-#include <fastgltf/core.hpp>
 #include "gltf_path.hpp"
 
 constexpr std::string_view testBase64 = "SGVsbG8gV29ybGQuIEhlbGxvIFdvcmxkLiBIZWxsbyBXb3JsZC4=";
 
 TEST_CASE("Check base64 utility functions", "[base64]") {
-    REQUIRE(fastgltf::base64::getPadding("Li==") == 2);
-    REQUIRE(fastgltf::base64::getPadding("Li4=") == 1);
-    REQUIRE(fastgltf::base64::getPadding("Li4u") == 0);
+	REQUIRE(fastgltf::base64::getPadding("Li==") == 2);
+	REQUIRE(fastgltf::base64::getPadding("Li4=") == 1);
+	REQUIRE(fastgltf::base64::getPadding("Li4u") == 0);
 
-    REQUIRE(fastgltf::base64::getOutputSize(4, 0) == 3); // Li4u
-    REQUIRE(fastgltf::base64::getOutputSize(4, 1) == 2); // Li4=
-    REQUIRE(fastgltf::base64::getOutputSize(4, 2) == 1); // Li==
+	REQUIRE(fastgltf::base64::getOutputSize(4, 0) == 3);  // Li4u
+	REQUIRE(fastgltf::base64::getOutputSize(4, 1) == 2);  // Li4=
+	REQUIRE(fastgltf::base64::getOutputSize(4, 2) == 1);  // Li==
 }
 
 TEST_CASE("Check base64 decoding", "[base64]") {
-    // This is "Hello World. Hello World.". The decode function
-    // uses the best possible SIMD version of the algorithm.
-    auto bytes = fastgltf::base64::decode(testBase64);
-    std::string strings(bytes.begin(), bytes.end());
-    REQUIRE(strings == "Hello World. Hello World. Hello World.");
+	// This is "Hello World. Hello World.". The decode function
+	// uses the best possible SIMD version of the algorithm.
+	auto bytes = fastgltf::base64::decode(testBase64);
+	std::string strings(bytes.begin(), bytes.end());
+	REQUIRE(strings == "Hello World. Hello World. Hello World.");
 }
 
 TEST_CASE("Check all base64 decoders", "[base64]") {
-    // Checks that the base64 decoders return the same.
-    auto bytes = fastgltf::base64::fallback_decode(testBase64);
-    std::string strings(bytes.begin(), bytes.end());
-    REQUIRE(strings == "Hello World. Hello World. Hello World.");
+	// Checks that the base64 decoders return the same.
+	auto bytes = fastgltf::base64::fallback_decode(testBase64);
+	std::string strings(bytes.begin(), bytes.end());
+	REQUIRE(strings == "Hello World. Hello World. Hello World.");
 
 #if defined(__x86_64__) || defined(_M_AMD64) || defined(_M_IX86)
-    REQUIRE(bytes == fastgltf::base64::avx2_decode(testBase64));
-    REQUIRE(bytes == fastgltf::base64::sse4_decode(testBase64));
+	REQUIRE(bytes == fastgltf::base64::avx2_decode(testBase64));
+	REQUIRE(bytes == fastgltf::base64::sse4_decode(testBase64));
 #endif
 #if defined(__aarch64__)
 	REQUIRE(bytes == fastgltf::base64::neon_decode(testBase64));
@@ -45,71 +44,74 @@ TEST_CASE("Check all base64 decoders", "[base64]") {
 }
 
 TEST_CASE("Check big base64 data decoding", "[base64]") {
-    std::ifstream file(path / "base64.txt");
-    REQUIRE(file.is_open());
+	std::ifstream file(path / "base64.txt");
+	REQUIRE(file.is_open());
 
-    std::stringstream buffer;
-    buffer << file.rdbuf();
+	std::stringstream buffer;
+	buffer << file.rdbuf();
 
-    auto encodedBytes = buffer.str();
-    auto bytes = fastgltf::base64::decode(encodedBytes);
-    REQUIRE(!bytes.empty());
+	auto encodedBytes = buffer.str();
+	auto bytes = fastgltf::base64::decode(encodedBytes);
+	REQUIRE(!bytes.empty());
 
-    std::ifstream output(path / "base64.txt.out", std::ios::binary | std::ios::ate);
-    REQUIRE(output.is_open());
-    std::vector<uint8_t> decodedBytes(output.tellg());
-    output.seekg(0);
-    output.read(reinterpret_cast<char*>(decodedBytes.data()), static_cast<std::streamsize>(decodedBytes.size()));
+	std::ifstream output(path / "base64.txt.out", std::ios::binary | std::ios::ate);
+	REQUIRE(output.is_open());
+	std::vector<uint8_t> decodedBytes(output.tellg());
+	output.seekg(0);
+	output.read(reinterpret_cast<char*>(decodedBytes.data()),
+				static_cast<std::streamsize>(decodedBytes.size()));
 
-    REQUIRE(bytes == decodedBytes);
+	REQUIRE(bytes == decodedBytes);
 }
 
 TEST_CASE("Test base64 buffer decoding", "[base64]") {
-    fastgltf::Parser parser;
-    fastgltf::Image texture;
-    std::string bufferData;
+	fastgltf::Parser parser;
+	fastgltf::Image texture;
+	std::string bufferData;
 
-    auto cylinderEngine = sampleAssets / "Models" / "MetalRoughSpheres" / "glTF-Embedded";
-    auto boxTextured = sampleAssets / "Models" / "BoxTextured" / "glTF-Embedded";
+	auto cylinderEngine = sampleAssets / "Models" / "MetalRoughSpheres" / "glTF-Embedded";
+	auto boxTextured = sampleAssets / "Models" / "BoxTextured" / "glTF-Embedded";
 
 	fastgltf::GltfFileStream tceJsonData(cylinderEngine / "MetalRoughSpheres.gltf");
 	REQUIRE(tceJsonData.isOpen());
 	fastgltf::GltfFileStream btJsonData(boxTextured / "BoxTextured.gltf");
 	REQUIRE(btJsonData.isOpen());
 
-    SECTION("Validate large buffer load from glTF") {
-        auto asset = parser.loadGltfJson(tceJsonData, cylinderEngine, fastgltf::Options::None, fastgltf::Category::Buffers);
-        REQUIRE(asset.error() == fastgltf::Error::None);
+	SECTION("Validate large buffer load from glTF") {
+		auto asset = parser.loadGltfJson(tceJsonData, cylinderEngine, fastgltf::Options::None,
+										 fastgltf::Category::Buffers);
+		REQUIRE(asset.error() == fastgltf::Error::None);
 
-        REQUIRE(asset->buffers.size() == 1);
+		REQUIRE(asset->buffers.size() == 1);
 
-        // Load the buffer from the parsed glTF file.
-        auto& buffer = asset->buffers.front();
-        REQUIRE(buffer.byteLength == 11199904);
-        auto bufferVector = std::get_if<fastgltf::sources::Array>(&buffer.data);
-        REQUIRE(bufferVector != nullptr);
-        REQUIRE(bufferVector->mimeType == fastgltf::MimeType::OctetStream);
-        REQUIRE(!bufferVector->bytes.empty());
-    }
+		// Load the buffer from the parsed glTF file.
+		auto& buffer = asset->buffers.front();
+		REQUIRE(buffer.byteLength == 11199904);
+		auto bufferVector = std::get_if<fastgltf::sources::Array>(&buffer.data);
+		REQUIRE(bufferVector != nullptr);
+		REQUIRE(bufferVector->mimeType == fastgltf::MimeType::OctetStream);
+		REQUIRE(!bufferVector->bytes.empty());
+	}
 
-    SECTION("Validate base64 buffer and image load from glTF") {
-        auto asset = parser.loadGltfJson(btJsonData, boxTextured, fastgltf::Options::None, fastgltf::Category::Images | fastgltf::Category::Buffers);
-        REQUIRE(asset.error() == fastgltf::Error::None);
+	SECTION("Validate base64 buffer and image load from glTF") {
+		auto asset = parser.loadGltfJson(btJsonData, boxTextured, fastgltf::Options::None,
+										 fastgltf::Category::Images | fastgltf::Category::Buffers);
+		REQUIRE(asset.error() == fastgltf::Error::None);
 
-        REQUIRE(asset->buffers.size() == 1);
-        REQUIRE(asset->images.size() == 1);
+		REQUIRE(asset->buffers.size() == 1);
+		REQUIRE(asset->images.size() == 1);
 
-        auto& buffer = asset->buffers.front();
-        REQUIRE(buffer.byteLength == 840);
-        auto bufferVector = std::get_if<fastgltf::sources::Array>(&buffer.data);
-        REQUIRE(bufferVector != nullptr);
-        REQUIRE(bufferVector->mimeType == fastgltf::MimeType::OctetStream);
-        REQUIRE(!bufferVector->bytes.empty());
+		auto& buffer = asset->buffers.front();
+		REQUIRE(buffer.byteLength == 840);
+		auto bufferVector = std::get_if<fastgltf::sources::Array>(&buffer.data);
+		REQUIRE(bufferVector != nullptr);
+		REQUIRE(bufferVector->mimeType == fastgltf::MimeType::OctetStream);
+		REQUIRE(!bufferVector->bytes.empty());
 
-        auto& image = asset->images.front();
-        auto imageVector = std::get_if<fastgltf::sources::Array>(&image.data);
-        REQUIRE(imageVector != nullptr);
-        REQUIRE(imageVector->mimeType == fastgltf::MimeType::PNG);
-        REQUIRE(!imageVector->bytes.empty());
-    }
+		auto& image = asset->images.front();
+		auto imageVector = std::get_if<fastgltf::sources::Array>(&image.data);
+		REQUIRE(imageVector != nullptr);
+		REQUIRE(imageVector->mimeType == fastgltf::MimeType::PNG);
+		REQUIRE(!imageVector->bytes.empty());
+	}
 }

--- a/tests/basic_test.cpp
+++ b/tests/basic_test.cpp
@@ -494,15 +494,9 @@ TEST_CASE("Test accessors min/max", "[gltf-loader]") {
 }
 
 TEST_CASE("Test unicode characters", "[gltf-loader]") {
-#if FASTGLTF_CPP_20
 	auto unicodePath = sampleAssets / "Models" / std::filesystem::path(u8"Unicode❤♻Test") / "glTF";
 	fastgltf::GltfFileStream jsonData(unicodePath / std::filesystem::path(u8"Unicode❤♻Test.gltf"));
 	REQUIRE(jsonData.isOpen());
-#else
-	auto unicodePath = sampleAssets / "Models" / std::filesystem::u8path(u8"Unicode❤♻Test") / "glTF";
-	fastgltf::GltfFileStream jsonData(unicodePath / std::filesystem::u8path(u8"Unicode❤♻Test.gltf"));
-	REQUIRE(jsonData.isOpen());
-#endif
 
 	fastgltf::Parser parser;
 	auto asset = parser.loadGltfJson(jsonData, unicodePath);
@@ -515,11 +509,7 @@ TEST_CASE("Test unicode characters", "[gltf-loader]") {
 	REQUIRE(!asset->buffers.empty());
 	auto bufferUri = std::get<fastgltf::sources::URI>(asset->buffers[0].data);
 	REQUIRE(bufferUri.uri.path() == "Unicode❤♻Binary.bin");
-#if FASTGLTF_CPP_20
 	REQUIRE(bufferUri.uri.fspath() == std::filesystem::path{ u8"Unicode❤♻Binary.bin" });
-#else
-	REQUIRE(bufferUri.uri.fspath() == std::filesystem::u8path("Unicode❤♻Binary.bin"));
-#endif
 }
 
 TEST_CASE("Test extras callback", "[gltf-loader]") {

--- a/tests/basic_test.cpp
+++ b/tests/basic_test.cpp
@@ -1,29 +1,29 @@
 #include <algorithm>
-#include <cstdlib>
-
+#include <catch2/benchmark/catch_benchmark.hpp>
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
-#include <catch2/benchmark/catch_benchmark.hpp>
+#include <cstdlib>
 
 // All headers not in the root directory require this
 #define GLM_ENABLE_EXPERIMENTAL 1
 
-#include <glm/glm.hpp>
-#include <glm/gtc/epsilon.hpp>
+#include <simdjson.h>
 
 #include <fastgltf/base64.hpp>
 #include <fastgltf/core.hpp>
-#include <fastgltf/types.hpp>
 #include <fastgltf/math.hpp>
+#include <fastgltf/types.hpp>
+#include <glm/glm.hpp>
+#include <glm/gtc/epsilon.hpp>
+
 #include "gltf_path.hpp"
-#include <simdjson.h>
 
 constexpr auto noOptions = fastgltf::Options::None;
 
 TEST_CASE("Component type tests", "[gltf-loader]") {
-    using namespace fastgltf;
+	using namespace fastgltf;
 
-    // clang-format off
+	// clang-format off
     REQUIRE(fastgltf::getNumComponents(AccessorType::Scalar) ==  1);
     REQUIRE(fastgltf::getNumComponents(AccessorType::Vec2)   ==  2);
     REQUIRE(fastgltf::getNumComponents(AccessorType::Vec3)   ==  3);
@@ -62,226 +62,234 @@ TEST_CASE("Component type tests", "[gltf-loader]") {
 	REQUIRE(fastgltf::getGLComponentType(ComponentType::Float) == 5126);
 	REQUIRE(fastgltf::getGLComponentType(ComponentType::Double) == 5130);
 	REQUIRE(fastgltf::getGLComponentType(ComponentType::Invalid) == 0);
-    // clang-format on
+	// clang-format on
 }
 
 TEST_CASE("Test extension stringification", "[gltf-loader]") {
 	auto stringified = stringifyExtension(fastgltf::Extensions::EXT_meshopt_compression);
 	REQUIRE(stringified == fastgltf::extensions::EXT_meshopt_compression);
 
-	stringified = stringifyExtension(fastgltf::Extensions::EXT_meshopt_compression | fastgltf::Extensions::EXT_texture_webp);
+	stringified = stringifyExtension(fastgltf::Extensions::EXT_meshopt_compression |
+									 fastgltf::Extensions::EXT_texture_webp);
 	REQUIRE(stringified == fastgltf::extensions::EXT_meshopt_compression);
 
-	auto list = stringifyExtensionBits(fastgltf::Extensions::EXT_meshopt_compression | fastgltf::Extensions::EXT_texture_webp);
+	auto list = stringifyExtensionBits(fastgltf::Extensions::EXT_meshopt_compression |
+									   fastgltf::Extensions::EXT_texture_webp);
 	REQUIRE(list.size() == 2);
 	REQUIRE(list[0] == fastgltf::extensions::EXT_meshopt_compression);
 	REQUIRE(list[1] == fastgltf::extensions::EXT_texture_webp);
 }
 
 TEST_CASE("Test if glTF type detection works", "[gltf-loader]") {
-    fastgltf::Parser parser;
+	fastgltf::Parser parser;
 
-    SECTION("glTF") {
-        auto gltfPath = sampleAssets / "Models" / "ABeautifulGame" / "glTF";
-        REQUIRE(std::filesystem::exists(gltfPath));
+	SECTION("glTF") {
+		auto gltfPath = sampleAssets / "Models" / "ABeautifulGame" / "glTF";
+		REQUIRE(std::filesystem::exists(gltfPath));
 		fastgltf::GltfFileStream jsonData(gltfPath / "ABeautifulGame.gltf");
 		REQUIRE(jsonData.isOpen());
 
-        REQUIRE(fastgltf::determineGltfFileType(jsonData) == fastgltf::GltfType::glTF);
+		REQUIRE(fastgltf::determineGltfFileType(jsonData) == fastgltf::GltfType::glTF);
 
-        auto model = parser.loadGltfJson(jsonData, gltfPath);
+		auto model = parser.loadGltfJson(jsonData, gltfPath);
 		REQUIRE(model.error() == fastgltf::Error::None);
-        REQUIRE(model.get_if() != nullptr);
+		REQUIRE(model.get_if() != nullptr);
 		REQUIRE(fastgltf::validate(model.get()) == fastgltf::Error::None);
-    }
+	}
 
-    SECTION("GLB") {
-        auto glbPath = sampleAssets / "Models" / "BoomBox" / "glTF-Binary";
-        REQUIRE(std::filesystem::exists(glbPath));
+	SECTION("GLB") {
+		auto glbPath = sampleAssets / "Models" / "BoomBox" / "glTF-Binary";
+		REQUIRE(std::filesystem::exists(glbPath));
 		fastgltf::GltfFileStream jsonData(glbPath / "BoomBox.glb");
 		REQUIRE(jsonData.isOpen());
 
-        REQUIRE(fastgltf::determineGltfFileType(jsonData) == fastgltf::GltfType::GLB);
+		REQUIRE(fastgltf::determineGltfFileType(jsonData) == fastgltf::GltfType::GLB);
 
-        auto model = parser.loadGltfBinary(jsonData, glbPath);
-        REQUIRE(model.error() == fastgltf::Error::None);
+		auto model = parser.loadGltfBinary(jsonData, glbPath);
+		REQUIRE(model.error() == fastgltf::Error::None);
 		REQUIRE(model.get_if() != nullptr);
-    }
+	}
 
-    SECTION("Invalid") {
-        auto fakePath = path / "base64.txt"; // Random file in the test directory that's not a glTF file.
-        REQUIRE(std::filesystem::exists(fakePath));
+	SECTION("Invalid") {
+		auto fakePath =
+			path / "base64.txt";  // Random file in the test directory that's not a glTF file.
+		REQUIRE(std::filesystem::exists(fakePath));
 		fastgltf::GltfFileStream jsonData(fakePath);
 		REQUIRE(jsonData.isOpen());
 
-        REQUIRE(fastgltf::determineGltfFileType(jsonData) == fastgltf::GltfType::Invalid);
-    }
+		REQUIRE(fastgltf::determineGltfFileType(jsonData) == fastgltf::GltfType::Invalid);
+	}
 }
 
 TEST_CASE("Loading some basic glTF", "[gltf-loader]") {
-    fastgltf::Parser parser;
-    SECTION("Loading basic invalid glTF files") {
+	fastgltf::Parser parser;
+	SECTION("Loading basic invalid glTF files") {
 		fastgltf::GltfFileStream jsonData(path / "empty_json.gltf");
 		REQUIRE(jsonData.isOpen());
 
-        auto emptyGltf = parser.loadGltfJson(jsonData, path);
-        REQUIRE(emptyGltf.error() == fastgltf::Error::InvalidOrMissingAssetField);
-    }
+		auto emptyGltf = parser.loadGltfJson(jsonData, path);
+		REQUIRE(emptyGltf.error() == fastgltf::Error::InvalidOrMissingAssetField);
+	}
 
-    SECTION("Load basic glTF file") {
+	SECTION("Load basic glTF file") {
 		fastgltf::GltfFileStream jsonData(path / "basic_gltf.gltf");
 		REQUIRE(jsonData.isOpen());
 
 		auto basicGltf = parser.loadGltfJson(jsonData, path);
-        REQUIRE(basicGltf.error() == fastgltf::Error::None);
+		REQUIRE(basicGltf.error() == fastgltf::Error::None);
 		REQUIRE(fastgltf::validate(basicGltf.get()) == fastgltf::Error::None);
-    }
+	}
 
-    SECTION("Loading basic Cube.gltf") {
-        auto cubePath = sampleAssets / "Models" / "Cube" / "glTF";
+	SECTION("Loading basic Cube.gltf") {
+		auto cubePath = sampleAssets / "Models" / "Cube" / "glTF";
 		fastgltf::GltfFileStream jsonData(cubePath / "Cube.gltf");
 		REQUIRE(jsonData.isOpen());
 
-        auto cube = parser.loadGltfJson(jsonData, cubePath, noOptions, fastgltf::Category::OnlyRenderable);
-        REQUIRE(cube.error() == fastgltf::Error::None);
+		auto cube =
+			parser.loadGltfJson(jsonData, cubePath, noOptions, fastgltf::Category::OnlyRenderable);
+		REQUIRE(cube.error() == fastgltf::Error::None);
 		REQUIRE(fastgltf::validate(cube.get()) == fastgltf::Error::None);
 
-        REQUIRE(cube->scenes.size() == 1);
-        REQUIRE(cube->scenes.front().nodeIndices.size() == 1);
-        REQUIRE(cube->scenes.front().nodeIndices.front() == 0);
+		REQUIRE(cube->scenes.size() == 1);
+		REQUIRE(cube->scenes.front().nodeIndices.size() == 1);
+		REQUIRE(cube->scenes.front().nodeIndices.front() == 0);
 
-        REQUIRE(cube->nodes.size() == 1);
-        REQUIRE(cube->nodes.front().name == "Cube");
-        REQUIRE(std::holds_alternative<fastgltf::TRS>(cube->nodes.front().transform));
+		REQUIRE(cube->nodes.size() == 1);
+		REQUIRE(cube->nodes.front().name == "Cube");
+		REQUIRE(std::holds_alternative<fastgltf::TRS>(cube->nodes.front().transform));
 
-        REQUIRE(cube->accessors.size() == 5);
-        REQUIRE(cube->accessors[0].type == fastgltf::AccessorType::Scalar);
-        REQUIRE(cube->accessors[0].componentType == fastgltf::ComponentType::UnsignedShort);
-        REQUIRE(cube->accessors[1].type == fastgltf::AccessorType::Vec3);
-        REQUIRE(cube->accessors[1].componentType == fastgltf::ComponentType::Float);
+		REQUIRE(cube->accessors.size() == 5);
+		REQUIRE(cube->accessors[0].type == fastgltf::AccessorType::Scalar);
+		REQUIRE(cube->accessors[0].componentType == fastgltf::ComponentType::UnsignedShort);
+		REQUIRE(cube->accessors[1].type == fastgltf::AccessorType::Vec3);
+		REQUIRE(cube->accessors[1].componentType == fastgltf::ComponentType::Float);
 
-        REQUIRE(cube->bufferViews.size() == 5);
-        REQUIRE(cube->buffers.size() == 1);
+		REQUIRE(cube->bufferViews.size() == 5);
+		REQUIRE(cube->buffers.size() == 1);
 
-        REQUIRE(cube->materials.size() == 1);
-        auto& material = cube->materials.front();
-        REQUIRE(material.name == "Cube");
-        REQUIRE(material.pbrData.baseColorTexture.has_value());
-        REQUIRE(material.pbrData.baseColorTexture->textureIndex == 0);
-        REQUIRE(material.pbrData.metallicRoughnessTexture.has_value());
-        REQUIRE(material.pbrData.metallicRoughnessTexture->textureIndex == 1);
-        REQUIRE(!material.normalTexture.has_value());
-        REQUIRE(!material.emissiveTexture.has_value());
-        REQUIRE(!material.occlusionTexture.has_value());
-    }
+		REQUIRE(cube->materials.size() == 1);
+		auto& material = cube->materials.front();
+		REQUIRE(material.name == "Cube");
+		REQUIRE(material.pbrData.baseColorTexture.has_value());
+		REQUIRE(material.pbrData.baseColorTexture->textureIndex == 0);
+		REQUIRE(material.pbrData.metallicRoughnessTexture.has_value());
+		REQUIRE(material.pbrData.metallicRoughnessTexture->textureIndex == 1);
+		REQUIRE(!material.normalTexture.has_value());
+		REQUIRE(!material.emissiveTexture.has_value());
+		REQUIRE(!material.occlusionTexture.has_value());
+	}
 
-    SECTION("Loading basic Box.gltf") {
-        auto boxPath = sampleAssets / "Models" / "Box" / "glTF";
+	SECTION("Loading basic Box.gltf") {
+		auto boxPath = sampleAssets / "Models" / "Box" / "glTF";
 		fastgltf::GltfFileStream jsonData(boxPath / "Box.gltf");
 		REQUIRE(jsonData.isOpen());
 
-        auto box = parser.loadGltfJson(jsonData, boxPath, noOptions, fastgltf::Category::OnlyRenderable);
-        REQUIRE(box.error() == fastgltf::Error::None);
+		auto box =
+			parser.loadGltfJson(jsonData, boxPath, noOptions, fastgltf::Category::OnlyRenderable);
+		REQUIRE(box.error() == fastgltf::Error::None);
 		REQUIRE(fastgltf::validate(box.get()) == fastgltf::Error::None);
 
-        REQUIRE(box->defaultScene.has_value());
-        REQUIRE(box->defaultScene.value() == 0);
+		REQUIRE(box->defaultScene.has_value());
+		REQUIRE(box->defaultScene.value() == 0);
 
-        REQUIRE(box->nodes.size() == 2);
-        REQUIRE(box->nodes[0].children.size() == 1);
-        REQUIRE(box->nodes[0].children[0] == 1);
-        REQUIRE(box->nodes[1].children.empty());
-        REQUIRE(box->nodes[1].meshIndex.has_value());
-        REQUIRE(box->nodes[1].meshIndex.value() == 0);
+		REQUIRE(box->nodes.size() == 2);
+		REQUIRE(box->nodes[0].children.size() == 1);
+		REQUIRE(box->nodes[0].children[0] == 1);
+		REQUIRE(box->nodes[1].children.empty());
+		REQUIRE(box->nodes[1].meshIndex.has_value());
+		REQUIRE(box->nodes[1].meshIndex.value() == 0);
 
-        REQUIRE(box->materials.size() == 1);
-        REQUIRE(box->materials[0].name == "Red");
-        REQUIRE(box->materials[0].pbrData.baseColorFactor[3] == 1.0f);
-        REQUIRE(box->materials[0].pbrData.metallicFactor == 0.0f);
-    }
+		REQUIRE(box->materials.size() == 1);
+		REQUIRE(box->materials[0].name == "Red");
+		REQUIRE(box->materials[0].pbrData.baseColorFactor[3] == 1.0f);
+		REQUIRE(box->materials[0].pbrData.metallicFactor == 0.0f);
+	}
 }
 
-
 TEST_CASE("Loading glTF animation", "[gltf-loader]") {
-    auto animatedCube = sampleAssets / "Models" / "AnimatedCube" / "glTF";
+	auto animatedCube = sampleAssets / "Models" / "AnimatedCube" / "glTF";
 	fastgltf::GltfFileStream jsonData(animatedCube / "AnimatedCube.gltf");
 	REQUIRE(jsonData.isOpen());
 
-    fastgltf::Parser parser;
-    auto asset = parser.loadGltfJson(jsonData, animatedCube, noOptions, fastgltf::Category::OnlyAnimations);
-    REQUIRE(asset.error() == fastgltf::Error::None);
+	fastgltf::Parser parser;
+	auto asset =
+		parser.loadGltfJson(jsonData, animatedCube, noOptions, fastgltf::Category::OnlyAnimations);
+	REQUIRE(asset.error() == fastgltf::Error::None);
 	REQUIRE(fastgltf::validate(asset.get()) == fastgltf::Error::None);
 
-    REQUIRE(!asset->animations.empty());
+	REQUIRE(!asset->animations.empty());
 
-    auto& animation = asset->animations.front();
-    REQUIRE(animation.name == "animation_AnimatedCube");
+	auto& animation = asset->animations.front();
+	REQUIRE(animation.name == "animation_AnimatedCube");
 
-    REQUIRE(!animation.channels.empty());
-    REQUIRE(animation.channels.front().nodeIndex == 0U);
-    REQUIRE(animation.channels.front().samplerIndex == 0);
-    REQUIRE(animation.channels.front().path == fastgltf::AnimationPath::Rotation);
+	REQUIRE(!animation.channels.empty());
+	REQUIRE(animation.channels.front().nodeIndex == 0U);
+	REQUIRE(animation.channels.front().samplerIndex == 0);
+	REQUIRE(animation.channels.front().path == fastgltf::AnimationPath::Rotation);
 
-    REQUIRE(!animation.samplers.empty());
-    REQUIRE(animation.samplers.front().interpolation == fastgltf::AnimationInterpolation::Linear);
-    REQUIRE(animation.samplers.front().inputAccessor == 0);
-    REQUIRE(animation.samplers.front().outputAccessor == 1);
+	REQUIRE(!animation.samplers.empty());
+	REQUIRE(animation.samplers.front().interpolation == fastgltf::AnimationInterpolation::Linear);
+	REQUIRE(animation.samplers.front().inputAccessor == 0);
+	REQUIRE(animation.samplers.front().outputAccessor == 1);
 }
 
 TEST_CASE("Loading glTF skins", "[gltf-loader]") {
-    auto simpleSkin = sampleAssets / "Models" / "SimpleSkin" / "glTF";
+	auto simpleSkin = sampleAssets / "Models" / "SimpleSkin" / "glTF";
 	fastgltf::GltfFileStream jsonData(simpleSkin / "SimpleSkin.gltf");
 	REQUIRE(jsonData.isOpen());
 
-    fastgltf::Parser parser;
-    auto asset = parser.loadGltfJson(jsonData, simpleSkin, noOptions, fastgltf::Category::Skins | fastgltf::Category::Nodes);
-    REQUIRE(asset.error() == fastgltf::Error::None);
+	fastgltf::Parser parser;
+	auto asset = parser.loadGltfJson(jsonData, simpleSkin, noOptions,
+									 fastgltf::Category::Skins | fastgltf::Category::Nodes);
+	REQUIRE(asset.error() == fastgltf::Error::None);
 	REQUIRE(fastgltf::validate(asset.get()) == fastgltf::Error::None);
 
-    REQUIRE(!asset->skins.empty());
+	REQUIRE(!asset->skins.empty());
 
-    auto& skin = asset->skins.front();
-    REQUIRE(skin.joints.size() == 2);
-    REQUIRE(skin.joints[0] == 1);
-    REQUIRE(skin.joints[1] == 2);
-    REQUIRE(skin.inverseBindMatrices.has_value());
-    REQUIRE(skin.inverseBindMatrices.value() == 4);
+	auto& skin = asset->skins.front();
+	REQUIRE(skin.joints.size() == 2);
+	REQUIRE(skin.joints[0] == 1);
+	REQUIRE(skin.joints[1] == 2);
+	REQUIRE(skin.inverseBindMatrices.has_value());
+	REQUIRE(skin.inverseBindMatrices.value() == 4);
 
-    REQUIRE(!asset->nodes.empty());
+	REQUIRE(!asset->nodes.empty());
 
-    auto& node = asset->nodes.front();
-    REQUIRE(node.skinIndex.has_value());
-    REQUIRE(node.skinIndex == 0U);
+	auto& node = asset->nodes.front();
+	REQUIRE(node.skinIndex.has_value());
+	REQUIRE(node.skinIndex == 0U);
 }
 
 TEST_CASE("Loading glTF cameras", "[gltf-loader]") {
-    auto cameras = sampleAssets / "Models" / "Cameras" / "glTF";
+	auto cameras = sampleAssets / "Models" / "Cameras" / "glTF";
 	fastgltf::GltfFileStream jsonData(cameras / "Cameras.gltf");
 	REQUIRE(jsonData.isOpen());
 
-    fastgltf::Parser parser;
-    auto asset = parser.loadGltfJson(jsonData, cameras, noOptions, fastgltf::Category::Cameras);
-    REQUIRE(asset.error() == fastgltf::Error::None);
+	fastgltf::Parser parser;
+	auto asset = parser.loadGltfJson(jsonData, cameras, noOptions, fastgltf::Category::Cameras);
+	REQUIRE(asset.error() == fastgltf::Error::None);
 	REQUIRE(fastgltf::validate(asset.get()) == fastgltf::Error::None);
 
-    REQUIRE(asset->cameras.size() == 2);
+	REQUIRE(asset->cameras.size() == 2);
 
-    REQUIRE(std::holds_alternative<fastgltf::Camera::Perspective>(asset->cameras[0].camera));
-    REQUIRE(std::holds_alternative<fastgltf::Camera::Orthographic>(asset->cameras[1].camera));
+	REQUIRE(std::holds_alternative<fastgltf::Camera::Perspective>(asset->cameras[0].camera));
+	REQUIRE(std::holds_alternative<fastgltf::Camera::Orthographic>(asset->cameras[1].camera));
 
-    const auto* pPerspective = std::get_if<fastgltf::Camera::Perspective>(&asset->cameras[0].camera);
-    REQUIRE(pPerspective != nullptr);
-    REQUIRE(pPerspective->aspectRatio == 1.0f);
-    REQUIRE(pPerspective->yfov == 0.7f);
-    REQUIRE(pPerspective->zfar == 100);
-    REQUIRE(pPerspective->znear == 0.01f);
+	const auto* pPerspective =
+		std::get_if<fastgltf::Camera::Perspective>(&asset->cameras[0].camera);
+	REQUIRE(pPerspective != nullptr);
+	REQUIRE(pPerspective->aspectRatio == 1.0f);
+	REQUIRE(pPerspective->yfov == 0.7f);
+	REQUIRE(pPerspective->zfar == 100);
+	REQUIRE(pPerspective->znear == 0.01f);
 
-    const auto* pOrthographic = std::get_if<fastgltf::Camera::Orthographic>(&asset->cameras[1].camera);
-    REQUIRE(pOrthographic != nullptr);
-    REQUIRE(pOrthographic->xmag == 1.0f);
-    REQUIRE(pOrthographic->ymag == 1.0f);
-    REQUIRE(pOrthographic->zfar == 100);
-    REQUIRE(pOrthographic->znear == 0.01f);
+	const auto* pOrthographic =
+		std::get_if<fastgltf::Camera::Orthographic>(&asset->cameras[1].camera);
+	REQUIRE(pOrthographic != nullptr);
+	REQUIRE(pOrthographic->xmag == 1.0f);
+	REQUIRE(pOrthographic->ymag == 1.0f);
+	REQUIRE(pOrthographic->zfar == 100);
+	REQUIRE(pOrthographic->znear == 0.01f);
 }
 
 TEST_CASE("Validate models with re-used parser", "[gltf-loader]") {
@@ -309,118 +317,120 @@ TEST_CASE("Validate models with re-used parser", "[gltf-loader]") {
 }
 
 TEST_CASE("Test allocation callbacks for embedded buffers", "[gltf-loader]") {
-    auto boxPath = sampleAssets / "Models" / "Box" / "glTF-Embedded";
+	auto boxPath = sampleAssets / "Models" / "Box" / "glTF-Embedded";
 	fastgltf::GltfFileStream jsonData(boxPath / "Box.gltf");
 	REQUIRE(jsonData.isOpen());
 
-    std::vector<void*> allocations;
+	std::vector<void*> allocations;
 
-    auto mapCallback = [](uint64_t bufferSize, void* userPointer) -> fastgltf::BufferInfo {
-        REQUIRE(userPointer != nullptr);
-        auto* allocations = static_cast<std::vector<void*>*>(userPointer);
-        allocations->emplace_back(std::malloc(bufferSize));
-        return fastgltf::BufferInfo {
-            allocations->back(),
-            allocations->size() - 1,
-        };
-    };
+	auto mapCallback = [](uint64_t bufferSize, void* userPointer) -> fastgltf::BufferInfo {
+		REQUIRE(userPointer != nullptr);
+		auto* allocations = static_cast<std::vector<void*>*>(userPointer);
+		allocations->emplace_back(std::malloc(bufferSize));
+		return fastgltf::BufferInfo{
+			allocations->back(),
+			allocations->size() - 1,
+		};
+	};
 
-    fastgltf::Parser parser;
-    parser.setUserPointer(&allocations);
-    parser.setBufferAllocationCallback(mapCallback, nullptr);
+	fastgltf::Parser parser;
+	parser.setUserPointer(&allocations);
+	parser.setBufferAllocationCallback(mapCallback, nullptr);
 	auto asset = parser.loadGltfJson(jsonData, boxPath, noOptions, fastgltf::Category::Buffers);
 	REQUIRE(asset.error() == fastgltf::Error::None);
 	REQUIRE(fastgltf::validate(asset.get()) == fastgltf::Error::None);
 
-    REQUIRE(allocations.size() == 1);
-    REQUIRE(asset->buffers.size() == 1);
+	REQUIRE(allocations.size() == 1);
+	REQUIRE(asset->buffers.size() == 1);
 
-    auto& buffer = asset->buffers.front();
-    const auto* customBuffer = std::get_if<fastgltf::sources::CustomBuffer>(&buffer.data);
-    REQUIRE(customBuffer != nullptr);
-    REQUIRE(customBuffer->id == 0);
+	auto& buffer = asset->buffers.front();
+	const auto* customBuffer = std::get_if<fastgltf::sources::CustomBuffer>(&buffer.data);
+	REQUIRE(customBuffer != nullptr);
+	REQUIRE(customBuffer->id == 0);
 
-    for (auto& allocation : allocations) {
-        REQUIRE(allocation != nullptr);
-        std::free(allocation);
-    }
+	for (auto& allocation : allocations) {
+		REQUIRE(allocation != nullptr);
+		std::free(allocation);
+	}
 }
 
 TEST_CASE("Test base64 decoding callbacks", "[gltf-loader]") {
-    auto boxPath = sampleAssets / "Models" / "Box" / "glTF-Embedded";
+	auto boxPath = sampleAssets / "Models" / "Box" / "glTF-Embedded";
 	fastgltf::GltfFileStream jsonData(boxPath / "Box.gltf");
 	REQUIRE(jsonData.isOpen());
 
-    size_t decodeCounter = 0;
-    auto decodeCallback = [](const std::string_view encodedData, uint8_t* outputData,
-        const size_t padding, [[maybe_unused]] size_t outputSize, void* userPointer) {
-        (*static_cast<size_t*>(userPointer))++;
-        fastgltf::base64::decode_inplace(encodedData, outputData, padding);
-    };
+	size_t decodeCounter = 0;
+	auto decodeCallback = [](const std::string_view encodedData, uint8_t* outputData,
+							 const size_t padding, [[maybe_unused]] size_t outputSize,
+							 void* userPointer) {
+		(*static_cast<size_t*>(userPointer))++;
+		fastgltf::base64::decode_inplace(encodedData, outputData, padding);
+	};
 
-    fastgltf::Parser parser;
-    parser.setUserPointer(&decodeCounter);
-    parser.setBase64DecodeCallback(decodeCallback);
-    auto model = parser.loadGltfJson(jsonData, boxPath, noOptions, fastgltf::Category::Buffers);
-    REQUIRE(model.error() == fastgltf::Error::None);
+	fastgltf::Parser parser;
+	parser.setUserPointer(&decodeCounter);
+	parser.setBase64DecodeCallback(decodeCallback);
+	auto model = parser.loadGltfJson(jsonData, boxPath, noOptions, fastgltf::Category::Buffers);
+	REQUIRE(model.error() == fastgltf::Error::None);
 	REQUIRE(fastgltf::validate(model.get()) == fastgltf::Error::None);
-    REQUIRE(decodeCounter != 0);
+	REQUIRE(decodeCounter != 0);
 }
 
 TEST_CASE("Validate sparse accessor parsing", "[gltf-loader]") {
-    auto simpleSparseAccessor = sampleAssets / "Models" / "SimpleSparseAccessor" / "glTF";
+	auto simpleSparseAccessor = sampleAssets / "Models" / "SimpleSparseAccessor" / "glTF";
 	fastgltf::GltfFileStream jsonData(simpleSparseAccessor / "SimpleSparseAccessor.gltf");
 	REQUIRE(jsonData.isOpen());
 
-    fastgltf::Parser parser;
-    auto asset = parser.loadGltfJson(jsonData, simpleSparseAccessor, noOptions, fastgltf::Category::Accessors);
-    REQUIRE(asset.error() == fastgltf::Error::None);
+	fastgltf::Parser parser;
+	auto asset = parser.loadGltfJson(jsonData, simpleSparseAccessor, noOptions,
+									 fastgltf::Category::Accessors);
+	REQUIRE(asset.error() == fastgltf::Error::None);
 	REQUIRE(fastgltf::validate(asset.get()) == fastgltf::Error::None);
 
-    REQUIRE(asset->accessors.size() == 2);
-    REQUIRE(!asset->accessors[0].sparse.has_value());
-    REQUIRE(asset->accessors[1].sparse.has_value());
-    auto& sparse = asset->accessors[1].sparse.value();
-    REQUIRE(sparse.count == 3);
-    REQUIRE(sparse.indicesBufferView == 2);
-    REQUIRE(sparse.indicesByteOffset == 0);
-    REQUIRE(sparse.valuesBufferView == 3);
-    REQUIRE(sparse.valuesByteOffset == 0);
-    REQUIRE(sparse.indexComponentType == fastgltf::ComponentType::UnsignedShort);
+	REQUIRE(asset->accessors.size() == 2);
+	REQUIRE(!asset->accessors[0].sparse.has_value());
+	REQUIRE(asset->accessors[1].sparse.has_value());
+	auto& sparse = asset->accessors[1].sparse.value();
+	REQUIRE(sparse.count == 3);
+	REQUIRE(sparse.indicesBufferView == 2);
+	REQUIRE(sparse.indicesByteOffset == 0);
+	REQUIRE(sparse.valuesBufferView == 3);
+	REQUIRE(sparse.valuesByteOffset == 0);
+	REQUIRE(sparse.indexComponentType == fastgltf::ComponentType::UnsignedShort);
 }
 
 TEST_CASE("Validate morph target parsing", "[gltf-loader]") {
-    auto simpleMorph = sampleAssets / "Models" / "SimpleMorph" / "glTF";
+	auto simpleMorph = sampleAssets / "Models" / "SimpleMorph" / "glTF";
 	fastgltf::GltfFileStream jsonData(simpleMorph / "SimpleMorph.gltf");
 	REQUIRE(jsonData.isOpen());
 
-    fastgltf::Parser parser;
-    auto asset = parser.loadGltfJson(jsonData, simpleMorph, noOptions, fastgltf::Category::Meshes);
-    REQUIRE(asset.error() == fastgltf::Error::None);
+	fastgltf::Parser parser;
+	auto asset = parser.loadGltfJson(jsonData, simpleMorph, noOptions, fastgltf::Category::Meshes);
+	REQUIRE(asset.error() == fastgltf::Error::None);
 	REQUIRE(fastgltf::validate(asset.get()) == fastgltf::Error::None);
 
-    REQUIRE(asset->meshes.size() == 1);
-    REQUIRE(asset->meshes.front().weights.size() == 2);
-    REQUIRE(asset->meshes.front().primitives.size() == 1);
+	REQUIRE(asset->meshes.size() == 1);
+	REQUIRE(asset->meshes.front().weights.size() == 2);
+	REQUIRE(asset->meshes.front().primitives.size() == 1);
 
-    auto& primitive = asset->meshes.front().primitives.front();
+	auto& primitive = asset->meshes.front().primitives.front();
 
 	auto position = primitive.findAttribute("POSITION");
 	REQUIRE(position != primitive.attributes.end());
 	REQUIRE(position->name == "POSITION");
 	REQUIRE(position->accessorIndex == 1);
 
-    REQUIRE(primitive.targets.size() == 2);
+	REQUIRE(primitive.targets.size() == 2);
 
 	auto positionTarget0 = primitive.findTargetAttribute(0, "POSITION");
-    REQUIRE(positionTarget0 != primitive.targets[0].end());
+	REQUIRE(positionTarget0 != primitive.targets[0].end());
 	REQUIRE(positionTarget0->name == "POSITION");
-    REQUIRE(positionTarget0->accessorIndex == 2);
+	REQUIRE(positionTarget0->accessorIndex == 2);
 
 	auto positionTarget1 = primitive.findTargetAttribute(1, "POSITION");
-    REQUIRE(positionTarget1 != primitive.targets[1].end());
+	REQUIRE(positionTarget1 != primitive.targets[1].end());
 	REQUIRE(positionTarget1->name == "POSITION");
-    REQUIRE(positionTarget1->accessorIndex == 3);
+	REQUIRE(positionTarget1->accessorIndex == 3);
 }
 
 TEST_CASE("Test accessors min/max", "[gltf-loader]") {
@@ -429,11 +439,13 @@ TEST_CASE("Test accessors min/max", "[gltf-loader]") {
 	REQUIRE(jsonData.isOpen());
 
 	fastgltf::Parser parser(fastgltf::Extensions::KHR_lights_punctual);
-	auto asset = parser.loadGltfJson(jsonData, lightsLamp, noOptions, fastgltf::Category::Accessors);
+	auto asset =
+		parser.loadGltfJson(jsonData, lightsLamp, noOptions, fastgltf::Category::Accessors);
 	REQUIRE(asset.error() == fastgltf::Error::None);
 	REQUIRE(fastgltf::validate(asset.get()) == fastgltf::Error::None);
 
-	REQUIRE(std::find_if(asset->extensionsUsed.begin(), asset->extensionsUsed.end(), [](auto& string) {
+	REQUIRE(
+		std::find_if(asset->extensionsUsed.begin(), asset->extensionsUsed.end(), [](auto& string) {
 		return string == fastgltf::extensions::KHR_lights_punctual;
 	}) != asset->extensionsUsed.end());
 
@@ -456,9 +468,9 @@ TEST_CASE("Test accessors min/max", "[gltf-loader]") {
 	}
 
 	{
-    	auto& secondAccessor = accessors[1];
-    	const auto& max = secondAccessor.max;
-    	const auto& min = secondAccessor.min;
+		auto& secondAccessor = accessors[1];
+		const auto& max = secondAccessor.max;
+		const auto& min = secondAccessor.min;
 		REQUIRE(max.has_value());
 		REQUIRE(min.has_value());
 		REQUIRE(max->size() == fastgltf::getNumComponents(secondAccessor.type));
@@ -509,7 +521,7 @@ TEST_CASE("Test unicode characters", "[gltf-loader]") {
 	REQUIRE(!asset->buffers.empty());
 	auto bufferUri = std::get<fastgltf::sources::URI>(asset->buffers[0].data);
 	REQUIRE(bufferUri.uri.path() == "Unicode❤♻Binary.bin");
-	REQUIRE(bufferUri.uri.fspath() == std::filesystem::path{ u8"Unicode❤♻Binary.bin" });
+	REQUIRE(bufferUri.uri.fspath() == std::filesystem::path{u8"Unicode❤♻Binary.bin"});
 }
 
 TEST_CASE("Test extras callback", "[gltf-loader]") {
@@ -518,11 +530,10 @@ TEST_CASE("Test extras callback", "[gltf-loader]") {
 
 	// lambda callback to parse the glTF JSON from the jsonData buffer
 	auto parseJson = [&](fastgltf::GltfDataGetter& data) {
-		auto extrasCallback = [](simdjson::dom::object *extras, std::size_t objectIndex, fastgltf::Category category,
-								 void *userPointer) {
-			if (category != fastgltf::Category::Nodes)
-				return;
-			auto *nodeNames = static_cast<std::vector<std::string> *>(userPointer);
+		auto extrasCallback = [](simdjson::dom::object* extras, std::size_t objectIndex,
+								 fastgltf::Category category, void* userPointer) {
+			if (category != fastgltf::Category::Nodes) return;
+			auto* nodeNames = static_cast<std::vector<std::string>*>(userPointer);
 			nodeNames->resize(fastgltf::max(nodeNames->size(), objectIndex + 1));
 
 			std::string_view nodeName;
@@ -555,13 +566,11 @@ TEST_CASE("Test extras callback", "[gltf-loader]") {
 
 	SECTION("Re-export asset") {
 		auto extrasWriteCallback = [](std::size_t objectIndex, fastgltf::Category category,
-									  void *userPointer) -> std::optional<std::string> {
-			if (category != fastgltf::Category::Nodes)
-				return std::nullopt;
+									  void* userPointer) -> std::optional<std::string> {
+			if (category != fastgltf::Category::Nodes) return std::nullopt;
 
-			auto *nodeNames = static_cast<std::vector<std::string> *>(userPointer);
-			if (objectIndex >= nodeNames->size())
-				return std::nullopt; // TODO: Error?
+			auto* nodeNames = static_cast<std::vector<std::string>*>(userPointer);
+			if (objectIndex >= nodeNames->size()) return std::nullopt;  // TODO: Error?
 			return {std::string(R"({"name":")") + (*nodeNames)[objectIndex] + "\"}"};
 		};
 		fastgltf::Exporter exporter;
@@ -573,7 +582,7 @@ TEST_CASE("Test extras callback", "[gltf-loader]") {
 		// Update the data buffer
 		auto& string = json.get().output;
 		auto reexportedJson = fastgltf::GltfDataBuffer::FromBytes(
-				reinterpret_cast<const std::byte*>(string.data()), string.size());
+			reinterpret_cast<const std::byte*>(string.data()), string.size());
 		REQUIRE(reexportedJson.error() == fastgltf::Error::None);
 
 		nodeNames.clear();

--- a/tests/benchmarks.cpp
+++ b/tests/benchmarks.cpp
@@ -1,196 +1,208 @@
-#include <fstream>
-#include <random>
+#include <simdjson.h>
 
 #include <catch2/benchmark/catch_benchmark.hpp>
 #include <catch2/catch_test_macros.hpp>
-
-#include <simdjson.h>
-
-#include <fastgltf/core.hpp>
 #include <fastgltf/base64.hpp>
+#include <fastgltf/core.hpp>
+#include <fstream>
+#include <random>
+
 #include "gltf_path.hpp"
 
 constexpr auto benchmarkOptions = fastgltf::Options::DontRequireValidAssetMember;
 
 #ifdef HAS_RAPIDJSON
-#include "rapidjson/document.h"
-#include "rapidjson/prettywriter.h"
-#include "rapidjson/rapidjson.h"
-#include "rapidjson/stringbuffer.h"
-#include "rapidjson/writer.h"
+#	include "rapidjson/document.h"
+#	include "rapidjson/prettywriter.h"
+#	include "rapidjson/rapidjson.h"
+#	include "rapidjson/stringbuffer.h"
+#	include "rapidjson/writer.h"
 #endif
 
 #ifdef HAS_TINYGLTF
 // We don't want tinygltf to load/write images.
-#define TINYGLTF_NO_STB_IMAGE_WRITE
-#define TINYGLTF_NO_STB_IMAGE
-#define TINYGLTF_NO_FS
-#define TINYGLTF_IMPLEMENTATION
-#include <tiny_gltf.h>
+#	define TINYGLTF_NO_STB_IMAGE_WRITE
+#	define TINYGLTF_NO_STB_IMAGE
+#	define TINYGLTF_NO_FS
+#	define TINYGLTF_IMPLEMENTATION
+#	include <tiny_gltf.h>
 
-bool tinygltf_FileExistsFunction([[maybe_unused]] const std::string& filename, [[maybe_unused]] void* user) {
-    return true;
+bool tinygltf_FileExistsFunction([[maybe_unused]] const std::string& filename,
+								 [[maybe_unused]] void* user) {
+	return true;
 }
 
-std::string tinygltf_ExpandFilePathFunction(const std::string& filePath, [[maybe_unused]] void* user) {
-    return filePath;
+std::string tinygltf_ExpandFilePathFunction(const std::string& filePath,
+											[[maybe_unused]] void* user) {
+	return filePath;
 }
 
-bool tinygltf_ReadWholeFileFunction(std::vector<unsigned char>* data, std::string*, const std::string&, void*) {
-    // tinygltf checks if size == 1. It also checks if the size is correct for glb files, but
-    // well ignore that for now.
-    data->resize(1);
-    return true;
+bool tinygltf_ReadWholeFileFunction(std::vector<unsigned char>* data, std::string*,
+									const std::string&, void*) {
+	// tinygltf checks if size == 1. It also checks if the size is correct for glb files, but
+	// well ignore that for now.
+	data->resize(1);
+	return true;
 }
 
-bool tinygltf_LoadImageData(tinygltf::Image *image, const int image_idx, std::string *err,
-                   std::string *warn, int req_width, int req_height,
-                   const unsigned char *bytes, int size, void *user_data) {
-    return true;
+bool tinygltf_LoadImageData(tinygltf::Image* image, const int image_idx, std::string* err,
+							std::string* warn, int req_width, int req_height,
+							const unsigned char* bytes, int size, void* user_data) {
+	return true;
 }
 
 void setTinyGLTFCallbacks(tinygltf::TinyGLTF& gltf) {
-    gltf.SetFsCallbacks({
-        tinygltf_FileExistsFunction,
-        tinygltf_ExpandFilePathFunction,
-        tinygltf_ReadWholeFileFunction,
-        nullptr, nullptr,
-    });
-    gltf.SetImageLoader(tinygltf_LoadImageData, nullptr);
+	gltf.SetFsCallbacks({
+		tinygltf_FileExistsFunction,
+		tinygltf_ExpandFilePathFunction,
+		tinygltf_ReadWholeFileFunction,
+		nullptr,
+		nullptr,
+	});
+	gltf.SetImageLoader(tinygltf_LoadImageData, nullptr);
 }
 #endif
 
 #ifdef HAS_CGLTF
-#define CGLTF_IMPLEMENTATION
-#include <cgltf.h>
+#	define CGLTF_IMPLEMENTATION
+#	include <cgltf.h>
 #endif
 
 #ifdef HAS_GLTFRS
-#include "rust/cxx.h"
-#include "gltf-rs-bridge/lib.h"
+#	include "gltf-rs-bridge/lib.h"
+#	include "rust/cxx.h"
 #endif
 
 #ifdef HAS_ASSIMP
-#include <assimp/cimport.h>
-#include <assimp/scene.h>
-#include <assimp/Base64.hpp>
+#	include <assimp/cimport.h>
+#	include <assimp/scene.h>
+
+#	include <assimp/Base64.hpp>
 #endif
 
 fastgltf::StaticVector<std::uint8_t> readFileAsBytes(const std::filesystem::path& filePath) {
-    std::ifstream file(filePath, std::ios::ate | std::ios::binary);
-    if (!file.is_open())
-        throw std::runtime_error(std::string { "Failed to open file: " } + filePath.string());
+	std::ifstream file(filePath, std::ios::ate | std::ios::binary);
+	if (!file.is_open())
+		throw std::runtime_error(std::string{"Failed to open file: "} + filePath.string());
 
-    auto fileSize = file.tellg();
-    fastgltf::StaticVector<std::uint8_t> bytes(static_cast<std::size_t>(fileSize));
-    file.seekg(0, std::ifstream::beg);
-    file.read(reinterpret_cast<char*>(bytes.data()), fileSize);
-    file.close();
-    return bytes;
+	auto fileSize = file.tellg();
+	fastgltf::StaticVector<std::uint8_t> bytes(static_cast<std::size_t>(fileSize));
+	file.seekg(0, std::ifstream::beg);
+	file.read(reinterpret_cast<char*>(bytes.data()), fileSize);
+	file.close();
+	return bytes;
 }
 
 TEST_CASE("Benchmark loading of NewSponza", "[gltf-benchmark]") {
-    if (!std::filesystem::exists(intelSponza / "NewSponza_Main_glTF_002.gltf")) {
-        // NewSponza is not part of gltf-Sample-Models, and therefore not always available.
-        SKIP("Intel's NewSponza (GLTF) is required for this benchmark.");
-    }
+	if (!std::filesystem::exists(intelSponza / "NewSponza_Main_glTF_002.gltf")) {
+		// NewSponza is not part of gltf-Sample-Models, and therefore not always available.
+		SKIP("Intel's NewSponza (GLTF) is required for this benchmark.");
+	}
 
-    fastgltf::Parser parser;
+	fastgltf::Parser parser;
 #ifdef HAS_TINYGLTF
-    tinygltf::TinyGLTF tinygltf;
-    tinygltf::Model model;
-    std::string warn, err;
+	tinygltf::TinyGLTF tinygltf;
+	tinygltf::Model model;
+	std::string warn, err;
 #endif
 
-    auto bytes = readFileAsBytes(intelSponza / "NewSponza_Main_glTF_002.gltf");
+	auto bytes = readFileAsBytes(intelSponza / "NewSponza_Main_glTF_002.gltf");
 	auto jsonData = fastgltf::GltfDataBuffer::FromBytes(
-			reinterpret_cast<const std::byte*>(bytes.data()), bytes.size());
+		reinterpret_cast<const std::byte*>(bytes.data()), bytes.size());
 	REQUIRE(jsonData.error() == fastgltf::Error::None);
 
-    BENCHMARK("Parse NewSponza") {
-        return parser.loadGltfJson(jsonData.get(), intelSponza, benchmarkOptions);
-    };
+	BENCHMARK("Parse NewSponza") {
+		return parser.loadGltfJson(jsonData.get(), intelSponza, benchmarkOptions);
+	};
 
 #ifdef HAS_TINYGLTF
-    setTinyGLTFCallbacks(tinygltf);
-    BENCHMARK("Parse NewSponza with tinygltf") {
-        return tinygltf.LoadASCIIFromString(&model, &err, &warn, reinterpret_cast<char*>(bytes.data()), bytes.size(), intelSponza.string());
-    };
+	setTinyGLTFCallbacks(tinygltf);
+	BENCHMARK("Parse NewSponza with tinygltf") {
+		return tinygltf.LoadASCIIFromString(&model, &err, &warn,
+											reinterpret_cast<char*>(bytes.data()), bytes.size(),
+											intelSponza.string());
+	};
 #endif
 
 #ifdef HAS_CGLTF
-    BENCHMARK("Parse NewSponza with cgltf") {
-        cgltf_options options = {};
-        cgltf_data* data = nullptr;
-        cgltf_result result = cgltf_parse(&options, bytes.data(), bytes.size(), &data);
-        REQUIRE(result == cgltf_result_success);
-        cgltf_free(data);
-        return result;
-    };
+	BENCHMARK("Parse NewSponza with cgltf") {
+		cgltf_options options = {};
+		cgltf_data* data = nullptr;
+		cgltf_result result = cgltf_parse(&options, bytes.data(), bytes.size(), &data);
+		REQUIRE(result == cgltf_result_success);
+		cgltf_free(data);
+		return result;
+	};
 #endif
 
 #ifdef HAS_GLTFRS
 	BENCHMARK("Parse NewSponza with gltf-rs") {
-		auto slice = rust::Slice<const std::uint8_t>(reinterpret_cast<std::uint8_t*>(bytes.data()), bytes.size());
+		auto slice = rust::Slice<const std::uint8_t>(reinterpret_cast<std::uint8_t*>(bytes.data()),
+													 bytes.size());
 		return rust::gltf::run(slice);
 	};
 #endif
 
 #ifdef HAS_ASSIMP
 	BENCHMARK("Parse NewSponza with assimp") {
-		return aiImportFileFromMemory(reinterpret_cast<const char*>(bytes.data()), bytes.size(), 0, nullptr);
+		return aiImportFileFromMemory(reinterpret_cast<const char*>(bytes.data()), bytes.size(), 0,
+									  nullptr);
 	};
 #endif
 }
 
 TEST_CASE("Benchmark base64 decoding from glTF file", "[gltf-benchmark]") {
-    fastgltf::Parser parser;
+	fastgltf::Parser parser;
 #ifdef HAS_TINYGLTF
-    tinygltf::TinyGLTF tinygltf;
-    tinygltf::Model model;
-    std::string warn, err;
+	tinygltf::TinyGLTF tinygltf;
+	tinygltf::Model model;
+	std::string warn, err;
 #endif
 
-    auto cylinderEngine = sampleAssets / "Models" / "MetalRoughSpheres" / "glTF-Embedded";
-    auto bytes = readFileAsBytes(cylinderEngine / "MetalRoughSpheres.gltf");
+	auto cylinderEngine = sampleAssets / "Models" / "MetalRoughSpheres" / "glTF-Embedded";
+	auto bytes = readFileAsBytes(cylinderEngine / "MetalRoughSpheres.gltf");
 	auto jsonData = fastgltf::GltfDataBuffer::FromBytes(
-			reinterpret_cast<const std::byte*>(bytes.data()), bytes.size());
+		reinterpret_cast<const std::byte*>(bytes.data()), bytes.size());
 	REQUIRE(jsonData.error() == fastgltf::Error::None);
 
-    BENCHMARK("Parse MetalRoughSpheres and decode base64") {
-        return parser.loadGltfJson(jsonData.get(), cylinderEngine, benchmarkOptions);
-    };
+	BENCHMARK("Parse MetalRoughSpheres and decode base64") {
+		return parser.loadGltfJson(jsonData.get(), cylinderEngine, benchmarkOptions);
+	};
 
 #ifdef HAS_TINYGLTF
-    setTinyGLTFCallbacks(tinygltf);
-    BENCHMARK("MetalRoughSpheres decode with tinygltf") {
-        return tinygltf.LoadASCIIFromString(&model, &err, &warn, reinterpret_cast<char*>(bytes.data()), bytes.size(), cylinderEngine.string());
-    };
+	setTinyGLTFCallbacks(tinygltf);
+	BENCHMARK("MetalRoughSpheres decode with tinygltf") {
+		return tinygltf.LoadASCIIFromString(&model, &err, &warn,
+											reinterpret_cast<char*>(bytes.data()), bytes.size(),
+											cylinderEngine.string());
+	};
 #endif
 
 #ifdef HAS_CGLTF
-    BENCHMARK("MetalRoughSpheres decode with cgltf") {
-        cgltf_options options = {};
-        cgltf_data* data = nullptr;
-        auto filePath = cylinderEngine.string();
-        cgltf_result result = cgltf_parse(&options, bytes.data(), bytes.size(), &data);
-        REQUIRE(result == cgltf_result_success);
-        result = cgltf_load_buffers(&options, data, filePath.c_str());
-        cgltf_free(data);
-        return result;
-    };
+	BENCHMARK("MetalRoughSpheres decode with cgltf") {
+		cgltf_options options = {};
+		cgltf_data* data = nullptr;
+		auto filePath = cylinderEngine.string();
+		cgltf_result result = cgltf_parse(&options, bytes.data(), bytes.size(), &data);
+		REQUIRE(result == cgltf_result_success);
+		result = cgltf_load_buffers(&options, data, filePath.c_str());
+		cgltf_free(data);
+		return result;
+	};
 #endif
 
 #ifdef HAS_GLTFRS
 	BENCHMARK("MetalRoughSpheres with gltf-rs") {
-		auto slice = rust::Slice<const std::uint8_t>(reinterpret_cast<std::uint8_t*>(bytes.data()), bytes.size());
+		auto slice = rust::Slice<const std::uint8_t>(reinterpret_cast<std::uint8_t*>(bytes.data()),
+													 bytes.size());
 		return rust::gltf::run(slice);
 	};
 #endif
 
 #ifdef HAS_ASSIMP
 	BENCHMARK("MetalRoughSpheres with assimp") {
-		const auto* scene = aiImportFileFromMemory(reinterpret_cast<const char*>(bytes.data()), bytes.size(), 0, nullptr);
+		const auto* scene = aiImportFileFromMemory(reinterpret_cast<const char*>(bytes.data()),
+												   bytes.size(), 0, nullptr);
 		REQUIRE(scene != nullptr);
 		return scene;
 	};
@@ -198,166 +210,177 @@ TEST_CASE("Benchmark base64 decoding from glTF file", "[gltf-benchmark]") {
 }
 
 TEST_CASE("Benchmark raw JSON parsing", "[gltf-benchmark]") {
-    fastgltf::Parser parser;
+	fastgltf::Parser parser;
 #ifdef HAS_TINYGLTF
-    tinygltf::TinyGLTF tinygltf;
-    tinygltf::Model model;
-    std::string warn, err;
+	tinygltf::TinyGLTF tinygltf;
+	tinygltf::Model model;
+	std::string warn, err;
 #endif
 
-    auto sponzaPath = sampleAssets / "Models" / "Sponza" / "glTF";
-    auto bytes = readFileAsBytes(sponzaPath / "Sponza.gltf");
+	auto sponzaPath = sampleAssets / "Models" / "Sponza" / "glTF";
+	auto bytes = readFileAsBytes(sponzaPath / "Sponza.gltf");
 	auto jsonData = fastgltf::GltfDataBuffer::FromBytes(
-			reinterpret_cast<const std::byte*>(bytes.data()), bytes.size());
+		reinterpret_cast<const std::byte*>(bytes.data()), bytes.size());
 	REQUIRE(jsonData.error() == fastgltf::Error::None);
 
-    BENCHMARK("Parse Sponza.gltf") {
-        return parser.loadGltfJson(jsonData.get(), sponzaPath, benchmarkOptions);
-    };
+	BENCHMARK("Parse Sponza.gltf") {
+		return parser.loadGltfJson(jsonData.get(), sponzaPath, benchmarkOptions);
+	};
 
 #ifdef HAS_TINYGLTF
-    setTinyGLTFCallbacks(tinygltf);
-    BENCHMARK("Parse Sponza.gltf with tinygltf") {
-        return tinygltf.LoadASCIIFromString(&model, &err, &warn, reinterpret_cast<char*>(bytes.data()), bytes.size(), sponzaPath.string());
-    };
+	setTinyGLTFCallbacks(tinygltf);
+	BENCHMARK("Parse Sponza.gltf with tinygltf") {
+		return tinygltf.LoadASCIIFromString(&model, &err, &warn,
+											reinterpret_cast<char*>(bytes.data()), bytes.size(),
+											sponzaPath.string());
+	};
 #endif
 
 #ifdef HAS_CGLTF
-    BENCHMARK("Parse Sponza.gltf with cgltf") {
-        cgltf_options options = {};
-        cgltf_data* data = nullptr;
-        auto filePath = sponzaPath.string();
-        cgltf_result result = cgltf_parse(&options, bytes.data(), bytes.size(), &data);
-        REQUIRE(result == cgltf_result_success);
-        cgltf_free(data);
-        return result;
-    };
+	BENCHMARK("Parse Sponza.gltf with cgltf") {
+		cgltf_options options = {};
+		cgltf_data* data = nullptr;
+		auto filePath = sponzaPath.string();
+		cgltf_result result = cgltf_parse(&options, bytes.data(), bytes.size(), &data);
+		REQUIRE(result == cgltf_result_success);
+		cgltf_free(data);
+		return result;
+	};
 #endif
 
 #ifdef HAS_GLTFRS
 	BENCHMARK("Parse Sponza.gltf with gltf-rs") {
-		auto slice = rust::Slice<const std::uint8_t>(reinterpret_cast<std::uint8_t*>(bytes.data()), bytes.size());
+		auto slice = rust::Slice<const std::uint8_t>(reinterpret_cast<std::uint8_t*>(bytes.data()),
+													 bytes.size());
 		return rust::gltf::run(slice);
 	};
 #endif
 
 #ifdef HAS_ASSIMP
 	BENCHMARK("Parse Sponza.gltf with assimp") {
-		return aiImportFileFromMemory(reinterpret_cast<const char*>(bytes.data()), bytes.size(), 0, nullptr);
+		return aiImportFileFromMemory(reinterpret_cast<const char*>(bytes.data()), bytes.size(), 0,
+									  nullptr);
 	};
 #endif
 }
 
 TEST_CASE("Benchmark massive gltf file", "[gltf-benchmark]") {
-    if (!std::filesystem::exists(bistroPath / "bistro.gltf")) {
-        // Bistro is not part of gltf-Sample-Models, and therefore not always available.
-        SKIP("Amazon's Bistro (GLTF) is required for this benchmark.");
-    }
+	if (!std::filesystem::exists(bistroPath / "bistro.gltf")) {
+		// Bistro is not part of gltf-Sample-Models, and therefore not always available.
+		SKIP("Amazon's Bistro (GLTF) is required for this benchmark.");
+	}
 
-    fastgltf::Parser parser(fastgltf::Extensions::KHR_mesh_quantization);
+	fastgltf::Parser parser(fastgltf::Extensions::KHR_mesh_quantization);
 #ifdef HAS_TINYGLTF
-    tinygltf::TinyGLTF tinygltf;
-    tinygltf::Model model;
-    std::string warn, err;
+	tinygltf::TinyGLTF tinygltf;
+	tinygltf::Model model;
+	std::string warn, err;
 #endif
 
-    auto bytes = readFileAsBytes(bistroPath / "bistro.gltf");
+	auto bytes = readFileAsBytes(bistroPath / "bistro.gltf");
 	auto jsonData = fastgltf::GltfDataBuffer::FromBytes(
-			reinterpret_cast<const std::byte*>(bytes.data()), bytes.size());
+		reinterpret_cast<const std::byte*>(bytes.data()), bytes.size());
 	REQUIRE(jsonData.error() == fastgltf::Error::None);
 
-    BENCHMARK("Parse Bistro") {
+	BENCHMARK("Parse Bistro") {
 		return parser.loadGltfJson(jsonData.get(), bistroPath, benchmarkOptions);
-    };
+	};
 
 #ifdef HAS_TINYGLTF
-    setTinyGLTFCallbacks(tinygltf);
-    BENCHMARK("Parse Bistro with tinygltf") {
-        return tinygltf.LoadASCIIFromString(&model, &err, &warn, reinterpret_cast<char*>(bytes.data()), bytes.size(), bistroPath.string());
-    };
+	setTinyGLTFCallbacks(tinygltf);
+	BENCHMARK("Parse Bistro with tinygltf") {
+		return tinygltf.LoadASCIIFromString(&model, &err, &warn,
+											reinterpret_cast<char*>(bytes.data()), bytes.size(),
+											bistroPath.string());
+	};
 #endif
 
 #ifdef HAS_CGLTF
-    BENCHMARK("Parse Bistro with cgltf") {
-        cgltf_options options = {};
-        cgltf_data* data = nullptr;
-        auto filePath = bistroPath.string();
-        cgltf_result result = cgltf_parse(&options, bytes.data(), bytes.size(), &data);
-        REQUIRE(result == cgltf_result_success);
-        cgltf_free(data);
-        return result;
-    };
+	BENCHMARK("Parse Bistro with cgltf") {
+		cgltf_options options = {};
+		cgltf_data* data = nullptr;
+		auto filePath = bistroPath.string();
+		cgltf_result result = cgltf_parse(&options, bytes.data(), bytes.size(), &data);
+		REQUIRE(result == cgltf_result_success);
+		cgltf_free(data);
+		return result;
+	};
 #endif
 
 #ifdef HAS_GLTFRS
 	BENCHMARK("Parse Bistro with gltf-rs") {
-		auto slice = rust::Slice<const std::uint8_t>(reinterpret_cast<std::uint8_t*>(bytes.data()), bytes.size());
+		auto slice = rust::Slice<const std::uint8_t>(reinterpret_cast<std::uint8_t*>(bytes.data()),
+													 bytes.size());
 		return rust::gltf::run(slice);
 	};
 #endif
 
 #ifdef HAS_ASSIMP
 	BENCHMARK("Parse Bistro with assimp") {
-		return aiImportFileFromMemory(reinterpret_cast<const char*>(bytes.data()), bytes.size(), 0, nullptr);
+		return aiImportFileFromMemory(reinterpret_cast<const char*>(bytes.data()), bytes.size(), 0,
+									  nullptr);
 	};
 #endif
 }
 
 TEST_CASE("Compare parsing performance with minified documents", "[gltf-benchmark]") {
-    auto sponzaPath = sampleAssets / "Models" / "Sponza" / "glTF";
-    auto bytes = readFileAsBytes(sponzaPath / "Sponza.gltf");
+	auto sponzaPath = sampleAssets / "Models" / "Sponza" / "glTF";
+	auto bytes = readFileAsBytes(sponzaPath / "Sponza.gltf");
 	auto jsonData = fastgltf::GltfDataBuffer::FromBytes(
-			reinterpret_cast<const std::byte*>(bytes.data()), bytes.size());
+		reinterpret_cast<const std::byte*>(bytes.data()), bytes.size());
 	REQUIRE(jsonData.error() == fastgltf::Error::None);
 
-    // Create a minified JSON string
-    std::vector<uint8_t> minified(bytes.size());
-    size_t dstLen = 0;
-    auto result = simdjson::minify(reinterpret_cast<const char*>(bytes.data()), bytes.size(),
-                                   reinterpret_cast<char*>(minified.data()), dstLen);
-    REQUIRE(result == simdjson::SUCCESS);
-    minified.resize(dstLen);
+	// Create a minified JSON string
+	std::vector<uint8_t> minified(bytes.size());
+	size_t dstLen = 0;
+	auto result = simdjson::minify(reinterpret_cast<const char*>(bytes.data()), bytes.size(),
+								   reinterpret_cast<char*>(minified.data()), dstLen);
+	REQUIRE(result == simdjson::SUCCESS);
+	minified.resize(dstLen);
 
-    // For completeness, benchmark minifying the JSON
-    BENCHMARK("Minify Sponza.gltf") {
-        auto result = simdjson::minify(reinterpret_cast<const char*>(bytes.data()), bytes.size(),
-                                       reinterpret_cast<char*>(minified.data()), dstLen);
-        REQUIRE(result == simdjson::SUCCESS);
-        return result;
-    };
+	// For completeness, benchmark minifying the JSON
+	BENCHMARK("Minify Sponza.gltf") {
+		auto result = simdjson::minify(reinterpret_cast<const char*>(bytes.data()), bytes.size(),
+									   reinterpret_cast<char*>(minified.data()), dstLen);
+		REQUIRE(result == simdjson::SUCCESS);
+		return result;
+	};
 
 	auto minifiedJsonData = fastgltf::GltfDataBuffer::FromBytes(
-			reinterpret_cast<const std::byte*>(bytes.data()), bytes.size());
+		reinterpret_cast<const std::byte*>(bytes.data()), bytes.size());
 	REQUIRE(minifiedJsonData.error() == fastgltf::Error::None);
 
-    fastgltf::Parser parser;
-    BENCHMARK("Parse Sponza.gltf with normal JSON") {
-        return parser.loadGltfJson(jsonData.get(), sponzaPath, benchmarkOptions);
-    };
+	fastgltf::Parser parser;
+	BENCHMARK("Parse Sponza.gltf with normal JSON") {
+		return parser.loadGltfJson(jsonData.get(), sponzaPath, benchmarkOptions);
+	};
 
-    BENCHMARK("Parse Sponza.gltf with minified JSON") {
-        return parser.loadGltfJson(minifiedJsonData.get(), sponzaPath, benchmarkOptions);
-    };
+	BENCHMARK("Parse Sponza.gltf with minified JSON") {
+		return parser.loadGltfJson(minifiedJsonData.get(), sponzaPath, benchmarkOptions);
+	};
 }
 
 TEST_CASE("Small CRC32-C benchmark", "[gltf-benchmark]") {
-    static constexpr std::string_view test = "abcdefghijklmnopqrstuvwxyz";
-    BENCHMARK("Default 1-byte tabular algorithm") {
-        return fastgltf::crc32c(reinterpret_cast<const std::uint8_t*>(test.data()), test.size());
-    };
+	static constexpr std::string_view test = "abcdefghijklmnopqrstuvwxyz";
+	BENCHMARK("Default 1-byte tabular algorithm") {
+		return fastgltf::crc32c(reinterpret_cast<const std::uint8_t*>(test.data()), test.size());
+	};
 #if defined(FASTGLTF_IS_X86)
-    BENCHMARK("SSE4 hardware algorithm") {
-        return fastgltf::sse_crc32c(reinterpret_cast<const std::uint8_t*>(test.data()), test.size());
-    };
+	BENCHMARK("SSE4 hardware algorithm") {
+		return fastgltf::sse_crc32c(reinterpret_cast<const std::uint8_t*>(test.data()),
+									test.size());
+	};
 #elif defined(FASTGLTF_IS_A64)
 	BENCHMARK("ARMv8 hardware CRC32-C algorithm") {
-		return fastgltf::armv8_crc32c(reinterpret_cast<const std::uint8_t*>(test.data()), test.size());
+		return fastgltf::armv8_crc32c(reinterpret_cast<const std::uint8_t*>(test.data()),
+									  test.size());
 	};
 #endif
 }
 
 TEST_CASE("Compare base64 decoding performance", "[gltf-benchmark]") {
-	std::string base64Characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+	std::string base64Characters =
+		"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 	constexpr std::size_t bufferSize = 2 * 1024 * 1024;
 
 	// We'll generate a random base64 buffer
@@ -371,34 +394,32 @@ TEST_CASE("Compare base64 decoding performance", "[gltf-benchmark]") {
 	}
 
 #ifdef HAS_TINYGLTF
-	BENCHMARK("Run tinygltf's base64 decoder") {
-		return tinygltf::base64_decode(generatedData);
-	};
+	BENCHMARK("Run tinygltf's base64 decoder") { return tinygltf::base64_decode(generatedData); };
 #endif
 
 #ifdef HAS_CGLTF
-	cgltf_options options {};
+	cgltf_options options{};
 	BENCHMARK("Run cgltf's base64 decoder") {
 		auto padding = fastgltf::base64::getPadding(generatedData);
 		auto outputSize = fastgltf::base64::getOutputSize(generatedData.size(), padding);
 		std::string output;
 		output.resize(outputSize);
 		auto* outputData = output.data();
-		return cgltf_load_buffer_base64(&options, generatedData.size(), generatedData.data(), reinterpret_cast<void**>(&outputData));
+		return cgltf_load_buffer_base64(&options, generatedData.size(), generatedData.data(),
+										reinterpret_cast<void**>(&outputData));
 	};
 #endif
 
 #ifdef HAS_GLTFRS
 	BENCHMARK("Run base64 Rust library decoder") {
-		auto slice = rust::Slice<const std::uint8_t>(reinterpret_cast<std::uint8_t*>(generatedData.data()), generatedData.size());
+		auto slice = rust::Slice<const std::uint8_t>(
+			reinterpret_cast<std::uint8_t*>(generatedData.data()), generatedData.size());
 		return rust::gltf::run_base64(slice);
 	};
 #endif
 
 #ifdef HAS_ASSIMP
-	BENCHMARK("Run Assimp's base64 decoder") {
-		return Assimp::Base64::Decode(generatedData);
-	};
+	BENCHMARK("Run Assimp's base64 decoder") { return Assimp::Base64::Decode(generatedData); };
 #endif
 
 	BENCHMARK("Run fastgltf's fallback base64 decoder") {
@@ -407,13 +428,15 @@ TEST_CASE("Compare base64 decoding performance", "[gltf-benchmark]") {
 
 #if defined(FASTGLTF_IS_X86)
 	const auto& impls = simdjson::get_available_implementations();
-	if (const auto* sse4 = impls["westmere"]; sse4 != nullptr && sse4->supported_by_runtime_system()) {
+	if (const auto* sse4 = impls["westmere"];
+		sse4 != nullptr && sse4->supported_by_runtime_system()) {
 		BENCHMARK("Run fastgltf's SSE4 base64 decoder") {
 			return fastgltf::base64::sse4_decode(generatedData);
 		};
 	}
 
-	if (const auto* avx2 = impls["haswell"]; avx2 != nullptr && avx2->supported_by_runtime_system()) {
+	if (const auto* avx2 = impls["haswell"];
+		avx2 != nullptr && avx2->supported_by_runtime_system()) {
 		BENCHMARK("Run fastgltf's AVX2 base64 decoder") {
 			return fastgltf::base64::avx2_decode(generatedData);
 		};

--- a/tests/extension_tests.cpp
+++ b/tests/extension_tests.cpp
@@ -1,8 +1,8 @@
+#include <catch2/benchmark/catch_benchmark.hpp>
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
-#include <catch2/benchmark/catch_benchmark.hpp>
-
 #include <fastgltf/core.hpp>
+
 #include "gltf_path.hpp"
 
 // Tests for extension functionality, declared in the same order as the fastgltf::Extensions enum.
@@ -14,7 +14,9 @@ TEST_CASE("Extension KHR_texture_transform", "[gltf-loader]") {
 	REQUIRE(jsonData.isOpen());
 
 	fastgltf::Parser parser(fastgltf::Extensions::KHR_texture_transform);
-	auto asset = parser.loadGltfJson(jsonData, transformTest, fastgltf::Options::DontRequireValidAssetMember, fastgltf::Category::Materials);
+	auto asset =
+		parser.loadGltfJson(jsonData, transformTest, fastgltf::Options::DontRequireValidAssetMember,
+							fastgltf::Category::Materials);
 	REQUIRE(asset.error() == fastgltf::Error::None);
 	REQUIRE(fastgltf::validate(asset.get()) == fastgltf::Error::None);
 
@@ -24,44 +26,47 @@ TEST_CASE("Extension KHR_texture_transform", "[gltf-loader]") {
 	REQUIRE(material.pbrData.baseColorTexture.has_value());
 	REQUIRE(material.pbrData.baseColorTexture->transform != nullptr);
 	REQUIRE(material.pbrData.baseColorTexture->transform->uvOffset[0] == 0.705f);
-	REQUIRE(material.pbrData.baseColorTexture->transform->rotation == Catch::Approx(1.5707963705062866f));
+	REQUIRE(material.pbrData.baseColorTexture->transform->rotation ==
+			Catch::Approx(1.5707963705062866f));
 }
 
 TEST_CASE("Extension KHR_texture_basisu", "[gltf-loader]") {
-    auto stainedLamp = sampleAssets / "Models" / "StainedGlassLamp" / "glTF-KTX-BasisU";
+	auto stainedLamp = sampleAssets / "Models" / "StainedGlassLamp" / "glTF-KTX-BasisU";
 	fastgltf::GltfFileStream jsonData(stainedLamp / "StainedGlassLamp.gltf");
 	REQUIRE(jsonData.isOpen());
 
-    SECTION("Loading KHR_texture_basisu") {
-        fastgltf::Parser parser(fastgltf::Extensions::KHR_texture_basisu);
-        auto asset = parser.loadGltfJson(jsonData, path, fastgltf::Options::DontRequireValidAssetMember,
-									 fastgltf::Category::Textures | fastgltf::Category::Images);
-        REQUIRE(asset.error() == fastgltf::Error::None);
+	SECTION("Loading KHR_texture_basisu") {
+		fastgltf::Parser parser(fastgltf::Extensions::KHR_texture_basisu);
+		auto asset =
+			parser.loadGltfJson(jsonData, path, fastgltf::Options::DontRequireValidAssetMember,
+								fastgltf::Category::Textures | fastgltf::Category::Images);
+		REQUIRE(asset.error() == fastgltf::Error::None);
 		REQUIRE(fastgltf::validate(asset.get()) == fastgltf::Error::None);
 
-        REQUIRE(asset->textures.size() == 19);
-        REQUIRE(!asset->images.empty());
+		REQUIRE(asset->textures.size() == 19);
+		REQUIRE(!asset->images.empty());
 
-        auto& texture = asset->textures[1];
-        REQUIRE(!texture.imageIndex.has_value());
-        REQUIRE(texture.samplerIndex == 0U);
+		auto& texture = asset->textures[1];
+		REQUIRE(!texture.imageIndex.has_value());
+		REQUIRE(texture.samplerIndex == 0U);
 		REQUIRE(texture.basisuImageIndex.has_value());
 		REQUIRE(texture.basisuImageIndex.value() == 1);
 
-        auto& image = asset->images.front();
-        auto* filePath = std::get_if<fastgltf::sources::URI>(&image.data);
-        REQUIRE(filePath != nullptr);
-        REQUIRE(filePath->uri.valid());
-        REQUIRE(filePath->uri.isLocalPath());
-        REQUIRE(filePath->mimeType == fastgltf::MimeType::KTX2);
-    }
+		auto& image = asset->images.front();
+		auto* filePath = std::get_if<fastgltf::sources::URI>(&image.data);
+		REQUIRE(filePath != nullptr);
+		REQUIRE(filePath->uri.valid());
+		REQUIRE(filePath->uri.isLocalPath());
+		REQUIRE(filePath->mimeType == fastgltf::MimeType::KTX2);
+	}
 
-    SECTION("Testing requiredExtensions") {
-        // We specify no extensions, yet the StainedGlassLamp requires KHR_texture_basisu.
-        fastgltf::Parser parser(fastgltf::Extensions::None);
-        auto stainedGlassLamp = parser.loadGltfJson(jsonData, path, fastgltf::Options::DontRequireValidAssetMember);
-        REQUIRE(stainedGlassLamp.error() == fastgltf::Error::MissingExtensions);
-    }
+	SECTION("Testing requiredExtensions") {
+		// We specify no extensions, yet the StainedGlassLamp requires KHR_texture_basisu.
+		fastgltf::Parser parser(fastgltf::Extensions::None);
+		auto stainedGlassLamp =
+			parser.loadGltfJson(jsonData, path, fastgltf::Options::DontRequireValidAssetMember);
+		REQUIRE(stainedGlassLamp.error() == fastgltf::Error::MissingExtensions);
+	}
 }
 
 // TODO: Add tests for MSFT_texture_dds, KHR_mesh_quantization extension
@@ -71,7 +76,8 @@ TEST_CASE("Extension EXT_meshopt_compression", "[gltf-loader]") {
 	fastgltf::GltfFileStream jsonData(brainStem / "BrainStem.gltf");
 	REQUIRE(jsonData.isOpen());
 
-	fastgltf::Parser parser(fastgltf::Extensions::EXT_meshopt_compression | fastgltf::Extensions::KHR_mesh_quantization);
+	fastgltf::Parser parser(fastgltf::Extensions::EXT_meshopt_compression |
+							fastgltf::Extensions::KHR_mesh_quantization);
 	auto asset = parser.loadGltfJson(jsonData, brainStem, fastgltf::Options::None);
 	REQUIRE(asset.error() == fastgltf::Error::None);
 	REQUIRE(fastgltf::validate(asset.get()) == fastgltf::Error::None);
@@ -157,7 +163,8 @@ TEST_CASE("Extension KHR_lights_punctual", "[gltf-loader]") {
 		REQUIRE(jsonData.isOpen());
 
 		fastgltf::Parser parser(fastgltf::Extensions::KHR_lights_punctual);
-		auto asset = parser.loadGltfJson(jsonData, lightsLamp, fastgltf::Options::None, fastgltf::Category::Nodes);
+		auto asset = parser.loadGltfJson(jsonData, lightsLamp, fastgltf::Options::None,
+										 fastgltf::Category::Nodes);
 		REQUIRE(asset.error() == fastgltf::Error::None);
 		REQUIRE(fastgltf::validate(asset.get()) == fastgltf::Error::None);
 
@@ -183,7 +190,8 @@ TEST_CASE("Extension KHR_lights_punctual", "[gltf-loader]") {
 		REQUIRE(jsonData.isOpen());
 
 		fastgltf::Parser parser(fastgltf::Extensions::KHR_lights_punctual);
-		auto asset = parser.loadGltfJson(jsonData, directionalLight, fastgltf::Options::None, fastgltf::Category::Nodes);
+		auto asset = parser.loadGltfJson(jsonData, directionalLight, fastgltf::Options::None,
+										 fastgltf::Category::Nodes);
 		REQUIRE(asset.error() == fastgltf::Error::None);
 		REQUIRE(fastgltf::validate(asset.get()) == fastgltf::Error::None);
 
@@ -200,109 +208,115 @@ TEST_CASE("Extension KHR_lights_punctual", "[gltf-loader]") {
 // TODO: Add tests for EXT_texture_webp extension
 
 TEST_CASE("Extension KHR_materials_specular", "[gltf-loader]") {
-    auto specularTest = sampleAssets / "Models" / "SpecularTest" / "glTF";
+	auto specularTest = sampleAssets / "Models" / "SpecularTest" / "glTF";
 	fastgltf::GltfFileStream jsonData(specularTest / "SpecularTest.gltf");
 	REQUIRE(jsonData.isOpen());
 
-    fastgltf::Parser parser(fastgltf::Extensions::KHR_materials_specular);
-    auto asset = parser.loadGltfJson(jsonData, specularTest, fastgltf::Options::None, fastgltf::Category::Materials);
-    REQUIRE(asset.error() == fastgltf::Error::None);
+	fastgltf::Parser parser(fastgltf::Extensions::KHR_materials_specular);
+	auto asset = parser.loadGltfJson(jsonData, specularTest, fastgltf::Options::None,
+									 fastgltf::Category::Materials);
+	REQUIRE(asset.error() == fastgltf::Error::None);
 	REQUIRE(fastgltf::validate(asset.get()) == fastgltf::Error::None);
 
-    REQUIRE(asset->materials.size() >= 12);
+	REQUIRE(asset->materials.size() >= 12);
 
-    auto& materials = asset->materials;
-    REQUIRE(materials[1].specular != nullptr);
-    REQUIRE(materials[1].specular->specularFactor == 0.0f);
+	auto& materials = asset->materials;
+	REQUIRE(materials[1].specular != nullptr);
+	REQUIRE(materials[1].specular->specularFactor == 0.0f);
 
-    REQUIRE(materials[2].specular != nullptr);
+	REQUIRE(materials[2].specular != nullptr);
 	REQUIRE(materials[2].specular->specularFactor == Catch::Approx(0.051269f));
 
-    REQUIRE(materials[8].specular != nullptr);
+	REQUIRE(materials[8].specular != nullptr);
 	REQUIRE(materials[8].specular->specularColorFactor[0] == Catch::Approx(0.051269f));
 	REQUIRE(materials[8].specular->specularColorFactor[0] == Catch::Approx(0.051269f));
 	REQUIRE(materials[8].specular->specularColorFactor[0] == Catch::Approx(0.051269f));
 
-    REQUIRE(materials[12].specular != nullptr);
-    REQUIRE(materials[12].specular->specularColorTexture.has_value());
-    REQUIRE(materials[12].specular->specularColorTexture.value().textureIndex == 2);
+	REQUIRE(materials[12].specular != nullptr);
+	REQUIRE(materials[12].specular->specularColorTexture.has_value());
+	REQUIRE(materials[12].specular->specularColorTexture.value().textureIndex == 2);
 }
 
 TEST_CASE("Extension KHR_materials_ior and KHR_materials_iridescence", "[gltf-loader]") {
-    auto specularTest = sampleAssets / "Models" / "IridescenceDielectricSpheres" / "glTF";
+	auto specularTest = sampleAssets / "Models" / "IridescenceDielectricSpheres" / "glTF";
 	fastgltf::GltfFileStream jsonData(specularTest / "IridescenceDielectricSpheres.gltf");
 	REQUIRE(jsonData.isOpen());
 
-    fastgltf::Parser parser(fastgltf::Extensions::KHR_materials_iridescence | fastgltf::Extensions::KHR_materials_ior);
-    auto asset = parser.loadGltfJson(jsonData, specularTest, fastgltf::Options::None, fastgltf::Category::Materials);
-    REQUIRE(asset.error() == fastgltf::Error::None);
+	fastgltf::Parser parser(fastgltf::Extensions::KHR_materials_iridescence |
+							fastgltf::Extensions::KHR_materials_ior);
+	auto asset = parser.loadGltfJson(jsonData, specularTest, fastgltf::Options::None,
+									 fastgltf::Category::Materials);
+	REQUIRE(asset.error() == fastgltf::Error::None);
 	REQUIRE(fastgltf::validate(asset.get()) == fastgltf::Error::None);
 
-    REQUIRE(asset->materials.size() >= 50);
+	REQUIRE(asset->materials.size() >= 50);
 
-    auto& materials = asset->materials;
-    REQUIRE(materials[0].iridescence != nullptr);
-    REQUIRE(materials[0].iridescence->iridescenceFactor == 1.0f);
-    REQUIRE(materials[0].iridescence->iridescenceIor == 1.0f);
-    REQUIRE(materials[0].iridescence->iridescenceThicknessMaximum == 100.0f);
+	auto& materials = asset->materials;
+	REQUIRE(materials[0].iridescence != nullptr);
+	REQUIRE(materials[0].iridescence->iridescenceFactor == 1.0f);
+	REQUIRE(materials[0].iridescence->iridescenceIor == 1.0f);
+	REQUIRE(materials[0].iridescence->iridescenceThicknessMaximum == 100.0f);
 
-    REQUIRE(materials[0].ior == 1.0f);
+	REQUIRE(materials[0].ior == 1.0f);
 
-    REQUIRE(materials[7].ior == 1.17f);
+	REQUIRE(materials[7].ior == 1.17f);
 
-    REQUIRE(materials[50].iridescence != nullptr);
-    REQUIRE(materials[50].iridescence->iridescenceFactor == 1.0f);
-    REQUIRE(materials[50].iridescence->iridescenceIor == 1.17f);
-    REQUIRE(materials[50].iridescence->iridescenceThicknessMaximum == 200.0f);
+	REQUIRE(materials[50].iridescence != nullptr);
+	REQUIRE(materials[50].iridescence->iridescenceFactor == 1.0f);
+	REQUIRE(materials[50].iridescence->iridescenceIor == 1.17f);
+	REQUIRE(materials[50].iridescence->iridescenceThicknessMaximum == 200.0f);
 }
 
 TEST_CASE("Extension KHR_materials_volume and KHR_materials_transmission", "[gltf-loader]") {
-    auto beautifulGame = sampleAssets / "Models" / "ABeautifulGame" / "glTF";
+	auto beautifulGame = sampleAssets / "Models" / "ABeautifulGame" / "glTF";
 
 	fastgltf::GltfFileStream jsonData(beautifulGame / "ABeautifulGame.gltf");
 	REQUIRE(jsonData.isOpen());
 
-    fastgltf::Parser parser(fastgltf::Extensions::KHR_materials_volume | fastgltf::Extensions::KHR_materials_transmission);
-    auto asset = parser.loadGltfJson(jsonData, beautifulGame, fastgltf::Options::None, fastgltf::Category::Materials);
-    REQUIRE(asset.error() == fastgltf::Error::None);
+	fastgltf::Parser parser(fastgltf::Extensions::KHR_materials_volume |
+							fastgltf::Extensions::KHR_materials_transmission);
+	auto asset = parser.loadGltfJson(jsonData, beautifulGame, fastgltf::Options::None,
+									 fastgltf::Category::Materials);
+	REQUIRE(asset.error() == fastgltf::Error::None);
 	REQUIRE(fastgltf::validate(asset.get()) == fastgltf::Error::None);
 
-    REQUIRE(asset->materials.size() >= 5);
+	REQUIRE(asset->materials.size() >= 5);
 
-    auto& materials = asset->materials;
-    REQUIRE(materials[5].volume != nullptr);
+	auto& materials = asset->materials;
+	REQUIRE(materials[5].volume != nullptr);
 	REQUIRE(materials[5].volume->thicknessFactor == Catch::Approx(0.2199999988079071f));
 	REQUIRE(materials[5].volume->attenuationColor[0] == Catch::Approx(0.800000011920929f));
 	REQUIRE(materials[5].volume->attenuationColor[1] == Catch::Approx(0.800000011920929f));
 	REQUIRE(materials[5].volume->attenuationColor[2] == Catch::Approx(0.800000011920929f));
 
-    REQUIRE(materials[5].transmission != nullptr);
-    REQUIRE(materials[5].transmission->transmissionFactor == 1.0f);
+	REQUIRE(materials[5].transmission != nullptr);
+	REQUIRE(materials[5].transmission->transmissionFactor == 1.0f);
 }
 
 TEST_CASE("Extension KHR_materials_clearcoat", "[gltf-loader]") {
-    auto clearcoatTest = sampleAssets / "Models" / "ClearCoatTest" / "glTF";
+	auto clearcoatTest = sampleAssets / "Models" / "ClearCoatTest" / "glTF";
 	fastgltf::GltfFileStream jsonData(clearcoatTest / "ClearCoatTest.gltf");
 	REQUIRE(jsonData.isOpen());
 
-    fastgltf::Parser parser(fastgltf::Extensions::KHR_materials_clearcoat);
-    auto asset = parser.loadGltfJson(jsonData, clearcoatTest, fastgltf::Options::None, fastgltf::Category::Materials);
-    REQUIRE(asset.error() == fastgltf::Error::None);
+	fastgltf::Parser parser(fastgltf::Extensions::KHR_materials_clearcoat);
+	auto asset = parser.loadGltfJson(jsonData, clearcoatTest, fastgltf::Options::None,
+									 fastgltf::Category::Materials);
+	REQUIRE(asset.error() == fastgltf::Error::None);
 	REQUIRE(fastgltf::validate(asset.get()) == fastgltf::Error::None);
 
-    REQUIRE(asset->materials.size() >= 7);
+	REQUIRE(asset->materials.size() >= 7);
 
-    auto& materials = asset->materials;
-    REQUIRE(materials[1].clearcoat != nullptr);
-    REQUIRE(materials[1].clearcoat->clearcoatFactor == 1.0f);
-    REQUIRE(materials[1].clearcoat->clearcoatRoughnessFactor == 0.03f);
+	auto& materials = asset->materials;
+	REQUIRE(materials[1].clearcoat != nullptr);
+	REQUIRE(materials[1].clearcoat->clearcoatFactor == 1.0f);
+	REQUIRE(materials[1].clearcoat->clearcoatRoughnessFactor == 0.03f);
 
-    REQUIRE(materials[7].clearcoat != nullptr);
-    REQUIRE(materials[7].clearcoat->clearcoatFactor == 1.0f);
-    REQUIRE(materials[7].clearcoat->clearcoatRoughnessFactor == 1.0f);
-    REQUIRE(materials[7].clearcoat->clearcoatRoughnessTexture.has_value());
-    REQUIRE(materials[7].clearcoat->clearcoatRoughnessTexture->textureIndex == 1);
-    REQUIRE(materials[7].clearcoat->clearcoatRoughnessTexture->texCoordIndex == 0);
+	REQUIRE(materials[7].clearcoat != nullptr);
+	REQUIRE(materials[7].clearcoat->clearcoatFactor == 1.0f);
+	REQUIRE(materials[7].clearcoat->clearcoatRoughnessFactor == 1.0f);
+	REQUIRE(materials[7].clearcoat->clearcoatRoughnessTexture.has_value());
+	REQUIRE(materials[7].clearcoat->clearcoatRoughnessTexture->textureIndex == 1);
+	REQUIRE(materials[7].clearcoat->clearcoatRoughnessTexture->texCoordIndex == 0);
 }
 
 TEST_CASE("Extension KHR_materials_emissive_strength", "[gltf-loader]") {
@@ -326,7 +340,8 @@ TEST_CASE("Extension KHR_materials_sheen", "[gltf-loader]") {
 	fastgltf::GltfFileStream jsonData(sheenChair / "SheenChair.gltf");
 	REQUIRE(jsonData.isOpen());
 
-	fastgltf::Parser parser(fastgltf::Extensions::KHR_materials_sheen | fastgltf::Extensions::KHR_texture_transform);
+	fastgltf::Parser parser(fastgltf::Extensions::KHR_materials_sheen |
+							fastgltf::Extensions::KHR_texture_transform);
 	auto asset = parser.loadGltfJson(jsonData, sheenChair);
 	REQUIRE(asset.error() == fastgltf::Error::None);
 	REQUIRE(fastgltf::validate(asset.get()) == fastgltf::Error::None);
@@ -374,55 +389,58 @@ TEST_CASE("Extension KHR_materials_anisotropy", "[gltf-loader]") {
 }
 
 TEST_CASE("Extension EXT_mesh_gpu_instancing", "[gltf-loader]") {
-    auto simpleInstancingTest = sampleAssets / "Models" / "SimpleInstancing" / "glTF";
+	auto simpleInstancingTest = sampleAssets / "Models" / "SimpleInstancing" / "glTF";
 
 	fastgltf::GltfFileStream jsonData(simpleInstancingTest / "SimpleInstancing.gltf");
 	REQUIRE(jsonData.isOpen());
 
-    fastgltf::Parser parser(fastgltf::Extensions::EXT_mesh_gpu_instancing);
-    auto asset = parser.loadGltfJson(jsonData, simpleInstancingTest, fastgltf::Options::None, fastgltf::Category::Accessors | fastgltf::Category::Nodes);
-    REQUIRE(asset.error() == fastgltf::Error::None);
-    REQUIRE(fastgltf::validate(asset.get()) == fastgltf::Error::None);
+	fastgltf::Parser parser(fastgltf::Extensions::EXT_mesh_gpu_instancing);
+	auto asset = parser.loadGltfJson(jsonData, simpleInstancingTest, fastgltf::Options::None,
+									 fastgltf::Category::Accessors | fastgltf::Category::Nodes);
+	REQUIRE(asset.error() == fastgltf::Error::None);
+	REQUIRE(fastgltf::validate(asset.get()) == fastgltf::Error::None);
 
-    REQUIRE(asset->accessors.size() >= 6);
-    REQUIRE(asset->nodes.size() >= 1);
+	REQUIRE(asset->accessors.size() >= 6);
+	REQUIRE(asset->nodes.size() >= 1);
 
-    auto& nodes = asset->nodes;
-    REQUIRE(nodes[0].instancingAttributes.size() == 3u);
-    REQUIRE(nodes[0].findInstancingAttribute("TRANSLATION") != nodes[0].instancingAttributes.cend());
-    REQUIRE(nodes[0].findInstancingAttribute("SCALE") != nodes[0].instancingAttributes.cend());
-    REQUIRE(nodes[0].findInstancingAttribute("ROTATION") != nodes[0].instancingAttributes.cend());
+	auto& nodes = asset->nodes;
+	REQUIRE(nodes[0].instancingAttributes.size() == 3u);
+	REQUIRE(nodes[0].findInstancingAttribute("TRANSLATION") !=
+			nodes[0].instancingAttributes.cend());
+	REQUIRE(nodes[0].findInstancingAttribute("SCALE") != nodes[0].instancingAttributes.cend());
+	REQUIRE(nodes[0].findInstancingAttribute("ROTATION") != nodes[0].instancingAttributes.cend());
 }
 
 #if FASTGLTF_ENABLE_DEPRECATED_EXT
 TEST_CASE("Extension KHR_materials_pbrSpecularGlossiness", "[gltf-loader]") {
-    auto specularGlossinessTest = sampleAssets / "Models" / "SpecGlossVsMetalRough" / "glTF";
-    fastgltf::GltfFileStream jsonData(specularGlossinessTest / "SpecGlossVsMetalRough.gltf");
-    REQUIRE(jsonData.isOpen());
+	auto specularGlossinessTest = sampleAssets / "Models" / "SpecGlossVsMetalRough" / "glTF";
+	fastgltf::GltfFileStream jsonData(specularGlossinessTest / "SpecGlossVsMetalRough.gltf");
+	REQUIRE(jsonData.isOpen());
 
-    fastgltf::Parser parser(fastgltf::Extensions::KHR_materials_pbrSpecularGlossiness | fastgltf::Extensions::KHR_materials_specular);
-    auto asset = parser.loadGltfJson(jsonData, specularGlossinessTest);
-    REQUIRE(asset.error() == fastgltf::Error::None);
-    REQUIRE(fastgltf::validate(asset.get()) == fastgltf::Error::None);
+	fastgltf::Parser parser(fastgltf::Extensions::KHR_materials_pbrSpecularGlossiness |
+							fastgltf::Extensions::KHR_materials_specular);
+	auto asset = parser.loadGltfJson(jsonData, specularGlossinessTest);
+	REQUIRE(asset.error() == fastgltf::Error::None);
+	REQUIRE(fastgltf::validate(asset.get()) == fastgltf::Error::None);
 
-    REQUIRE(asset->materials.size() == 4);
+	REQUIRE(asset->materials.size() == 4);
 
-    auto& materials = asset->materials;
-    REQUIRE(materials[0].specularGlossiness != nullptr);
+	auto& materials = asset->materials;
+	REQUIRE(materials[0].specularGlossiness != nullptr);
 	REQUIRE(materials[0].specularGlossiness->diffuseFactor == fastgltf::math::nvec4(1));
 	REQUIRE(materials[0].specularGlossiness->specularFactor == fastgltf::math::nvec3(1));
-    REQUIRE(materials[0].specularGlossiness->glossinessFactor == 1.0f);
-    REQUIRE(materials[0].specularGlossiness->diffuseTexture.has_value());
-    REQUIRE(materials[0].specularGlossiness->diffuseTexture.value().textureIndex == 5);
-    REQUIRE(materials[0].specularGlossiness->specularGlossinessTexture.has_value());
-    REQUIRE(materials[0].specularGlossiness->specularGlossinessTexture.value().textureIndex == 6);
+	REQUIRE(materials[0].specularGlossiness->glossinessFactor == 1.0f);
+	REQUIRE(materials[0].specularGlossiness->diffuseTexture.has_value());
+	REQUIRE(materials[0].specularGlossiness->diffuseTexture.value().textureIndex == 5);
+	REQUIRE(materials[0].specularGlossiness->specularGlossinessTexture.has_value());
+	REQUIRE(materials[0].specularGlossiness->specularGlossinessTexture.value().textureIndex == 6);
 
-    REQUIRE(materials[3].specularGlossiness != nullptr);
+	REQUIRE(materials[3].specularGlossiness != nullptr);
 	REQUIRE(materials[3].specularGlossiness->diffuseFactor == fastgltf::math::nvec4(1));
 	REQUIRE(materials[3].specularGlossiness->specularFactor == fastgltf::math::nvec3(0));
-    REQUIRE(materials[3].specularGlossiness->glossinessFactor == 0.0f);
-    REQUIRE(materials[3].specularGlossiness->diffuseTexture.has_value());
-    REQUIRE(materials[3].specularGlossiness->diffuseTexture.value().textureIndex == 7);
+	REQUIRE(materials[3].specularGlossiness->glossinessFactor == 0.0f);
+	REQUIRE(materials[3].specularGlossiness->diffuseTexture.has_value());
+	REQUIRE(materials[3].specularGlossiness->diffuseTexture.value().textureIndex == 7);
 }
 #endif
 
@@ -439,11 +457,12 @@ TEST_CASE("Extension KHR_materials_dispersion", "[gltf-loader]") {
         }
     ]})";
 	auto jsonData = fastgltf::GltfDataBuffer::FromBytes(
-			reinterpret_cast<const std::byte*>(json.data()), json.size());
+		reinterpret_cast<const std::byte*>(json.data()), json.size());
 	REQUIRE(jsonData.error() == fastgltf::Error::None);
 
 	fastgltf::Parser parser(fastgltf::Extensions::KHR_materials_dispersion);
-	auto asset = parser.loadGltfJson(jsonData.get(), {}, fastgltf::Options::DontRequireValidAssetMember);
+	auto asset =
+		parser.loadGltfJson(jsonData.get(), {}, fastgltf::Options::DontRequireValidAssetMember);
 	REQUIRE(asset.error() == fastgltf::Error::None);
 	REQUIRE(fastgltf::validate(asset.get()) == fastgltf::Error::None);
 
@@ -457,7 +476,8 @@ TEST_CASE("Extension KHR_materials_variant", "[gltf-loader]") {
 	fastgltf::GltfFileStream jsonData(velvetSofa / "GlamVelvetSofa.gltf");
 	REQUIRE(jsonData.isOpen());
 
-	fastgltf::Parser parser(fastgltf::Extensions::KHR_materials_variants | fastgltf::Extensions::KHR_texture_transform);
+	fastgltf::Parser parser(fastgltf::Extensions::KHR_materials_variants |
+							fastgltf::Extensions::KHR_texture_transform);
 	auto asset = parser.loadGltfJson(jsonData, velvetSofa, fastgltf::Options::None);
 	REQUIRE(asset.error() == fastgltf::Error::None);
 	REQUIRE(fastgltf::validate(asset.get()) == fastgltf::Error::None);
@@ -486,7 +506,8 @@ TEST_CASE("Extension GODOT_single_root", "[gltf-loader]") {
 	auto godotSingleRootValid = path / "godot_single_root_valid.gltf";
 	fastgltf::GltfFileStream jsonData(godotSingleRootValid);
 	REQUIRE(jsonData.isOpen());
-	auto asset = parser.loadGltfJson(jsonData, godotSingleRootValid, fastgltf::Options::DecomposeNodeMatrices);
+	auto asset = parser.loadGltfJson(jsonData, godotSingleRootValid,
+									 fastgltf::Options::DecomposeNodeMatrices);
 	REQUIRE(asset.error() == fastgltf::Error::None);
 	REQUIRE(fastgltf::validate(asset.get()) == fastgltf::Error::None);
 	SECTION("Valid") {
@@ -503,42 +524,35 @@ TEST_CASE("Extension GODOT_single_root", "[gltf-loader]") {
 		REQUIRE(trs.scale == defaultTRS.scale);
 		REQUIRE(trs.translation == defaultTRS.translation);
 	}
-	SECTION("Invalid - multiple scenes")
-	{
+	SECTION("Invalid - multiple scenes") {
 		asset->scenes.push_back({{1}, "Another Scene"});
 		REQUIRE(asset->scenes.size() == 2);
 		REQUIRE(fastgltf::validate(asset.get()) == fastgltf::Error::InvalidGltf);
 		asset->scenes.pop_back();
 		REQUIRE(fastgltf::validate(asset.get()) == fastgltf::Error::None);
 	}
-	SECTION("Invalid - DefaultScene is non-zero")
-	{
+	SECTION("Invalid - DefaultScene is non-zero") {
 		asset->defaultScene = 1;
 		REQUIRE(fastgltf::validate(asset.get()) == fastgltf::Error::InvalidGltf);
 		asset->defaultScene = 0;
 		REQUIRE(fastgltf::validate(asset.get()) == fastgltf::Error::None);
 	}
-	SECTION("Invalid - scene with non-zero nodeIndex")
-	{
+	SECTION("Invalid - scene with non-zero nodeIndex") {
 		asset->scenes[0].nodeIndices[0] = 1;
 		REQUIRE(fastgltf::validate(asset.get()) == fastgltf::Error::InvalidGltf);
 		asset->scenes[0].nodeIndices[0] = 0;
 		REQUIRE(fastgltf::validate(asset.get()) == fastgltf::Error::None);
 	}
-	SECTION("Invalid - scene with multiple root nodes")
-	{
+	SECTION("Invalid - scene with multiple root nodes") {
 		asset->scenes[0].nodeIndices.push_back(1);
 		REQUIRE(fastgltf::validate(asset.get()) == fastgltf::Error::InvalidGltf);
 		asset->scenes[0].nodeIndices.pop_back();
 		REQUIRE(fastgltf::validate(asset.get()) == fastgltf::Error::None);
 	}
-	SECTION("Invalid - root node with non-default transform")
-	{
-		asset->nodes[0].transform = fastgltf::TRS{
-			fastgltf::math::fvec3(1.0f),
-			fastgltf::math::fquat(1.0f, 1.0f, 1.0f, 1.0f),
-			fastgltf::math::fvec3(0.5f)
-		};
+	SECTION("Invalid - root node with non-default transform") {
+		asset->nodes[0].transform = fastgltf::TRS{fastgltf::math::fvec3(1.0f),
+												  fastgltf::math::fquat(1.0f, 1.0f, 1.0f, 1.0f),
+												  fastgltf::math::fvec3(0.5f)};
 		REQUIRE(fastgltf::validate(asset.get()) == fastgltf::Error::InvalidGltf);
 		asset->nodes[0].transform = fastgltf::TRS{};
 		REQUIRE(fastgltf::validate(asset.get()) == fastgltf::Error::None);
@@ -546,11 +560,14 @@ TEST_CASE("Extension GODOT_single_root", "[gltf-loader]") {
 }
 
 TEST_CASE("KHR_materials_diffuse_transmission", "[gltf-loader]") {
-	auto diffuseTransmissionTest = sampleAssets / "Models" / "DiffuseTransmissionTest" / "glTF" / "DiffuseTransmissionTest.gltf";
+	auto diffuseTransmissionTest = sampleAssets / "Models" / "DiffuseTransmissionTest" / "glTF" /
+								   "DiffuseTransmissionTest.gltf";
 	fastgltf::GltfFileStream jsonData(diffuseTransmissionTest);
 	REQUIRE(jsonData.isOpen());
 
-	fastgltf::Parser parser(fastgltf::Extensions::KHR_materials_diffuse_transmission | fastgltf::Extensions::KHR_materials_unlit | fastgltf::Extensions::KHR_lights_punctual);
+	fastgltf::Parser parser(fastgltf::Extensions::KHR_materials_diffuse_transmission |
+							fastgltf::Extensions::KHR_materials_unlit |
+							fastgltf::Extensions::KHR_lights_punctual);
 	auto asset = parser.loadGltfJson(jsonData, diffuseTransmissionTest);
 	REQUIRE(asset.error() == fastgltf::Error::None);
 	REQUIRE(fastgltf::validate(asset.get()) == fastgltf::Error::None);
@@ -559,14 +576,18 @@ TEST_CASE("KHR_materials_diffuse_transmission", "[gltf-loader]") {
 	REQUIRE(asset->materials[0].diffuseTransmission);
 	REQUIRE(asset->materials[0].diffuseTransmission->diffuseTransmissionFactor == 0.0f);
 	REQUIRE(asset->materials[0].diffuseTransmission->diffuseTransmissionTexture == std::nullopt);
-	REQUIRE(asset->materials[0].diffuseTransmission->diffuseTransmissionColorFactor == fastgltf::math::nvec3(1.0f));
-	REQUIRE(asset->materials[0].diffuseTransmission->diffuseTransmissionColorTexture == std::nullopt);
+	REQUIRE(asset->materials[0].diffuseTransmission->diffuseTransmissionColorFactor ==
+			fastgltf::math::nvec3(1.0f));
+	REQUIRE(asset->materials[0].diffuseTransmission->diffuseTransmissionColorTexture ==
+			std::nullopt);
 
 	REQUIRE(asset->materials[1].diffuseTransmission);
 	REQUIRE(asset->materials[1].diffuseTransmission->diffuseTransmissionFactor == 0.25f);
 	REQUIRE(asset->materials[1].diffuseTransmission->diffuseTransmissionTexture == std::nullopt);
-	REQUIRE(asset->materials[1].diffuseTransmission->diffuseTransmissionColorFactor == fastgltf::math::nvec3(1.0f));
-	REQUIRE(asset->materials[1].diffuseTransmission->diffuseTransmissionColorTexture == std::nullopt);
+	REQUIRE(asset->materials[1].diffuseTransmission->diffuseTransmissionColorFactor ==
+			fastgltf::math::nvec3(1.0f));
+	REQUIRE(asset->materials[1].diffuseTransmission->diffuseTransmissionColorTexture ==
+			std::nullopt);
 
 	REQUIRE(!asset->materials[20].diffuseTransmission);
 }
@@ -578,7 +599,8 @@ TEST_CASE("Extension KHR_implicit_shapes", "[gltf-loader]") {
 	fastgltf::GltfFileStream jsonData(shapeTypes);
 	REQUIRE(jsonData.isOpen());
 
-	fastgltf::Parser parser(fastgltf::Extensions::KHR_implicit_shapes | fastgltf::Extensions::KHR_lights_punctual);
+	fastgltf::Parser parser(fastgltf::Extensions::KHR_implicit_shapes |
+							fastgltf::Extensions::KHR_lights_punctual);
 	auto asset = parser.loadGltfJson(jsonData, shapeTypes.parent_path());
 	REQUIRE(asset.error() == fastgltf::Error::None);
 	REQUIRE(fastgltf::validate(asset.get()) == fastgltf::Error::None);
@@ -586,77 +608,46 @@ TEST_CASE("Extension KHR_implicit_shapes", "[gltf-loader]") {
 	REQUIRE(asset->shapes.size() == 7);
 
 	const auto& box0 = asset->shapes.at(0);
-	fastgltf::visit_exhaustive(fastgltf::visitor{
-	    [](const fastgltf::BoxShape& box) {
-			REQUIRE(box.size.x() == Catch::Approx(0.5285500288009644));
-			REQUIRE(box.size.y() == Catch::Approx(1));
-	        REQUIRE(box.size.z() == Catch::Approx(0.5285500288009644));
-	    },
-		[](const fastgltf::SphereShape& sphere) {
-			REQUIRE(false);
-		},
-		[](const fastgltf::CapsuleShape& capsule) {
-			REQUIRE(false);
-		},
-		[](const fastgltf::CylinderShape& cylinder) {
-			REQUIRE(false);
-		}
-		},
-		box0);
+	fastgltf::visit_exhaustive(fastgltf::visitor{[](const fastgltf::BoxShape& box) {
+		REQUIRE(box.size.x() == Catch::Approx(0.5285500288009644));
+		REQUIRE(box.size.y() == Catch::Approx(1));
+		REQUIRE(box.size.z() == Catch::Approx(0.5285500288009644));
+	}, [](const fastgltf::SphereShape& sphere) { REQUIRE(false); },
+												 [](const fastgltf::CapsuleShape& capsule) {
+		REQUIRE(false);
+	}, [](const fastgltf::CylinderShape& cylinder) { REQUIRE(false); }},
+							   box0);
 
 	const auto& sphere4 = asset->shapes.at(4);
-	fastgltf::visit_exhaustive(fastgltf::visitor{
-		[](const fastgltf::BoxShape& box) {
-			REQUIRE(false);
-		},
-		[](const fastgltf::SphereShape& sphere) {
-			REQUIRE(sphere.radius == Catch::Approx(0.3417187615099374));
-		},
-		[](const fastgltf::CapsuleShape& capsule) {
-			REQUIRE(false);
-		},
-		[](const fastgltf::CylinderShape& cylinder) {
-			REQUIRE(false);
-		}
-		},
+	fastgltf::visit_exhaustive(
+		fastgltf::visitor{[](const fastgltf::BoxShape& box) { REQUIRE(false); },
+						  [](const fastgltf::SphereShape& sphere) {
+		REQUIRE(sphere.radius == Catch::Approx(0.3417187615099374));
+	}, [](const fastgltf::CapsuleShape& capsule) { REQUIRE(false); },
+						  [](const fastgltf::CylinderShape& cylinder) { REQUIRE(false); }},
 		sphere4);
 
 	const auto& capsule6 = asset->shapes.at(6);
-	fastgltf::visit_exhaustive(fastgltf::visitor{
-		[](const fastgltf::BoxShape& box) {
-			REQUIRE(false);
-		},
-		[](const fastgltf::SphereShape& sphere) {
-			REQUIRE(false);
-		},
-		[](const fastgltf::CapsuleShape& capsule) {
-			REQUIRE(capsule.height == Catch::Approx(0.6000000238418579));
-			REQUIRE(capsule.radiusBottom == Catch::Approx(0.25));
-			REQUIRE(capsule.radiusTop == Catch::Approx(0.4000000059604645));
-		},
-		[](const fastgltf::CylinderShape& cylinder) {
-			REQUIRE(false);
-		}
-		},
-		capsule6);
+	fastgltf::visit_exhaustive(fastgltf::visitor{[](const fastgltf::BoxShape& box) {
+		REQUIRE(false);
+	}, [](const fastgltf::SphereShape& sphere) { REQUIRE(false); },
+												 [](const fastgltf::CapsuleShape& capsule) {
+		REQUIRE(capsule.height == Catch::Approx(0.6000000238418579));
+		REQUIRE(capsule.radiusBottom == Catch::Approx(0.25));
+		REQUIRE(capsule.radiusTop == Catch::Approx(0.4000000059604645));
+	}, [](const fastgltf::CylinderShape& cylinder) { REQUIRE(false); }},
+							   capsule6);
 
 	const auto& cylinder2 = asset->shapes.at(2);
-	fastgltf::visit_exhaustive(fastgltf::visitor{
-		[](const fastgltf::BoxShape& box) {
-			REQUIRE(false);
-		},
-		[](const fastgltf::SphereShape& sphere) {
-			REQUIRE(false);
-		},
-		[](const fastgltf::CapsuleShape& capsule) {
-			REQUIRE(false);
-		},
-		[](const fastgltf::CylinderShape& cylinder) {
-			REQUIRE(cylinder.height == Catch::Approx(0.06662015616893768));
-			REQUIRE(cylinder.radiusBottom == Catch::Approx(0.15483441948890686));
-			REQUIRE(cylinder.radiusTop == Catch::Approx(0.15483441948890686));
-		}
-		},
+	fastgltf::visit_exhaustive(
+		fastgltf::visitor{[](const fastgltf::BoxShape& box) { REQUIRE(false); },
+						  [](const fastgltf::SphereShape& sphere) { REQUIRE(false); },
+						  [](const fastgltf::CapsuleShape& capsule) { REQUIRE(false); },
+						  [](const fastgltf::CylinderShape& cylinder) {
+		REQUIRE(cylinder.height == Catch::Approx(0.06662015616893768));
+		REQUIRE(cylinder.radiusBottom == Catch::Approx(0.15483441948890686));
+		REQUIRE(cylinder.radiusTop == Catch::Approx(0.15483441948890686));
+	}},
 		cylinder2);
 }
 #endif
@@ -668,7 +659,8 @@ TEST_CASE("Extension KHR_physics_rigid_bodies simple", "[gltf-loader]") {
 	fastgltf::GltfFileStream jsonData(shapeTypes);
 	REQUIRE(jsonData.isOpen());
 
-	fastgltf::Parser parser(fastgltf::Extensions::KHR_physics_rigid_bodies | fastgltf::Extensions::KHR_lights_punctual);
+	fastgltf::Parser parser(fastgltf::Extensions::KHR_physics_rigid_bodies |
+							fastgltf::Extensions::KHR_lights_punctual);
 	auto asset = parser.loadGltfJson(jsonData, shapeTypes.parent_path());
 	REQUIRE(asset.error() == fastgltf::Error::None);
 	REQUIRE(fastgltf::validate(asset.get()) == fastgltf::Error::None);
@@ -707,7 +699,6 @@ TEST_CASE("Extension KHR_physics_rigid_bodies simple", "[gltf-loader]") {
 	REQUIRE(!node.physicsRigidBody->trigger.has_value());
 	REQUIRE(!node.physicsRigidBody->joint.has_value());
 
-
 	const auto& node10 = asset->nodes.at(11);
 
 	REQUIRE(node10.physicsRigidBody);
@@ -715,18 +706,13 @@ TEST_CASE("Extension KHR_physics_rigid_bodies simple", "[gltf-loader]") {
 	REQUIRE(!node10.physicsRigidBody->collider.has_value());
 
 	REQUIRE(node10.physicsRigidBody->trigger.has_value());
-	fastgltf::visit_exhaustive(fastgltf::visitor{
-		[](const fastgltf::GeometryTrigger& geo) {
-			REQUIRE(geo.geometry.convexHull);
-			REQUIRE(geo.geometry.node == 10);
-			REQUIRE(geo.collisionFilter.has_value());
-			REQUIRE(geo.collisionFilter == 0);
-		},
-		[](const fastgltf::NodeTrigger& node) {
-			REQUIRE(false);
-		}
-		},
-		*node10.physicsRigidBody->trigger);
+	fastgltf::visit_exhaustive(fastgltf::visitor{[](const fastgltf::GeometryTrigger& geo) {
+		REQUIRE(geo.geometry.convexHull);
+		REQUIRE(geo.geometry.node == 10);
+		REQUIRE(geo.collisionFilter.has_value());
+		REQUIRE(geo.collisionFilter == 0);
+	}, [](const fastgltf::NodeTrigger& node) { REQUIRE(false); }},
+							   *node10.physicsRigidBody->trigger);
 
 	REQUIRE(!node10.physicsRigidBody->joint.has_value());
 }
@@ -737,7 +723,8 @@ TEST_CASE("Extension KHR_physics_rigid_bodies complex", "[gltf-loader]") {
 	fastgltf::GltfFileStream jsonData(shapeTypes);
 	REQUIRE(jsonData.isOpen());
 
-	fastgltf::Parser parser(fastgltf::Extensions::KHR_physics_rigid_bodies | fastgltf::Extensions::KHR_lights_punctual);
+	fastgltf::Parser parser(fastgltf::Extensions::KHR_physics_rigid_bodies |
+							fastgltf::Extensions::KHR_lights_punctual);
 	auto asset = parser.loadGltfJson(jsonData, shapeTypes.parent_path());
 	REQUIRE(asset.error() == fastgltf::Error::None);
 	REQUIRE(fastgltf::validate(asset.get()) == fastgltf::Error::None);

--- a/tests/glb_tests.cpp
+++ b/tests/glb_tests.cpp
@@ -1,56 +1,58 @@
-#include <fstream>
-
 #include <catch2/catch_test_macros.hpp>
-
 #include <fastgltf/core.hpp>
 #include <fastgltf/types.hpp>
+#include <fstream>
+
 #include "gltf_path.hpp"
 
 TEST_CASE("Load basic GLB file", "[gltf-loader]") {
-    auto folder = sampleAssets / "Models" / "Box" / "glTF-Binary";
+	auto folder = sampleAssets / "Models" / "Box" / "glTF-Binary";
 	auto jsonData = fastgltf::GltfDataBuffer::FromPath(folder / "Box.glb");
 	REQUIRE(jsonData.error() == fastgltf::Error::None);
 
 	fastgltf::Parser parser;
-    SECTION("Load basic Box.glb") {
-        auto asset = parser.loadGltfBinary(jsonData.get(), folder, fastgltf::Options::None, fastgltf::Category::Buffers);
-        REQUIRE(asset.error() == fastgltf::Error::None);
+	SECTION("Load basic Box.glb") {
+		auto asset = parser.loadGltfBinary(jsonData.get(), folder, fastgltf::Options::None,
+										   fastgltf::Category::Buffers);
+		REQUIRE(asset.error() == fastgltf::Error::None);
 		REQUIRE(fastgltf::validate(asset.get()) == fastgltf::Error::None);
 
-        REQUIRE(asset->buffers.size() == 1);
+		REQUIRE(asset->buffers.size() == 1);
 
-        auto& buffer = asset->buffers.front();
+		auto& buffer = asset->buffers.front();
 		auto* array = std::get_if<fastgltf::sources::Array>(&buffer.data);
-        REQUIRE(array != nullptr);
+		REQUIRE(array != nullptr);
 		REQUIRE(array->bytes.size() == 1664 - 1016);
-    }
+	}
 
-    SECTION("Load basic Box.glb and load buffers") {
-        auto asset = parser.loadGltfBinary(jsonData.get(), folder, fastgltf::Options::None, fastgltf::Category::Buffers);
-        REQUIRE(asset.error() == fastgltf::Error::None);
+	SECTION("Load basic Box.glb and load buffers") {
+		auto asset = parser.loadGltfBinary(jsonData.get(), folder, fastgltf::Options::None,
+										   fastgltf::Category::Buffers);
+		REQUIRE(asset.error() == fastgltf::Error::None);
 		REQUIRE(fastgltf::validate(asset.get()) == fastgltf::Error::None);
 
-        REQUIRE(asset->buffers.size() == 1);
+		REQUIRE(asset->buffers.size() == 1);
 
-        auto& buffer = asset->buffers.front();
-        auto* bufferVector = std::get_if<fastgltf::sources::Array>(&buffer.data);
-        REQUIRE(bufferVector != nullptr);
-        REQUIRE(!bufferVector->bytes.empty());
-        REQUIRE(static_cast<uint64_t>(bufferVector->bytes.size() - buffer.byteLength) < 3);
-    }
+		auto& buffer = asset->buffers.front();
+		auto* bufferVector = std::get_if<fastgltf::sources::Array>(&buffer.data);
+		REQUIRE(bufferVector != nullptr);
+		REQUIRE(!bufferVector->bytes.empty());
+		REQUIRE(static_cast<uint64_t>(bufferVector->bytes.size() - buffer.byteLength) < 3);
+	}
 
-    SECTION("Load GLB by bytes") {
-        std::ifstream file(folder / "Box.glb", std::ios::binary | std::ios::ate);
-        auto length = static_cast<size_t>(file.tellg());
-        file.seekg(0, std::ifstream::beg);
-        std::vector<uint8_t> bytes(length);
-        file.read(reinterpret_cast<char*>(bytes.data()), static_cast<std::streamsize>(length));
+	SECTION("Load GLB by bytes") {
+		std::ifstream file(folder / "Box.glb", std::ios::binary | std::ios::ate);
+		auto length = static_cast<size_t>(file.tellg());
+		file.seekg(0, std::ifstream::beg);
+		std::vector<uint8_t> bytes(length);
+		file.read(reinterpret_cast<char*>(bytes.data()), static_cast<std::streamsize>(length));
 
 		auto byteBuffer = fastgltf::GltfDataBuffer::FromBytes(
-				reinterpret_cast<const std::byte*>(bytes.data()), length);
+			reinterpret_cast<const std::byte*>(bytes.data()), length);
 		REQUIRE(byteBuffer.error() == fastgltf::Error::None);
 
-        auto asset = parser.loadGltfBinary(byteBuffer.get(), folder, fastgltf::Options::None, fastgltf::Category::Buffers);
-        REQUIRE(asset.error() == fastgltf::Error::None);
-    }
+		auto asset = parser.loadGltfBinary(byteBuffer.get(), folder, fastgltf::Options::None,
+										   fastgltf::Category::Buffers);
+		REQUIRE(asset.error() == fastgltf::Error::None);
+	}
 }

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,19 +1,21 @@
+#include <catch2/catch_session.hpp>
 #include <iostream>
 
-#include <catch2/catch_session.hpp>
 #include "gltf_path.hpp"
 
 #ifdef _WIN32
-#include <windows.h>
+#	include <windows.h>
 #elif defined(__APPLE__) || defined(unix)
-#include <sys/resource.h>
-#include <unistd.h>
+#	include <sys/resource.h>
+#	include <unistd.h>
 #endif
 
 // See https://github.com/catchorg/Catch2/blob/v3.5.4/docs/own-main.md
 int main(int argc, char* argv[]) {
 	if (!is_directory(sampleAssets) || is_empty(sampleAssets)) {
-		std::cerr << "The sample models were not found. Please check the README for more information.\n" << std::endl;
+		std::cerr
+			<< "The sample models were not found. Please check the README for more information.\n"
+			<< std::endl;
 		return -1;
 	}
 

--- a/tests/math_tests.cpp
+++ b/tests/math_tests.cpp
@@ -1,65 +1,60 @@
-#include <random>
-
-#include <fastgltf/math.hpp>
 #include <fastgltf/core.hpp>
-#include "gltf_path.hpp"
-
+#include <fastgltf/math.hpp>
 #include <glm/glm.hpp>
 #include <glm/gtc/type_ptr.hpp>
-#include <glm/gtx/quaternion.hpp>
 #include <glm/gtx/matrix_decompose.hpp>
-
+#include <glm/gtx/quaternion.hpp>
 #include <ostream>
+#include <random>
 
-// We need these operator<< overloads for vector types to get proper output from Catch2 on assertions.
+#include "gltf_path.hpp"
+
+// We need these operator<< overloads for vector types to get proper output from Catch2 on
+// assertions.
 template <std::size_t N>
-std::ostream& operator <<(std::ostream& os, const fastgltf::math::vec<float, N>& value) {
+std::ostream& operator<<(std::ostream& os, const fastgltf::math::vec<float, N>& value) {
 	os << "vec<float," << N << ">(" << std::setprecision(std::numeric_limits<float>::digits10);
 	for (std::size_t i = 0; i < N; ++i) {
 		os << value[i];
-		if (i + 1 != N)
-			os << ',';
+		if (i + 1 != N) os << ',';
 	}
-    os << ')';
-    return os;
+	os << ')';
+	return os;
 }
 
 template <std::size_t N, std::size_t M>
-std::ostream& operator <<(std::ostream& os, const fastgltf::math::mat<float, N, M>& value) {
-	os << "mat<float," << N << ',' << M << ">(" << std::setprecision(std::numeric_limits<float>::digits10);
+std::ostream& operator<<(std::ostream& os, const fastgltf::math::mat<float, N, M>& value) {
+	os << "mat<float," << N << ',' << M << ">("
+	   << std::setprecision(std::numeric_limits<float>::digits10);
 	for (std::size_t i = 0; i < M; ++i) {
 		os << '[';
 		for (std::size_t j = 0; j < N; ++j) {
 			os << value.col(i)[j];
-			if (j + 1 != N)
-				os << ',';
+			if (j + 1 != N) os << ',';
 		}
 		os << ']';
-		if (i + 1 != M)
-			os << ',';
+		if (i + 1 != M) os << ',';
 	}
 	os << ')';
 	return os;
 }
 
 template <glm::length_t N>
-std::ostream& operator <<(std::ostream& os, const glm::vec<N, float>& value) {
+std::ostream& operator<<(std::ostream& os, const glm::vec<N, float>& value) {
 	os << "glm::vec<" << N << ",float>(" << std::setprecision(std::numeric_limits<float>::digits10);
 	for (glm::length_t i = 0; i < N; ++i) {
 		os << value[i];
-		if (i + 1 != N)
-			os << ',';
+		if (i + 1 != N) os << ',';
 	}
-    os << ')';
-    return os;
+	os << ')';
+	return os;
 }
 
-std::ostream& operator <<(std::ostream& os, const glm::quat& value) {
+std::ostream& operator<<(std::ostream& os, const glm::quat& value) {
 	os << "glm::quat<float>(" << std::setprecision(std::numeric_limits<float>::digits10);
 	for (glm::length_t i = 0; i < glm::quat::length(); ++i) {
 		os << value[i];
-		if (i + 1 != glm::quat::length())
-			os << ',';
+		if (i + 1 != glm::quat::length()) os << ',';
 	}
 	os << ')';
 	return os;
@@ -69,7 +64,7 @@ std::ostream& operator <<(std::ostream& os, const glm::quat& value) {
 
 TEST_CASE("Vector initialization", "[maths]") {
 	SECTION("Default init") {
-		fastgltf::math::fvec4 vector {};
+		fastgltf::math::fvec4 vector{};
 		REQUIRE(vector.x() == 0.0f);
 		REQUIRE(vector.y() == 0.0f);
 		REQUIRE(vector.z() == 0.0f);
@@ -200,10 +195,8 @@ TEST_CASE("Vector operations", "[maths]") {
 
 TEST_CASE("Matrix operations", "[maths]") {
 	SECTION("Transposing") {
-		fastgltf::math::fmat<3, 2> m(
-			fastgltf::math::fvec3(1, 2, 3),
-			fastgltf::math::fvec3(4, 1, 5)
-		);
+		fastgltf::math::fmat<3, 2> m(fastgltf::math::fvec3(1, 2, 3),
+									 fastgltf::math::fvec3(4, 1, 5));
 		REQUIRE(m.row(0) == fastgltf::math::fvec2(1, 4));
 		REQUIRE(m.row(1) == fastgltf::math::fvec2(2, 1));
 		REQUIRE(m.row(2) == fastgltf::math::fvec2(3, 5));
@@ -215,10 +208,8 @@ TEST_CASE("Matrix operations", "[maths]") {
 	}
 
 	SECTION("Determinant", "[maths]") {
-		fastgltf::math::fmat3x3 m(
-			fastgltf::math::fvec3(7, 0, -3),
-			fastgltf::math::fvec3(2, 3, 4),
-			fastgltf::math::fvec3(1, -1, -2));
+		fastgltf::math::fmat3x3 m(fastgltf::math::fvec3(7, 0, -3), fastgltf::math::fvec3(2, 3, 4),
+								  fastgltf::math::fvec3(1, -1, -2));
 		REQUIRE(determinant(m) == 1);
 	}
 }
@@ -230,11 +221,15 @@ TEST_CASE("Test TRS parsing and optional decomposition", "[maths]") {
 
 		// Parse once without decomposing, once with decomposing the matrix.
 		fastgltf::Parser parser;
-		auto assetWithMatrix = parser.loadGltfJson(jsonData, path, fastgltf::Options::None, fastgltf::Category::Nodes | fastgltf::Category::Cameras);
+		auto assetWithMatrix =
+			parser.loadGltfJson(jsonData, path, fastgltf::Options::None,
+								fastgltf::Category::Nodes | fastgltf::Category::Cameras);
 		REQUIRE(assetWithMatrix.error() == fastgltf::Error::None);
 		REQUIRE(fastgltf::validate(assetWithMatrix.get()) == fastgltf::Error::None);
 
-		auto assetDecomposed = parser.loadGltfJson(jsonData, path, fastgltf::Options::DecomposeNodeMatrices, fastgltf::Category::Nodes | fastgltf::Category::Cameras);
+		auto assetDecomposed =
+			parser.loadGltfJson(jsonData, path, fastgltf::Options::DecomposeNodeMatrices,
+								fastgltf::Category::Nodes | fastgltf::Category::Cameras);
 		REQUIRE(assetDecomposed.error() == fastgltf::Error::None);
 		REQUIRE(fastgltf::validate(assetDecomposed.get()) == fastgltf::Error::None);
 
@@ -242,25 +237,30 @@ TEST_CASE("Test TRS parsing and optional decomposition", "[maths]") {
 		REQUIRE(assetDecomposed->cameras.size() == 1);
 		REQUIRE(assetWithMatrix->nodes.size() == 2);
 		REQUIRE(assetDecomposed->nodes.size() == 2);
-		REQUIRE(std::holds_alternative<fastgltf::math::fmat4x4>(assetWithMatrix->nodes.back().transform));
+		REQUIRE(std::holds_alternative<fastgltf::math::fmat4x4>(
+			assetWithMatrix->nodes.back().transform));
 		REQUIRE(std::holds_alternative<fastgltf::TRS>(assetDecomposed->nodes.back().transform));
 
 		// Get the TRS components from the first node and use them as the test data for decomposing.
-		const auto* pDefaultTRS = std::get_if<fastgltf::TRS>(&assetWithMatrix->nodes.front().transform);
+		const auto* pDefaultTRS =
+			std::get_if<fastgltf::TRS>(&assetWithMatrix->nodes.front().transform);
 		REQUIRE(pDefaultTRS != nullptr);
 		auto translation = glm::make_vec3(pDefaultTRS->translation.data());
 		auto rotation = glm::make_quat(pDefaultTRS->rotation.data());
 		auto scale = glm::make_vec3(pDefaultTRS->scale.data());
 		auto rotationMatrix = glm::toMat4(rotation);
-		auto transform = glm::translate(glm::mat4(1.0f), translation) * rotationMatrix * glm::scale(glm::mat4(1.0f), scale);
+		auto transform = glm::translate(glm::mat4(1.0f), translation) * rotationMatrix *
+						 glm::scale(glm::mat4(1.0f), scale);
 
 		// Check if the parsed matrix is correct.
-		const auto* pMatrix = std::get_if<fastgltf::math::fmat4x4>(&assetWithMatrix->nodes.back().transform);
+		const auto* pMatrix =
+			std::get_if<fastgltf::math::fmat4x4>(&assetWithMatrix->nodes.back().transform);
 		REQUIRE(pMatrix != nullptr);
 		REQUIRE(glm::make_mat4x4(&pMatrix->col(0)[0]) == transform);
 
 		// Check if the decomposed components equal the original components.
-		const auto* pDecomposedTRS = std::get_if<fastgltf::TRS>(&assetDecomposed->nodes.back().transform);
+		const auto* pDecomposedTRS =
+			std::get_if<fastgltf::TRS>(&assetDecomposed->nodes.back().transform);
 		REQUIRE(glm::make_vec3(pDecomposedTRS->translation.data()) == translation);
 		REQUIRE(glm::make_quat(pDecomposedTRS->rotation.data()) == rotation);
 		REQUIRE(glm::make_vec3(pDecomposedTRS->scale.data()) == scale);
@@ -269,11 +269,13 @@ TEST_CASE("Test TRS parsing and optional decomposition", "[maths]") {
 	SECTION("Test decomposition against glm decomposition") {
 		// Some random complex transform matrix from one of the glTF sample models.
 		const fastgltf::math::fmat4x4 matrix(
-			fastgltf::math::fvec4(-0.4234085381031037F, -0.9059388637542724F, -7.575183536001616e-11F, 0.0F),
-			fastgltf::math::fvec4(-0.9059388637542724F, 0.4234085381031037F, -4.821281221478735e-11F, 0.0F),
+			fastgltf::math::fvec4(-0.4234085381031037F, -0.9059388637542724F,
+								  -7.575183536001616e-11F, 0.0F),
+			fastgltf::math::fvec4(-0.9059388637542724F, 0.4234085381031037F,
+								  -4.821281221478735e-11F, 0.0F),
 			fastgltf::math::fvec4(7.575183536001616e-11F, 4.821281221478735e-11F, -1.0F, 0.0F),
-			fastgltf::math::fvec4(-90.59386444091796F, -24.379817962646489F, -40.05522918701172F, 1.0F)
-		);
+			fastgltf::math::fvec4(-90.59386444091796F, -24.379817962646489F, -40.05522918701172F,
+								  1.0F));
 
 		fastgltf::math::fvec3 translation, scale;
 		fastgltf::math::fquat rotation;
@@ -290,7 +292,9 @@ TEST_CASE("Test TRS parsing and optional decomposition", "[maths]") {
 		// future, but I suspect using double in the decompose functions should help mitigate most
 		// of it.
 		REQUIRE(glm::make_vec3(translation.data()) == glmTranslation);
-		REQUIRE(glm::all(glm::epsilonEqual(glm::make_quat(rotation.data()), glmRotation, glm::epsilon<float>() * 10)));
-		REQUIRE(glm::all(glm::epsilonEqual(glm::make_vec3(scale.data()), glmScale, glm::epsilon<float>())));
+		REQUIRE(glm::all(glm::epsilonEqual(glm::make_quat(rotation.data()), glmRotation,
+										   glm::epsilon<float>() * 10)));
+		REQUIRE(glm::all(
+			glm::epsilonEqual(glm::make_vec3(scale.data()), glmScale, glm::epsilon<float>())));
 	}
 }

--- a/tests/optional_tests.cpp
+++ b/tests/optional_tests.cpp
@@ -6,13 +6,23 @@ TEST_CASE("Test basic Optional interface", "[optional-tests]") {
 	// We have no specialization for std::uint32_t, and therefore this is just
 	// a std::optional with a bool field padded by 3 bytes.
 	fastgltf::Optional<std::uint32_t> optional;
-	static_assert(sizeof(optional) > sizeof(std::uint32_t));
+	REQUIRE(sizeof(optional) > sizeof(std::uint32_t));
 }
 
 TEST_CASE("Test Optional float specialization", "[optional-tests]") {
-	fastgltf::Optional<double> doptional;
-	static_assert((std::numeric_limits<double>::is_iec559 && sizeof(doptional) == sizeof(double)) || !std::numeric_limits<double>::is_iec559);
-
 	fastgltf::Optional<float> foptional;
-	static_assert((std::numeric_limits<float>::is_iec559 && sizeof(foptional) == sizeof(float)) || !std::numeric_limits<float>::is_iec559);
+	REQUIRE(!foptional.has_value());
+	if constexpr (std::numeric_limits<float>::is_iec559) {
+		REQUIRE(sizeof(foptional) == sizeof(float));
+	} else {
+		REQUIRE(sizeof(foptional) > sizeof(float));
+	}
+
+	fastgltf::Optional<double> doptional;
+	REQUIRE(!doptional.has_value());
+	if constexpr (std::numeric_limits<double>::is_iec559) {
+		REQUIRE(sizeof(doptional) == sizeof(double));
+	} else {
+		REQUIRE(sizeof(doptional) > sizeof(double));
+	}
 }

--- a/tests/optional_tests.cpp
+++ b/tests/optional_tests.cpp
@@ -1,5 +1,4 @@
 #include <catch2/catch_test_macros.hpp>
-
 #include <fastgltf/types.hpp>
 
 TEST_CASE("Test basic Optional interface", "[optional-tests]") {

--- a/tests/uri_tests.cpp
+++ b/tests/uri_tests.cpp
@@ -1,126 +1,129 @@
 #include <catch2/catch_test_macros.hpp>
-
-#include <fastgltf/types.hpp>
 #include <fastgltf/core.hpp>
+#include <fastgltf/types.hpp>
 
 #include "gltf_path.hpp"
 
 TEST_CASE("Test basic URIs", "[uri-tests]") {
-    const fastgltf::URI uri1(std::string_view(""));
-    REQUIRE(uri1.scheme().empty());
-    REQUIRE(uri1.path().empty());
+	const fastgltf::URI uri1(std::string_view(""));
+	REQUIRE(uri1.scheme().empty());
+	REQUIRE(uri1.path().empty());
 
-    std::string_view relpath = "path/somewhere.xyz";
-    SECTION("Basic local path") {
-        const fastgltf::URI uri2(relpath);
-        REQUIRE(uri2.scheme().empty());
-        REQUIRE(uri2.path() == relpath);
-        REQUIRE(uri2.isLocalPath());
-        REQUIRE(uri2.fspath() == relpath);
-    }
+	std::string_view relpath = "path/somewhere.xyz";
+	SECTION("Basic local path") {
+		const fastgltf::URI uri2(relpath);
+		REQUIRE(uri2.scheme().empty());
+		REQUIRE(uri2.path() == relpath);
+		REQUIRE(uri2.isLocalPath());
+		REQUIRE(uri2.fspath() == relpath);
+	}
 
-    std::string_view abspath = "/path/somewhere.xyz";
-    SECTION("File scheme path") {
-        const std::string_view filePath = "file:/path/somewhere.xyz";
-        const fastgltf::URI uri3(filePath);
-        REQUIRE(uri3.scheme() == "file");
-        REQUIRE(uri3.isLocalPath());
-        REQUIRE(uri3.path() == abspath);
-    }
+	std::string_view abspath = "/path/somewhere.xyz";
+	SECTION("File scheme path") {
+		const std::string_view filePath = "file:/path/somewhere.xyz";
+		const fastgltf::URI uri3(filePath);
+		REQUIRE(uri3.scheme() == "file");
+		REQUIRE(uri3.isLocalPath());
+		REQUIRE(uri3.path() == abspath);
+	}
 
-    SECTION("File scheme localhost path") {
-        const std::string_view localhostPath = "file://localhost/path/somewhere.xyz";
-        const fastgltf::URI uri4(localhostPath);
-        REQUIRE(uri4.scheme() == "file");
-        REQUIRE(uri4.path() == abspath);
-        REQUIRE(!uri4.isLocalPath());
-    }
+	SECTION("File scheme localhost path") {
+		const std::string_view localhostPath = "file://localhost/path/somewhere.xyz";
+		const fastgltf::URI uri4(localhostPath);
+		REQUIRE(uri4.scheme() == "file");
+		REQUIRE(uri4.path() == abspath);
+		REQUIRE(!uri4.isLocalPath());
+	}
 }
 
 TEST_CASE("Test generic URIs", "[uri-tests]") {
-    // These are a bunch of example URIs from https://en.wikipedia.org/wiki/Uniform_Resource_Identifier#Example_URIs
-    const fastgltf::URI uri(std::string_view("https://john.doe@www.example.com:123/forum/questions/?tag=networking&order=newest#top"));
-    REQUIRE(uri.scheme() == "https");
-    REQUIRE(uri.userinfo() == "john.doe");
-    REQUIRE(uri.host() == "www.example.com");
-    REQUIRE(uri.port() == "123");
-    REQUIRE(uri.path() == "/forum/questions/");
-    REQUIRE(uri.query() == "tag=networking&order=newest");
-    REQUIRE(uri.fragment() == "top");
+	// These are a bunch of example URIs from
+	// https://en.wikipedia.org/wiki/Uniform_Resource_Identifier#Example_URIs
+	const fastgltf::URI uri(std::string_view(
+		"https://john.doe@www.example.com:123/forum/questions/?tag=networking&order=newest#top"));
+	REQUIRE(uri.scheme() == "https");
+	REQUIRE(uri.userinfo() == "john.doe");
+	REQUIRE(uri.host() == "www.example.com");
+	REQUIRE(uri.port() == "123");
+	REQUIRE(uri.path() == "/forum/questions/");
+	REQUIRE(uri.query() == "tag=networking&order=newest");
+	REQUIRE(uri.fragment() == "top");
 
-    const fastgltf::URI uri1(std::string_view("ldap://[2001:db8::7]/c=GB?objectClass?one"));
-    REQUIRE(uri1.scheme() == "ldap");
-    REQUIRE(uri1.host() == "2001:db8::7");
-    REQUIRE(uri1.path() == "/c=GB");
-    REQUIRE(uri1.query() == "objectClass?one");
+	const fastgltf::URI uri1(std::string_view("ldap://[2001:db8::7]/c=GB?objectClass?one"));
+	REQUIRE(uri1.scheme() == "ldap");
+	REQUIRE(uri1.host() == "2001:db8::7");
+	REQUIRE(uri1.path() == "/c=GB");
+	REQUIRE(uri1.query() == "objectClass?one");
 
-    const fastgltf::URI uri2(std::string_view("mailto:John.Doe@example.com"));
-    REQUIRE(uri2.scheme() == "mailto");
-    REQUIRE(uri2.path() == "John.Doe@example.com");
+	const fastgltf::URI uri2(std::string_view("mailto:John.Doe@example.com"));
+	REQUIRE(uri2.scheme() == "mailto");
+	REQUIRE(uri2.path() == "John.Doe@example.com");
 
-    const fastgltf::URI uri3(std::string_view("telnet://192.0.2.16:80/"));
-    REQUIRE(uri3.scheme() == "telnet");
-    REQUIRE(uri3.host() == "192.0.2.16");
-    REQUIRE(uri3.port() == "80");
-    REQUIRE(uri3.path() == "/");
+	const fastgltf::URI uri3(std::string_view("telnet://192.0.2.16:80/"));
+	REQUIRE(uri3.scheme() == "telnet");
+	REQUIRE(uri3.host() == "192.0.2.16");
+	REQUIRE(uri3.port() == "80");
+	REQUIRE(uri3.path() == "/");
 }
 
 TEST_CASE("Test percent decoding", "[uri-tests]") {
 	// All reserved characters as per RFC 3986 section 2.2 Reserved Characters (January 2005)
-    std::string test = "%20%21%22%23%24%25%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D";
-    fastgltf::URI::decodePercents(test);
-    REQUIRE(test == " !\"#$%&'()*+,/:;=?@[]");
+	std::string test = "%20%21%22%23%24%25%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D";
+	fastgltf::URI::decodePercents(test);
+	REQUIRE(test == " !\"#$%&'()*+,/:;=?@[]");
 }
 
 TEST_CASE("Test data URI parsing", "[uri-tests]") {
-    // This example base64 data is from an example on https://en.wikipedia.org/wiki/Data_URI_scheme.
-    const std::string_view data = "data:image/png;base64,iVBORw0KGgoAAA"
-                            "ANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4"
-                            "//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU"
-                            "5ErkJggg==";
-    const fastgltf::URI uri(data);
-    REQUIRE(uri.scheme() == "data");
-    REQUIRE(uri.path() == data.substr(5));
+	// This example base64 data is from an example on https://en.wikipedia.org/wiki/Data_URI_scheme.
+	const std::string_view data =
+		"data:image/png;base64,iVBORw0KGgoAAA"
+		"ANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4"
+		"//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU"
+		"5ErkJggg==";
+	const fastgltf::URI uri(data);
+	REQUIRE(uri.scheme() == "data");
+	REQUIRE(uri.path() == data.substr(5));
 }
 
 TEST_CASE("Validate URI copying/moving", "[uri-tests]") {
-    const std::string_view data = "test.bin";
-    SECTION("Copy semantics") {
-        fastgltf::URI uri(data);
-        REQUIRE(uri.path() == data);
-        fastgltf::URI uri2(uri);
-        REQUIRE(uri2.string().data() != uri.string().data());
-        REQUIRE(uri2.path() == data);
-    }
+	const std::string_view data = "test.bin";
+	SECTION("Copy semantics") {
+		fastgltf::URI uri(data);
+		REQUIRE(uri.path() == data);
+		fastgltf::URI uri2(uri);
+		REQUIRE(uri2.string().data() != uri.string().data());
+		REQUIRE(uri2.path() == data);
+	}
 
-    SECTION("Move semantics") {
-        fastgltf::URI uri;
-        {
-            fastgltf::URI uri2(data);
-            uri = std::move(uri2);
-            REQUIRE(uri2.string().empty());
-        }
-        // Test that the values were copied over and that the string views are still valid.
-        REQUIRE(uri.string() == data);
-        REQUIRE(uri.path() == uri.string());
-    }
+	SECTION("Move semantics") {
+		fastgltf::URI uri;
+		{
+			fastgltf::URI uri2(data);
+			uri = std::move(uri2);
+			REQUIRE(uri2.string().empty());
+		}
+		// Test that the values were copied over and that the string views are still valid.
+		REQUIRE(uri.string() == data);
+		REQUIRE(uri.path() == uri.string());
+	}
 }
 
 TEST_CASE("Validate escaped/percent-encoded URI", "[uri-tests]") {
 	const std::string_view gltfString = R"({"images": [{"uri": "grande_sph\u00E8re.png"}]})";
 	auto dataBuffer = fastgltf::GltfDataBuffer::FromBytes(
-			reinterpret_cast<const std::byte*>(gltfString.data()),
-			gltfString.size());
+		reinterpret_cast<const std::byte*>(gltfString.data()), gltfString.size());
 	REQUIRE(dataBuffer.error() == fastgltf::Error::None);
 
 	fastgltf::Parser parser;
-	auto asset = parser.loadGltfJson(dataBuffer.get(), "", fastgltf::Options::DontRequireValidAssetMember);
+	auto asset =
+		parser.loadGltfJson(dataBuffer.get(), "", fastgltf::Options::DontRequireValidAssetMember);
 	REQUIRE(asset.error() == fastgltf::Error::None);
 
 	REQUIRE(asset->images.size() == 1);
 	auto escaped = std::get<fastgltf::sources::URI>(asset->images.front().data);
 
-	// This only tests wether the default ctor of fastgltf::URI can handle percent-encoding correctly.
+	// This only tests wether the default ctor of fastgltf::URI can handle percent-encoding
+	// correctly.
 	const fastgltf::URI original(std::string_view("grande_sphère.png"));
 	const fastgltf::URI encoded(std::string_view("grande_sph%C3%A8re.png"));
 	REQUIRE(original.string() == escaped.uri.string());

--- a/tests/util_tests.cpp
+++ b/tests/util_tests.cpp
@@ -1,11 +1,9 @@
+#include <catch2/catch_test_macros.hpp>
+#include <fastgltf/util.hpp>
 #include <limits>
 #include <random>
 #include <string>
 #include <type_traits>
-
-#include <catch2/catch_test_macros.hpp>
-
-#include <fastgltf/util.hpp>
 
 TEST_CASE("Test all variants of CRC32-C hashing", "[gltf-loader]") {
 	// TODO: Determine SSE4.2 support here.
@@ -18,10 +16,10 @@ TEST_CASE("Test all variants of CRC32-C hashing", "[gltf-loader]") {
 		static std::mt19937 rng(std::random_device{}());
 		static std::uniform_int_distribution<std::string::size_type> pick(0, chars.size() - 1);
 		std::string str(i, '\0');
-		for (std::size_t j = 0; j < i; ++j)
-			str[j] = chars[pick(rng)];
+		for (std::size_t j = 0; j < i; ++j) str[j] = chars[pick(rng)];
 
-		// We'll try and test if the hardware accelerated version generates the same, correct results.
+		// We'll try and test if the hardware accelerated version generates the same, correct
+		// results.
 #if defined(FASTGLTF_IS_X86)
 		REQUIRE(fastgltf::crc32c(str) == fastgltf::sse_crc32c(str));
 #elif defined(FASTGLTF_IS_A64)

--- a/tests/vector_tests.cpp
+++ b/tests/vector_tests.cpp
@@ -2,18 +2,6 @@
 
 #include <fastgltf/types.hpp>
 
-TEST_CASE("Verify clz", "[vector-tests]") {
-	REQUIRE(fastgltf::clz<std::uint8_t>(0b00000000) == 8);
-	REQUIRE(fastgltf::clz<std::uint8_t>(0b00000001) == 7);
-	REQUIRE(fastgltf::clz<std::uint8_t>(0b00000010) == 6);
-	REQUIRE(fastgltf::clz<std::uint8_t>(0b00000100) == 5);
-	REQUIRE(fastgltf::clz<std::uint8_t>(0b00001000) == 4);
-	REQUIRE(fastgltf::clz<std::uint8_t>(0b00010000) == 3);
-	REQUIRE(fastgltf::clz<std::uint8_t>(0b00100000) == 2);
-	REQUIRE(fastgltf::clz<std::uint8_t>(0b01000000) == 1);
-	REQUIRE(fastgltf::clz<std::uint8_t>(0b10000000) == 0);
-}
-
 TEST_CASE("Test resize/reserve", "[vector-tests]") {
     fastgltf::SmallVector<uint32_t, 4> vec = {1, 2, 3};
     REQUIRE(vec[0] == 1);

--- a/tests/vector_tests.cpp
+++ b/tests/vector_tests.cpp
@@ -1,84 +1,78 @@
 #include <catch2/catch_test_macros.hpp>
-
 #include <fastgltf/types.hpp>
 
 TEST_CASE("Test resize/reserve", "[vector-tests]") {
-    fastgltf::SmallVector<uint32_t, 4> vec = {1, 2, 3};
-    REQUIRE(vec[0] == 1);
-    REQUIRE(vec[1] == 2);
-    REQUIRE(vec[2] == 3);
+	fastgltf::SmallVector<uint32_t, 4> vec = {1, 2, 3};
+	REQUIRE(vec[0] == 1);
+	REQUIRE(vec[1] == 2);
+	REQUIRE(vec[2] == 3);
 
-    vec.resize(5);
-    REQUIRE(vec.size() == 5);
-    REQUIRE(vec[3] == 0);
-    REQUIRE(vec[4] == 0);
+	vec.resize(5);
+	REQUIRE(vec.size() == 5);
+	REQUIRE(vec[3] == 0);
+	REQUIRE(vec[4] == 0);
 
-    vec.resize(2);
-    REQUIRE(vec.size() == 2);
-    REQUIRE(vec[0] == 1);
-    REQUIRE(vec[1] == 2);
+	vec.resize(2);
+	REQUIRE(vec.size() == 2);
+	REQUIRE(vec[0] == 1);
+	REQUIRE(vec[1] == 2);
 
-    vec.resize(6, 4);
-    REQUIRE(vec.size() == 6);
-    for (std::size_t i = 2; i < vec.size(); ++i) {
-        REQUIRE(vec[i] == 4);
-    }
+	vec.resize(6, 4);
+	REQUIRE(vec.size() == 6);
+	for (std::size_t i = 2; i < vec.size(); ++i) {
+		REQUIRE(vec[i] == 4);
+	}
 
-    vec.reserve(8);
-    REQUIRE(vec.size() == 6);
-    REQUIRE(vec.capacity() == 8);
+	vec.reserve(8);
+	REQUIRE(vec.size() == 6);
+	REQUIRE(vec.capacity() == 8);
 
 	vec.shrink_to_fit();
 	REQUIRE(vec.capacity() == 6);
 }
 
 TEST_CASE("Test constructors", "[vector-tests]") {
-    fastgltf::SmallVector<uint32_t, 4> vec = {0, 1, 2, 3};
-    for (std::size_t i = 0; i < vec.size(); ++i) {
-        REQUIRE(vec[i] == i);
-    }
+	fastgltf::SmallVector<uint32_t, 4> vec = {0, 1, 2, 3};
+	for (std::size_t i = 0; i < vec.size(); ++i) {
+		REQUIRE(vec[i] == i);
+	}
 
-    fastgltf::SmallVector<uint32_t, 4> vec2(vec);
-    for (std::size_t i = 0; i < vec2.size(); ++i) {
-        REQUIRE(vec2[i] == i);
-    }
+	fastgltf::SmallVector<uint32_t, 4> vec2(vec);
+	for (std::size_t i = 0; i < vec2.size(); ++i) {
+		REQUIRE(vec2[i] == i);
+	}
 
-    fastgltf::SmallVector<uint32_t, 4> vec3 = std::move(vec2);
-    REQUIRE(vec2.empty());
-    vec3.resize(6);
-    for (std::size_t i = 0; i < 4; ++i) {
-        REQUIRE(vec3[i] == i);
-    }
-    REQUIRE(vec3[4] == 0);
-    REQUIRE(vec3[5] == 0);
+	fastgltf::SmallVector<uint32_t, 4> vec3 = std::move(vec2);
+	REQUIRE(vec2.empty());
+	vec3.resize(6);
+	for (std::size_t i = 0; i < 4; ++i) {
+		REQUIRE(vec3[i] == i);
+	}
+	REQUIRE(vec3[4] == 0);
+	REQUIRE(vec3[5] == 0);
 }
 
 TEST_CASE("Nested SmallVector", "[vector-tests]") {
-    fastgltf::SmallVector<fastgltf::SmallVector<uint32_t, 2>, 4> vectors(6, {4}); // This should heap allocate straight away.
-    REQUIRE(vectors.size() == 6);
-    for (auto& vector : vectors) {
-        REQUIRE(vector.size() == 1);
-        REQUIRE(vector.front() == 4);
-        vector.reserve(6);
-    }
+	fastgltf::SmallVector<fastgltf::SmallVector<uint32_t, 2>, 4> vectors(
+		6, {4});  // This should heap allocate straight away.
+	REQUIRE(vectors.size() == 6);
+	for (auto& vector : vectors) {
+		REQUIRE(vector.size() == 1);
+		REQUIRE(vector.front() == 4);
+		vector.reserve(6);
+	}
 }
 
 struct RefCountedObject {
 	static inline std::size_t aliveObjects = 0;
 
-	RefCountedObject() {
-		++aliveObjects;
-	}
+	RefCountedObject() { ++aliveObjects; }
 
-	RefCountedObject(const RefCountedObject& other) {
-		++aliveObjects;
-	}
+	RefCountedObject(const RefCountedObject& other) { ++aliveObjects; }
 
 	RefCountedObject(RefCountedObject&& other) = delete;
 
-	~RefCountedObject() {
-		--aliveObjects;
-	}
+	~RefCountedObject() { --aliveObjects; }
 };
 
 TEST_CASE("Test shrinking vectors", "[vector-tests]") {

--- a/tests/write_tests.cpp
+++ b/tests/write_tests.cpp
@@ -1,13 +1,12 @@
-#include <algorithm>
-#include <cinttypes>
-#include <cstdint>
-#include <fstream>
-
-#include <catch2/catch_test_macros.hpp>
-
 #include <simdjson.h>
 
+#include <algorithm>
+#include <catch2/catch_test_macros.hpp>
+#include <cinttypes>
+#include <cstdint>
 #include <fastgltf/core.hpp>
+#include <fstream>
+
 #include "gltf_path.hpp"
 
 TEST_CASE("Test simple glTF composition", "[write-tests]") {
@@ -37,10 +36,11 @@ TEST_CASE("Read glTF, write it, and then read it again and validate", "[write-te
 
 	fastgltf::Exporter exporter;
 	auto expected = exporter.writeGltfJson(cube.get());
-    REQUIRE(expected.error() == fastgltf::Error::None);
+	REQUIRE(expected.error() == fastgltf::Error::None);
 
 	auto exportedJsonData = fastgltf::GltfDataBuffer::FromBytes(
-			reinterpret_cast<const std::byte*>(expected.get().output.data()), expected.get().output.size());
+		reinterpret_cast<const std::byte*>(expected.get().output.data()),
+		expected.get().output.size());
 	REQUIRE(exportedJsonData.error() == fastgltf::Error::None);
 	auto cube2 = parser.loadGltfJson(exportedJsonData.get(), cubePath);
 	REQUIRE(cube2.error() == fastgltf::Error::None);
@@ -53,9 +53,9 @@ TEST_CASE("Rewrite read glTF with multiple material extensions", "[write-tests]"
 	REQUIRE(dishJsonData.isOpen());
 
 	static constexpr auto requiredExtensions = fastgltf::Extensions::KHR_materials_ior |
-		fastgltf::Extensions::KHR_materials_iridescence |
-		fastgltf::Extensions::KHR_materials_transmission |
-		fastgltf::Extensions::KHR_materials_volume;
+											   fastgltf::Extensions::KHR_materials_iridescence |
+											   fastgltf::Extensions::KHR_materials_transmission |
+											   fastgltf::Extensions::KHR_materials_volume;
 
 	fastgltf::Parser parser(requiredExtensions);
 	auto dish = parser.loadGltfJson(dishJsonData, dishPath);
@@ -67,7 +67,8 @@ TEST_CASE("Rewrite read glTF with multiple material extensions", "[write-tests]"
 	REQUIRE(expected.error() == fastgltf::Error::None);
 
 	auto exportedDishJsonData = fastgltf::GltfDataBuffer::FromBytes(
-			reinterpret_cast<const std::byte*>(expected.get().output.data()), expected.get().output.size());
+		reinterpret_cast<const std::byte*>(expected.get().output.data()),
+		expected.get().output.size());
 	REQUIRE(exportedDishJsonData.error() == fastgltf::Error::None);
 	auto exportedDish = parser.loadGltfJson(exportedDishJsonData.get(), dishPath);
 	REQUIRE(exportedDish.error() == fastgltf::Error::None);
@@ -75,15 +76,15 @@ TEST_CASE("Rewrite read glTF with multiple material extensions", "[write-tests]"
 }
 
 TEST_CASE("Try writing a glTF with all buffers and images", "[write-tests]") {
-    auto cubePath = sampleAssets / "Models" / "Cube" / "glTF";
+	auto cubePath = sampleAssets / "Models" / "Cube" / "glTF";
 
 	fastgltf::GltfFileStream cubeJson(cubePath / "Cube.gltf");
 	REQUIRE(cubeJson.isOpen());
 
-    fastgltf::Parser parser;
-    auto options = fastgltf::Options::LoadExternalBuffers | fastgltf::Options::LoadExternalImages;
-    auto cube = parser.loadGltfJson(cubeJson, cubePath, options);
-    REQUIRE(cube.error() == fastgltf::Error::None);
+	fastgltf::Parser parser;
+	auto options = fastgltf::Options::LoadExternalBuffers | fastgltf::Options::LoadExternalImages;
+	auto cube = parser.loadGltfJson(cubeJson, cubePath, options);
+	REQUIRE(cube.error() == fastgltf::Error::None);
 
 	// Destroy the directory to make sure that the FileExporter correctly creates directories.
 	auto exportedFolder = path / "export";
@@ -93,25 +94,25 @@ TEST_CASE("Try writing a glTF with all buffers and images", "[write-tests]") {
 		REQUIRE(!ec);
 	}
 
-    fastgltf::FileExporter exporter;
-    auto error = exporter.writeGltfJson(cube.get(), exportedFolder / "cube.gltf",
-                                        fastgltf::ExportOptions::PrettyPrintJson);
-    REQUIRE(error == fastgltf::Error::None);
+	fastgltf::FileExporter exporter;
+	auto error = exporter.writeGltfJson(cube.get(), exportedFolder / "cube.gltf",
+										fastgltf::ExportOptions::PrettyPrintJson);
+	REQUIRE(error == fastgltf::Error::None);
 	REQUIRE(std::filesystem::exists(exportedFolder / "buffer0.bin"));
 	REQUIRE(std::filesystem::exists(exportedFolder / "image0.bin"));
 	REQUIRE(std::filesystem::exists(exportedFolder / "image1.bin"));
 }
 
 TEST_CASE("Try writing a GLB with all buffers and images", "[write-tests]") {
-    auto cubePath = sampleAssets / "Models" / "Cube" / "glTF";
+	auto cubePath = sampleAssets / "Models" / "Cube" / "glTF";
 
 	fastgltf::GltfFileStream cubeJson(cubePath / "Cube.gltf");
 	REQUIRE(cubeJson.isOpen());
 
-    fastgltf::Parser parser;
-    auto options = fastgltf::Options::LoadExternalBuffers | fastgltf::Options::LoadExternalImages;
-    auto cube = parser.loadGltfJson(cubeJson, cubePath, options);
-    REQUIRE(cube.error() == fastgltf::Error::None);
+	fastgltf::Parser parser;
+	auto options = fastgltf::Options::LoadExternalBuffers | fastgltf::Options::LoadExternalImages;
+	auto cube = parser.loadGltfJson(cubeJson, cubePath, options);
+	REQUIRE(cube.error() == fastgltf::Error::None);
 
 	// Destroy the directory to make sure that the FileExporter correctly creates directories.
 	auto exportedFolder = path / "export_glb";
@@ -121,10 +122,10 @@ TEST_CASE("Try writing a GLB with all buffers and images", "[write-tests]") {
 		REQUIRE(!ec);
 	}
 
-    fastgltf::FileExporter exporter;
+	fastgltf::FileExporter exporter;
 	auto exportedPath = exportedFolder / "cube.glb";
-    auto error = exporter.writeGltfBinary(cube.get(), exportedPath);
-    REQUIRE(error == fastgltf::Error::None);
+	auto error = exporter.writeGltfBinary(cube.get(), exportedPath);
+	REQUIRE(error == fastgltf::Error::None);
 	REQUIRE(std::filesystem::exists(exportedFolder / "image0.bin"));
 	REQUIRE(std::filesystem::exists(exportedFolder / "image1.bin"));
 
@@ -147,7 +148,7 @@ TEST_CASE("Try writing a GLB with all buffers and images", "[write-tests]") {
 	REQUIRE(chunkLength == cube->buffers.front().byteLength);
 
 	// Read & verify BIN chunk type id
-	std::array<std::uint8_t, 4> binType {};
+	std::array<std::uint8_t, 4> binType{};
 	glb.read(reinterpret_cast<char*>(binType.data()), sizeof binType);
 	REQUIRE(binType[0] == 'B');
 	REQUIRE(binType[1] == 'I');
@@ -156,14 +157,14 @@ TEST_CASE("Try writing a GLB with all buffers and images", "[write-tests]") {
 }
 
 TEST_CASE("Test string escape", "[write-tests]") {
-    std::string x = "\"stuff\\";
-    std::string escaped = fastgltf::escapeString(x);
-    REQUIRE(escaped == "\\\"stuff\\\\");
+	std::string x = "\"stuff\\";
+	std::string escaped = fastgltf::escapeString(x);
+	REQUIRE(escaped == "\\\"stuff\\\\");
 }
 
 TEST_CASE("Test pretty-print", "[write-tests]") {
-    std::string json = R"({"value":5,"thing":{}})";
-    fastgltf::prettyPrintJson(json);
+	std::string json = R"({"value":5,"thing":{}})";
+	fastgltf::prettyPrintJson(json);
 	REQUIRE(json == "{\n\t\"value\":5,\n\t\"thing\":{\n\t\t\n\t}\n}");
 }
 
@@ -179,19 +180,18 @@ TEST_CASE("Test all local models and re-export them", "[write-tests]") {
 
 	std::uint64_t testedAssets = 0;
 	for (const auto& entry : std::filesystem::recursive_directory_iterator(folderPath)) {
-		if (!entry.is_regular_file())
-			continue;
+		if (!entry.is_regular_file()) continue;
 		const auto& epath = entry.path();
-		if (!epath.has_extension())
-			continue;
-		if (epath.extension() != ".gltf" && epath.extension() != ".glb")
-			continue;
+		if (!epath.has_extension()) continue;
+		if (epath.extension() != ".gltf" && epath.extension() != ".glb") continue;
 
 		// Parse the glTF
 		fastgltf::GltfFileStream gltfData(epath);
 		auto model = parser.loadGltf(gltfData, epath.parent_path());
-		if (model.error() == fastgltf::Error::UnsupportedVersion || model.error() == fastgltf::Error::UnknownRequiredExtension || model.error() == fastgltf::Error::InvalidOrMissingAssetField)
-			continue; // Skip any glTF 1.0 or 0.x files or glTFs with unsupported extensions.
+		if (model.error() == fastgltf::Error::UnsupportedVersion ||
+			model.error() == fastgltf::Error::UnknownRequiredExtension ||
+			model.error() == fastgltf::Error::InvalidOrMissingAssetField)
+			continue;  // Skip any glTF 1.0 or 0.x files or glTFs with unsupported extensions.
 
 		REQUIRE(model.error() == fastgltf::Error::None);
 		REQUIRE(fastgltf::validate(model.get()) == fastgltf::Error::None);
@@ -207,7 +207,7 @@ TEST_CASE("Test all local models and re-export them", "[write-tests]") {
 
 		// Parse the re-generated glTF and validate
 		auto regeneratedJson = fastgltf::GltfDataBuffer::FromBytes(
-				reinterpret_cast<const std::byte*>(exportedJson.data()), exportedJson.size());
+			reinterpret_cast<const std::byte*>(exportedJson.data()), exportedJson.size());
 		REQUIRE(regeneratedJson.error() == fastgltf::Error::None);
 		auto regeneratedModel = parser.loadGltf(regeneratedJson.get(), epath.parent_path());
 		REQUIRE(regeneratedModel.error() == fastgltf::Error::None);
@@ -237,7 +237,7 @@ TEST_CASE("Test Unicode exporting", "[write-tests]") {
 	REQUIRE(simdjson::validate_utf8(exportedJson));
 
 	auto regeneratedJson = fastgltf::GltfDataBuffer::FromBytes(
-			reinterpret_cast<const std::byte*>(exportedJson.data()), exportedJson.size());
+		reinterpret_cast<const std::byte*>(exportedJson.data()), exportedJson.size());
 	REQUIRE(regeneratedJson.error() == fastgltf::Error::None);
 	auto reparsed = parser.loadGltfJson(regeneratedJson.get(), unicodePath);
 	REQUIRE(reparsed.error() == fastgltf::Error::None);
@@ -263,8 +263,8 @@ TEST_CASE("Test URI normalization and removing backslashes", "[write-tests]") {
 	REQUIRE(asset->images.size() == 1);
 	asset->images.front().name = "Unicode❤♻Texture";
 
-	// When exporting, we specify a redundant image base path to test if the normalization properly works.
-	// Additionally, on Windows we test if the slashes are changed properly.
+	// When exporting, we specify a redundant image base path to test if the normalization properly
+	// works. Additionally, on Windows we test if the slashes are changed properly.
 	fastgltf::Exporter exporter;
 #ifdef _WIN32
 	// When on Windows the default path separator is a backslash, but glTF requires a forward slash.
@@ -277,7 +277,10 @@ TEST_CASE("Test URI normalization and removing backslashes", "[write-tests]") {
 	// Parse the JSON and inspect the image URI.
 	simdjson::ondemand::parser jsonParser;
 	simdjson::ondemand::document doc;
-	REQUIRE(jsonParser.iterate(exported.get().output.c_str(), exported.get().output.size(), exported.get().output.capacity()).get(doc) == simdjson::SUCCESS);
+	REQUIRE(jsonParser
+				.iterate(exported.get().output.c_str(), exported.get().output.size(),
+						 exported.get().output.capacity())
+				.get(doc) == simdjson::SUCCESS);
 
 	simdjson::ondemand::object object;
 	REQUIRE(doc.get_object().get(object) == simdjson::SUCCESS);
@@ -303,7 +306,8 @@ TEST_CASE("Test floating point round-trip precision", "[write-tests]") {
 		fastgltf::GltfFileStream cubeJson(cubePath / "Duck.glb");
 		REQUIRE(cubeJson.isOpen());
 
-		auto asset = parser.loadGltfBinary(cubeJson, cubePath,
+		auto asset = parser.loadGltfBinary(
+			cubeJson, cubePath,
 			fastgltf::Options::LoadExternalBuffers | fastgltf::Options::LoadExternalImages);
 		REQUIRE(asset.error() == fastgltf::Error::None);
 		REQUIRE(fastgltf::validate(asset.get()) == fastgltf::Error::None);
@@ -314,7 +318,8 @@ TEST_CASE("Test floating point round-trip precision", "[write-tests]") {
 	auto exportedPath = path / "export_glb" / "Duck_rewritten.glb";
 	REQUIRE(exporter.writeGltfBinary(original, exportedPath) == fastgltf::Error::None);
 
-	// Now read the exported file again, and check if the floating-point values are the same as the original asset.
+	// Now read the exported file again, and check if the floating-point values are the same as the
+	// original asset.
 	auto reimported = [&parser, &exportedPath] {
 		fastgltf::GltfFileStream rewrittenJson(exportedPath);
 		REQUIRE(rewrittenJson.isOpen());
@@ -333,8 +338,7 @@ TEST_CASE("Test floating point round-trip precision", "[write-tests]") {
 		REQUIRE(accessor_a.min.has_value());
 		REQUIRE(accessor_b.min.has_value());
 		REQUIRE(accessor_a.min->type() == accessor_b.min->type());
-		if (!accessor_a.min->isType<double>())
-			continue;
+		if (!accessor_a.min->isType<double>()) continue;
 
 		const auto& min_a = accessor_a.min.value();
 		const auto& min_b = accessor_b.min.value();
@@ -344,8 +348,7 @@ TEST_CASE("Test floating point round-trip precision", "[write-tests]") {
 		}
 
 		REQUIRE(accessor_a.max->type() == accessor_b.max->type());
-		if (!accessor_a.max->isType<double>())
-			continue;
+		if (!accessor_a.max->isType<double>()) continue;
 
 		const auto& max_a = accessor_a.max.value();
 		const auto& max_b = accessor_b.max.value();

--- a/tests/write_tests.cpp
+++ b/tests/write_tests.cpp
@@ -220,13 +220,8 @@ TEST_CASE("Test all local models and re-export them", "[write-tests]") {
 }
 
 TEST_CASE("Test Unicode exporting", "[write-tests]") {
-#if FASTGLTF_CPP_20
 	auto unicodePath = sampleAssets / "Models" / std::filesystem::path(u8"Unicode❤♻Test") / "glTF";
 	fastgltf::GltfFileStream jsonData(unicodePath / std::filesystem::path(u8"Unicode❤♻Test.gltf"));
-#else
-	auto unicodePath = sampleAssets / "Models" / std::filesystem::u8path(u8"Unicode❤♻Test") / "glTF";
-	fastgltf::GltfFileStream jsonData(unicodePath / std::filesystem::u8path(u8"Unicode❤♻Test.gltf"));
-#endif
 	REQUIRE(jsonData.isOpen());
 
 	fastgltf::Parser parser;
@@ -257,13 +252,8 @@ TEST_CASE("Test Unicode exporting", "[write-tests]") {
 }
 
 TEST_CASE("Test URI normalization and removing backslashes", "[write-tests]") {
-#if FASTGLTF_CPP_20
 	auto unicodePath = sampleAssets / "Models" / std::filesystem::path(u8"Unicode❤♻Test") / "glTF";
 	fastgltf::GltfFileStream jsonData(unicodePath / std::filesystem::path(u8"Unicode❤♻Test.gltf"));
-#else
-	auto unicodePath = sampleAssets / "Models" / std::filesystem::u8path(u8"Unicode❤♻Test") / "glTF";
-	fastgltf::GltfFileStream jsonData(unicodePath / std::filesystem::u8path(u8"Unicode❤♻Test.gltf"));
-#endif
 	REQUIRE(jsonData.isOpen());
 
 	fastgltf::Parser parser;


### PR DESCRIPTION
Due to various reasons, including the fact that the codebase already used plenty of C++20 features and that C++20 is now mature enough to be used in widespread applications in my opinion, I want to update fastgltf to be a C++20 library.

As [this cppreference page](https://en.cppreference.com/w/cpp/compiler_support.html#cpp20) shows all relevant compilers (not just the big-three) support next to every single C++20 feature, and have for years now. These compiler versions are now popular and widespread making upgrading to any future version of fastgltf no problem.

There's still many more changes this PR needs, mainly about upgrading various other pieces of the codebase to use C++20 features, modernizing everything. I'm particularly interested in adopting C++ ranges and concepts as much as possible. I'm mainly opening this PR as a way to get feedback and maybe catch potential issues these major changes might have caused.