### PR TITLE
build: add gcc <9.1 and clang <9.0 compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,20 @@ if (SIMDJSON_TARGET_VERSION)
     target_compile_definitions(fastgltf PRIVATE SIMDJSON_TARGET_VERSION="${SIMDJSON_TARGET_VERSION}")
 endif ()
 
+# Old versions of GCC and Clang require linking with the standard filesystem library
+# See https://en.cppreference.com/w/cpp/filesystem.html#Notes
+set(FILESYSTEM_LIB "")
+
+if(CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.1)
+    set(FILESYSTEM_LIB stdc++fs)
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.0)
+    set(FILESYSTEM_LIB c++fs)
+endif()
+
+if(FILESYSTEM_LIB)
+    target_link_libraries(fastgltf PRIVATE ${FILESYSTEM_LIB})
+endif()
+
 target_compile_definitions(fastgltf PUBLIC "FASTGLTF_USE_CUSTOM_SMALLVECTOR=$<BOOL:${FASTGLTF_USE_CUSTOM_SMALLVECTOR}>")
 target_compile_definitions(fastgltf PUBLIC "FASTGLTF_ENABLE_DEPRECATED_EXT=$<BOOL:${FASTGLTF_ENABLE_DEPRECATED_EXT}>")
 target_compile_definitions(fastgltf PUBLIC "FASTGLTF_DISABLE_CUSTOM_MEMORY_POOL=$<BOOL:${FASTGLTF_DISABLE_CUSTOM_MEMORY_POOL}>")


### PR DESCRIPTION
Encountered a linking issue when using an old GCC version:

```bash
/home/andre/dev/lvgl/lv_port_linux/build/_deps/fastgltf-src/src/io.cpp:442: undefined reference to `std::filesystem::file_size(std::filesystem::__cxx11::path const&, std::error_code&)'
/opt/poky/3.1.33/sysroots/x86_64-pokysdk-linux/usr/libexec/aarch64-poky-linux/gcc/aarch64-poky-linux/8.3.0/real-ld: _deps/fastgltf-build/libfastgltf.a(io.cpp.o): in function `fastgltf::Parser::loadFileFromUri(fastgltf::URIView&) const':
/opt/poky/3.1.33/sysroots/aarch64-poky-linux/usr/include/c++/8.3.0/bits/fs_path.h:257: undefined reference to `std::filesystem::__cxx11::path::has_filename() const'
/opt/poky/3.1.33/sysroots/x86_64-pokysdk-linux/usr/libexec/aarch64-poky-linux/gcc/aarch64-poky-linux/8.3.0/real-ld: /opt/poky/3.1.33/sysroots/aarch64-poky-linux/usr/include/c++/8.3.0/bits/fs_path.h:260: undefined reference to `std::filesystem::__cxx11::path::_M_split_cmpts()'
/opt/poky/3.1.33/sysroots/x86_64-pokysdk-linux/usr/libexec/aarch64-poky-linux/gcc/aarch64-poky-linux/8.3.0/real-ld: /opt/poky/3.1.33/sysroots/aarch64-poky-linux/usr/include/c++/8.3.0/bits/fs_path.h:260: undefined reference to `std::filesystem::__cxx11::path::_M_split_cmpts()'
/opt/poky/3.1.33/sysroots/x86_64-pokysdk-linux/usr/libexec/aarch64-poky-linux/gcc/aarch64-poky-linux/8.3.0/real-ld: lvgl/lib/liblvgl.a(lv_gltf_data_injest.cpp.o): in function `create_data_from_bytes(unsigned char const*, unsigned long)':
/opt/poky/3.1.33/sysroots/aarch64-poky-linux/usr/include/c++/8.3.0/bits/fs_path.h:184: undefined reference to `std::filesystem::__cxx11::path::_M_split_cmpts()'
collect2: error: ld returned 1 exit status
```
cppreference mentions having to link with `stdc++fs` for GCC and `c++fs` for clang: https://en.cppreference.com/w/cpp/filesystem.html#Notes
