### PR TITLE
fix: correct order of operations for TRS encoded transforms

### DIFF
--- a/include/fastgltf/tools.hpp
+++ b/include/fastgltf/tools.hpp
@@ -901,7 +901,7 @@ FASTGLTF_EXPORT inline auto getTransformMatrix(const Node& node, const math::fma
 			return base * matrix;
 		},
 		[&](const TRS& trs) {
-			return scale(rotate(translate(base, trs.translation), trs.rotation), trs.scale);
+			return translate(rotate(scale(base, trs.scale), trs.rotation), trs.translation);
 		}
 	}, node.transform);
 }


### PR DESCRIPTION
the existing way looks like (in tools.hpp):
`return scale(rotate(translate(base, trs.translation), trs.rotation), trs.scale);`

This applies the translation first since it's inner-most, then the rotation, then the scaling.  But the glTF standard calls for the opposite of that, it should be scale first, then rotation, then translation.

> TRS properties are converted to matrices and **postmultiplied** in the T * R * S order to compose the transformation matrix; first the scale is applied to the vertices, then the rotation, and then the translation.

[https://kcoley.github.io/glTF/specification/2.0/](https://kcoley.github.io/glTF/specification/2.0/#transformations)

So this appears to be backwards to me.  It probably doesn't come up a whole lot since the transforms are usually stored as 4x4 matrices, but I noticed the discrepancy while working on other stuff here so I thought I'd pass it along.

edit: for addtional reference on this subject see link below
[https://github.com/javagl/glTF-Tutorials/blob/master/gltfTutorial/gltfTutorial_004_ScenesNodes.md#local-transforms-of-nodes](https://github.com/javagl/glTF-Tutorials/blob/master/gltfTutorial/gltfTutorial_004_ScenesNodes.md#local-transforms-of-nodes)