### PR TITLE
Fix SmallVector move constructor and move assignment for move-only types

### DIFF
--- a/include/fastgltf/types.hpp
+++ b/include/fastgltf/types.hpp
@@ -730,14 +730,21 @@ namespace fastgltf {
 		std::size_t _size = 0, _capacity = N;
 
 		void copy(const T* first, std::size_t count, T* result) {
-			if (count > 0) {
-				if constexpr (std::is_trivially_copyable_v<T>) {
-					std::memcpy(result, first, count * sizeof(T));
-				} else {
-					*result++ = *first;
-					for (std::size_t i = 1; i < count; ++i) {
-						*result++ = *++first;
-					}
+			if constexpr (std::is_trivially_copyable_v<T>) {
+				std::memcpy(result, first, count * sizeof(T));
+			} else {
+				for (std::size_t i = 0; i < count; ++i) {
+					result[i] = first[i];
+				}
+			}
+		}
+
+		void move_elements(T* first, std::size_t count, T* result) {
+			if constexpr (std::is_trivially_copyable_v<T>) {
+				std::memcpy(result, first, count * sizeof(T));
+			} else {
+				for (std::size_t i = 0; i < count; ++i) {
+					result[i] = std::move(first[i]);
 				}
 			}
 		}
@@ -771,7 +778,7 @@ namespace fastgltf {
 			if (other.isUsingStack()) {
 				if (!other.empty()) {
 					resize(other.size());
-					copy(other.begin(), other.size(), begin());
+					move_elements(other.begin(), other.size(), begin());
 					other._data = reinterpret_cast<T*>(other.storage.data()); // Reset pointer
 					_size = std::exchange(other._size, 0);
 					_capacity = std::exchange(other._capacity, N);
@@ -803,7 +810,7 @@ namespace fastgltf {
 				if (other.isUsingStack()) {
 					if (!other.empty()) {
 						resize(other.size());
-						copy(other.begin(), other.size(), begin());
+						move_elements(other.begin(), other.size(), begin());
 						other._data = reinterpret_cast<T*>(other.storage.data()); // Reset pointer
 						_size = std::exchange(other._size, 0);
 						_capacity = std::exchange(other._capacity, N);

--- a/tests/vector_tests.cpp
+++ b/tests/vector_tests.cpp
@@ -124,3 +124,79 @@ TEST_CASE("Test initial value for StaticVector", "[vector-tests]") {
 	}
 	REQUIRE(count == 10);
 }
+
+struct MoveOnlyObject {
+	std::unique_ptr<int> ptr;
+
+	MoveOnlyObject() : ptr(std::make_unique<int>(0)) {}
+	explicit MoveOnlyObject(int v) : ptr(std::make_unique<int>(v)) {}
+	MoveOnlyObject(const MoveOnlyObject&) = delete;
+	MoveOnlyObject& operator=(const MoveOnlyObject&) = delete;
+	MoveOnlyObject(MoveOnlyObject&&) noexcept = default;
+	MoveOnlyObject& operator=(MoveOnlyObject&&) noexcept = default;
+	~MoveOnlyObject() = default;
+};
+
+TEST_CASE("Test move-only types with SmallVector", "[vector-tests]") {
+	SECTION("Stack storage move constructor") {
+		fastgltf::SmallVector<MoveOnlyObject, 4> vec;
+		vec.emplace_back(10);
+		vec.emplace_back(20);
+		vec.emplace_back(30);
+
+		fastgltf::SmallVector<MoveOnlyObject, 4> vec2 = std::move(vec);
+		REQUIRE(vec.empty());
+		REQUIRE(vec2.size() == 3);
+		REQUIRE(*vec2[0].ptr == 10);
+		REQUIRE(*vec2[1].ptr == 20);
+		REQUIRE(*vec2[2].ptr == 30);
+	}
+
+	SECTION("Stack storage move assignment") {
+		fastgltf::SmallVector<MoveOnlyObject, 4> vec;
+		vec.emplace_back(10);
+		vec.emplace_back(20);
+
+		fastgltf::SmallVector<MoveOnlyObject, 4> vec2;
+		vec2.emplace_back(100);
+		vec2 = std::move(vec);
+
+		REQUIRE(vec.empty());
+		REQUIRE(vec2.size() == 2);
+		REQUIRE(*vec2[0].ptr == 10);
+		REQUIRE(*vec2[1].ptr == 20);
+	}
+
+	SECTION("Heap storage move constructor") {
+		fastgltf::SmallVector<MoveOnlyObject, 2> vec;
+		vec.emplace_back(1);
+		vec.emplace_back(2);
+		vec.emplace_back(3);
+
+		REQUIRE(!vec.isUsingStack());
+		fastgltf::SmallVector<MoveOnlyObject, 2> vec2 = std::move(vec);
+		REQUIRE(vec.empty());
+		REQUIRE(vec2.size() == 3);
+		REQUIRE(*vec2[0].ptr == 1);
+		REQUIRE(*vec2[1].ptr == 2);
+		REQUIRE(*vec2[2].ptr == 3);
+	}
+
+	SECTION("Heap storage move assignment") {
+		fastgltf::SmallVector<MoveOnlyObject, 2> vec;
+		vec.emplace_back(1);
+		vec.emplace_back(2);
+		vec.emplace_back(3);
+
+		fastgltf::SmallVector<MoveOnlyObject, 2> vec2;
+		vec2.emplace_back(99);
+		vec2 = std::move(vec);
+
+		REQUIRE(vec.empty());
+		REQUIRE(vec2.size() == 3);
+		REQUIRE(*vec2[0].ptr == 1);
+		REQUIRE(*vec2[1].ptr == 2);
+		REQUIRE(*vec2[2].ptr == 3);
+	}
+}
+


### PR DESCRIPTION
When FASTGLTF_USE_CUSTOM_SMALLVECTOR is enabled, SmallVector(SmallVector&&) and SmallVector::operator=(SmallVector&&) previously invoked copy(), which uses copy assignment *result++ = *first. For types with deleted copy constructors/assignments (such as Primitive containing std::unique_ptr<DracoCompressedPrimitive>), this caused compilation errors when moving SmallVector<Primitive>. This PR introduces a move_elements helper function to perform std::move instead of copying.