### PR TITLE
Exporter: fix KHR_lights_punctual spot light serialization

### DIFF
--- a/src/fastgltf.cpp
+++ b/src/fastgltf.cpp
@@ -5626,12 +5626,18 @@ void fg::Exporter::writeLights(const Asset& asset, std::string& json) {
 			json += R"(,"range":)" + to_string_fp(it->range.value());
 		}
 
-		if (it->type == LightType::Spot) {
-			if (it->innerConeAngle.has_value())
-				json += R"("innerConeAngle":)" + to_string_fp(it->innerConeAngle.value()) + ',';
-
+		// Spot cone angles live in a nested "spot" object per
+		// KHR_lights_punctual (the parser reads them from there too).
+		if (it->type == LightType::Spot && (it->innerConeAngle.has_value() || it->outerConeAngle.has_value())) {
+			json += R"(,"spot":{)";
+			if (it->innerConeAngle.has_value()) {
+				json += R"("innerConeAngle":)" + to_string_fp(it->innerConeAngle.value());
+				if (it->outerConeAngle.has_value())
+					json += ',';
+			}
 			if (it->outerConeAngle.has_value())
-				json += R"("outerConeAngle":)" + to_string_fp(it->outerConeAngle.value()) + ',';
+				json += R"("outerConeAngle":)" + to_string_fp(it->outerConeAngle.value());
+			json += '}';
 		}
 
 		if (!it->name.empty())


### PR DESCRIPTION
Exporter::writeLights wrote innerConeAngle / outerConeAngle at the light's top level with broken comma placement: no separator after "type" (or "range") and a trailing comma before "name" / the closing brace, so any spot light with cone angles produced invalid JSON.

Per the KHR_lights_punctual schema the cone angles belong inside a nested "spot" object -- which is also where this library's own parser reads them (parseLightsPunctual), so exported spot lights did not round-trip even ignoring the JSON syntax errors.

Write ',"spot":{"innerConeAngle":...,"outerConeAngle":...}' instead.