### PR TITLE
Allow user to define FASTGLTF_CPP_20 0 or FASTGLTF_CPP_23 0 in some cases

### DIFF
--- a/include/fastgltf/util.hpp
+++ b/include/fastgltf/util.hpp
@@ -51,17 +51,21 @@
 #error "fastgltf requires C++17"
 #endif
 
-#if (!defined(_MSVC_LANG) && __cplusplus >= 202002L) || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)
-#define FASTGLTF_CPP_20 1
-#include <version>
-#else
-#define FASTGLTF_CPP_20 0
+#ifndef FASTGLTF_CPP_20
+	#if (!defined(_MSVC_LANG) && __cplusplus >= 202002L) || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)
+	#define FASTGLTF_CPP_20 1
+	#include <version>
+	#else
+	#define FASTGLTF_CPP_20 0
+	#endif
 #endif
 
-#if (!defined(_MSVC_LANG) && __cplusplus >= 202302L) || (defined(_MSVC_LANG) && _MSVC_LANG >= 202302L)
-#define FASTGLTF_CPP_23 1
-#else
-#define FASTGLTF_CPP_23 0
+#ifndef FASTGLTF_CPP_23
+	#if (!defined(_MSVC_LANG) && __cplusplus >= 202302L) || (defined(_MSVC_LANG) && _MSVC_LANG >= 202302L)
+	#define FASTGLTF_CPP_23 1
+	#else
+	#define FASTGLTF_CPP_23 0
+	#endif
 #endif
 
 #if FASTGLTF_CPP_20 && defined(__cpp_lib_bitops) && __cpp_lib_bitops >= 201907L


### PR DESCRIPTION
Discussed here: https://github.com/cosmic-road/fastgltf/commit/6f99b9f6790a39d40e0adcd2febf0b973358722c

This fix exposes the `FASTGLTF_CPP_XX` flags to the user, allowing them to do the following in the case of a compiler version that doesn't have full support for that version, and forces fastgltf to use the next version down (20 -> 17, or 23 -> 20):

```cpp
#define FASTGLTF_CPP_20 0
#include <fastgltf/core.hpp>
```

This was needed in AppleClang14.0.0, where the following static_assert failed because `input_range` did not exist yet in that version:

```
build/install/include/fastgltf/tools.hpp:614:28: error: no member named 'input_range' in namespace 'std::ranges'
static_assert(std::ranges::input_range<IterableAccessor<math::fvec4>>, "IterableAccessor needs to satisfy input_range");
              ~~~~~~~~~~~~~^
build/install/include/fastgltf/tools.hpp:614:69: error: expected '(' for function-style cast or type construction
static_assert(std::ranges::input_range<IterableAccessor<math::fvec4>>, "IterableAccessor needs to satisfy input_range");
                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
build/install/include/fastgltf/tools.hpp:614:70: error: expected expression
static_assert(std::ranges::input_range<IterableAccessor<math::fvec4>>, "IterableAccessor needs to satisfy input_range");
                                                                     ^
```
