### PR TITLE
Declare pi constant as long double

### DIFF
--- a/include/fastgltf/math.hpp
+++ b/include/fastgltf/math.hpp
@@ -40,7 +40,7 @@
  * The fastgltf::math namespace contains all math functions and types which are needed for working with glTF assets.
  */
 namespace fastgltf::math {
-	FASTGLTF_EXPORT inline constexpr long double pi = 3.1415926535897932385;
+	FASTGLTF_EXPORT inline constexpr long double pi = 3.1415926535897932385L;
 
 	/** Value clamp using std::less */
 	FASTGLTF_EXPORT template <typename T>


### PR DESCRIPTION
Declare the `pi` constant as long double explicitly.  This silences the warning generated by `-Wdouble-promotion`:

> implicit conversion increases floating-point precision: 'double' to 'const long double'